### PR TITLE
fix: add make goal to build docker image

### DIFF
--- a/docker/Dockerfile.apiserver
+++ b/docker/Dockerfile.apiserver
@@ -1,0 +1,30 @@
+FROM quay.io/projectquay/golang:1.24 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/apiserver/ cmd/apiserver/
+COPY internal/ internal/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make image-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/batch-gateway-apiserver ./cmd/apiserver
+
+# TODO: switch base image to gcr.io/distroless/static:nonroot before release
+FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+WORKDIR /
+COPY --from=builder /workspace/bin/batch-gateway-apiserver /app/batch-gateway-apiserver
+USER 65532:65532
+
+ENTRYPOINT ["/app/batch-gateway-apiserver"]


### PR DESCRIPTION
The PR updated Makefile and Dockerfile
- check container tool
- build docker image for apiserver
- support build with multiple arch 

Build and test from my macbook
```
# uname -m
arm64

# make image-build-apiserver
==== Building Docker image ghcr.io/llm-d/batch-gateway-apiserver:0.0.1 ====
podman build \
		--platform linux/arm64 \
		--build-arg TARGETOS=linux \
		--build-arg TARGETARCH=arm64 \
		-f docker/Dockerfile.apiserver \
		-t ghcr.io/llm-d/batch-gateway-apiserver:0.0.1 .

# podman images ghcr.io/llm-d/batch-gateway-apiserver:0.0.1
REPOSITORY                             TAG         IMAGE ID      CREATED             SIZE
ghcr.io/llm-d/batch-gateway-apiserver  0.0.1       9409df368c01  About a minute ago  37.5 MB

# podman run -it ghcr.io/llm-d/batch-gateway-apiserver:0.0.1 bash
I0121 16:19:10.983433       1 main.go:66] "starting api server"
I0121 16:19:10.983796       1 server.go:105] "starting" logger="api server" addr="[::]:8000"
```