### PR TITLE
feat: support load config from file

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"os"
 	"os/signal"
 	"syscall"
@@ -33,15 +32,8 @@ import (
 func main() {
 	config := common.NewConfig()
 
-	// load and validate config
-	fs := flag.NewFlagSet("batch-gateway-apiserver", flag.ContinueOnError)
-	klog.InitFlags(fs)
-	config.AddFlags(fs)
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		klog.Fatalf("failed to parse config: %v", err)
-	}
-	if err := config.Validate(); err != nil {
-		klog.Fatalf("failed to validate config: %v", err)
+	if err := config.Load(); err != nil {
+		klog.Fatalf("failed to load config: %v", err)
 	}
 
 	// make sure to flush logs before exiting

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.130.1
 )
 

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -18,20 +18,54 @@ limitations under the License.
 package common
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+	"k8s.io/klog/v2"
 )
 
+// Use snake_case for YAML, and use camelCase for JSON
 type ServerConfig struct {
-	Host        string
-	Port        string
-	SSLCertFile string
-	SSLKeyFile  string
+	Host        string `json:"host" yaml:"host"`
+	Port        string `json:"port" yaml:"port"`
+	SSLCertFile string `json:"sslCertFile" yaml:"ssl_cert_file"`
+	SSLKeyFile  string `json:"sslKeyFile" yaml:"ssl_key_file"`
 }
 
 func NewConfig() *ServerConfig {
 	return &ServerConfig{}
+}
+
+func (c *ServerConfig) Load() error {
+	// Initialize flags (including klog flags)
+	fs := flag.NewFlagSet("batch-gateway-apiserver", flag.ContinueOnError)
+	klog.InitFlags(fs)
+
+	var configFile string
+	fs.StringVar(&configFile, "config", "", "path to config file")
+	fs.StringVar(&c.Host, "host", "", "server host")
+	fs.StringVar(&c.Port, "port", "8000", "server port")
+	fs.StringVar(&c.SSLCertFile, "ssl-cert-file", "", "SSL certificate file")
+	fs.StringVar(&c.SSLKeyFile, "ssl-key-file", "", "SSL key file")
+
+	// Parse all flags (klog flags and application flags)
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+
+	// If config file is provided, load from file (config file values replace CLI flag values)
+	if configFile != "" {
+		if err := c.loadFromFile(configFile); err != nil {
+			return err
+		}
+	}
+
+	return c.Validate()
 }
 
 func (c *ServerConfig) Validate() error {
@@ -57,11 +91,35 @@ func (c *ServerConfig) Validate() error {
 	return nil
 }
 
-func (c *ServerConfig) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&c.Host, "host", "", "server host")
-	fs.StringVar(&c.Port, "port", "8000", "server port")
-	fs.StringVar(&c.SSLCertFile, "ssl-cert-file", "", "SSL certificate file")
-	fs.StringVar(&c.SSLKeyFile, "ssl-private-key-file", "", "SSL key file")
+// LoadFromFile loads configuration from a JSON or YAML file
+// File format is determined by extension (.json, .yaml, .yml)
+// When config file is specified, it overrides all CLI flags
+func (c *ServerConfig) loadFromFile(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Determine file format by extension
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".json":
+		if err := json.Unmarshal(data, c); err != nil {
+			return fmt.Errorf("failed to parse JSON config file: %w", err)
+		}
+	case ".yaml", ".yml":
+		if err := yaml.Unmarshal(data, c); err != nil {
+			return fmt.Errorf("failed to parse YAML config file: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported config file format: %s (supported: .json, .yaml, .yml)", ext)
+	}
+
+	return nil
 }
 
 func (c *ServerConfig) SSLEnabled() bool {

--- a/internal/apiserver/common/config_test.go
+++ b/internal/apiserver/common/config_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The file contains unit tests for the configuration.
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServerConfig_Load_FromCLI(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    ServerConfig
+		wantErr bool
+	}{
+		{
+			name: "default values",
+			args: []string{"-logtostderr=false"}, // Add klog flag to avoid log output
+			want: ServerConfig{
+				Host: "",
+				Port: "8000",
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom host and port",
+			args: []string{"-logtostderr=false", "--host=localhost", "--port=9000"},
+			want: ServerConfig{
+				Host: "localhost",
+				Port: "9000",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with ssl cert files",
+			args: []string{"-logtostderr=false", "--host=0.0.0.0", "--port=8443", "--ssl-cert-file=testdata/cert.pem", "--ssl-key-file=testdata/key.pem"},
+			want: ServerConfig{
+				Host:        "0.0.0.0",
+				Port:        "8443",
+				SSLCertFile: "testdata/cert.pem",
+				SSLKeyFile:  "testdata/key.pem",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup test SSL files if needed
+			if tt.want.SSLCertFile != "" {
+				setupTestSSLFiles(t)
+				defer cleanupTestSSLFiles(t)
+			}
+
+			// Save original os.Args and restore after test
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+
+			// Set test args (program name + test args)
+			os.Args = append([]string{"test"}, tt.args...)
+
+			config := NewConfig()
+			err := config.Load()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if config.Host != tt.want.Host {
+					t.Errorf("Host = %v, want %v", config.Host, tt.want.Host)
+				}
+				if config.Port != tt.want.Port {
+					t.Errorf("Port = %v, want %v", config.Port, tt.want.Port)
+				}
+				if config.SSLCertFile != tt.want.SSLCertFile {
+					t.Errorf("SSLCertFile = %v, want %v", config.SSLCertFile, tt.want.SSLCertFile)
+				}
+				if config.SSLKeyFile != tt.want.SSLKeyFile {
+					t.Errorf("SSLKeyFile = %v, want %v", config.SSLKeyFile, tt.want.SSLKeyFile)
+				}
+			}
+		})
+	}
+}
+
+func TestServerConfig_Load_FromJSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		jsonConfig string
+		want       ServerConfig
+		wantErr    bool
+	}{
+		{
+			name: "valid json config",
+			jsonConfig: `{
+				"host": "0.0.0.0",
+				"port": "8080",
+				"sslCertFile": "testdata/cert.pem",
+				"sslKeyFile": "testdata/key.pem"
+			}`,
+			want: ServerConfig{
+				Host:        "0.0.0.0",
+				Port:        "8080",
+				SSLCertFile: "testdata/cert.pem",
+				SSLKeyFile:  "testdata/key.pem",
+			},
+			wantErr: false,
+		},
+		{
+			name: "json config without ssl",
+			jsonConfig: `{
+				"host": "127.0.0.1",
+				"port": "9000"
+			}`,
+			want: ServerConfig{
+				Host: "127.0.0.1",
+				Port: "9000",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "invalid json",
+			jsonConfig: `{invalid json}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary JSON config file
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, "config.json")
+			if err := os.WriteFile(configFile, []byte(tt.jsonConfig), 0644); err != nil {
+				t.Fatalf("Failed to create test config file: %v", err)
+			}
+
+			// Setup test SSL files if needed
+			if tt.want.SSLCertFile != "" {
+				setupTestSSLFiles(t)
+				defer cleanupTestSSLFiles(t)
+			}
+
+			// Save original os.Args and restore after test
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+
+			// Set args with config file
+			os.Args = []string{"test", "--config=" + configFile}
+
+			config := NewConfig()
+			err := config.Load()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if config.Host != tt.want.Host {
+					t.Errorf("Host = %v, want %v", config.Host, tt.want.Host)
+				}
+				if config.Port != tt.want.Port {
+					t.Errorf("Port = %v, want %v", config.Port, tt.want.Port)
+				}
+				if config.SSLCertFile != tt.want.SSLCertFile {
+					t.Errorf("SSLCertFile = %v, want %v", config.SSLCertFile, tt.want.SSLCertFile)
+				}
+				if config.SSLKeyFile != tt.want.SSLKeyFile {
+					t.Errorf("SSLKeyFile = %v, want %v", config.SSLKeyFile, tt.want.SSLKeyFile)
+				}
+			}
+		})
+	}
+}
+
+func TestServerConfig_Load_FromYAML(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlConfig string
+		fileName   string
+		want       ServerConfig
+		wantErr    bool
+	}{
+		{
+			name: "valid yaml config",
+			yamlConfig: `
+host: 0.0.0.0
+port: "8080"
+ssl_cert_file: testdata/cert.pem
+ssl_key_file: testdata/key.pem
+`,
+			fileName: "config.yaml",
+			want: ServerConfig{
+				Host:        "0.0.0.0",
+				Port:        "8080",
+				SSLCertFile: "testdata/cert.pem",
+				SSLKeyFile:  "testdata/key.pem",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid yml extension",
+			yamlConfig: `
+host: 127.0.0.1
+port: "9000"
+`,
+			fileName: "config.yml",
+			want: ServerConfig{
+				Host: "127.0.0.1",
+				Port: "9000",
+			},
+			wantErr: false,
+		},
+		{
+			name: "yaml config without ssl",
+			yamlConfig: `
+host: localhost
+port: "3000"
+`,
+			fileName: "config.yaml",
+			want: ServerConfig{
+				Host: "localhost",
+				Port: "3000",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "invalid yaml",
+			yamlConfig: `invalid: yaml: syntax: error`,
+			fileName:   "config.yaml",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary YAML config file
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, tt.fileName)
+			if err := os.WriteFile(configFile, []byte(tt.yamlConfig), 0644); err != nil {
+				t.Fatalf("Failed to create test config file: %v", err)
+			}
+
+			// Setup test SSL files if needed
+			if tt.want.SSLCertFile != "" {
+				setupTestSSLFiles(t)
+				defer cleanupTestSSLFiles(t)
+			}
+
+			// Save original os.Args and restore after test
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+
+			// Set args with config file
+			os.Args = []string{"test", "--config=" + configFile}
+
+			config := NewConfig()
+			err := config.Load()
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				if config.Host != tt.want.Host {
+					t.Errorf("Host = %v, want %v", config.Host, tt.want.Host)
+				}
+				if config.Port != tt.want.Port {
+					t.Errorf("Port = %v, want %v", config.Port, tt.want.Port)
+				}
+				if config.SSLCertFile != tt.want.SSLCertFile {
+					t.Errorf("SSLCertFile = %v, want %v", config.SSLCertFile, tt.want.SSLCertFile)
+				}
+				if config.SSLKeyFile != tt.want.SSLKeyFile {
+					t.Errorf("SSLKeyFile = %v, want %v", config.SSLKeyFile, tt.want.SSLKeyFile)
+				}
+			}
+		})
+	}
+}
+
+func TestServerConfig_Load_Negative(t *testing.T) {
+	t.Run("UnsupportedFormat", func(t *testing.T) {
+		// Create temporary config file with unsupported extension
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.toml")
+		if err := os.WriteFile(configFile, []byte("host = \"localhost\""), 0644); err != nil {
+			t.Fatalf("Failed to create test config file: %v", err)
+		}
+
+		// Save original os.Args and restore after test
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+
+		// Set args with config file
+		os.Args = []string{"test", "--config=" + configFile}
+
+		config := NewConfig()
+		err := config.Load()
+
+		if err == nil {
+			t.Error("Load() expected error for unsupported format, got nil")
+		}
+	})
+
+	t.Run("FileNotFound", func(t *testing.T) {
+		// Save original os.Args and restore after test
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+
+		// Set args with non-existent config file
+		os.Args = []string{"test", "--config=/nonexistent/config.yaml"}
+
+		config := NewConfig()
+		err := config.Load()
+
+		if err == nil {
+			t.Error("Load() expected error for non-existent file, got nil")
+		}
+	})
+}
+
+// Helper functions
+
+func setupTestSSLFiles(t *testing.T) {
+	// Create testdata directory
+	if err := os.MkdirAll("testdata", 0755); err != nil {
+		t.Fatalf("Failed to create testdata directory: %v", err)
+	}
+
+	// Create dummy cert file
+	certContent := []byte("-----BEGIN CERTIFICATE-----\nDUMMY CERT\n-----END CERTIFICATE-----")
+	if err := os.WriteFile("testdata/cert.pem", certContent, 0644); err != nil {
+		t.Fatalf("Failed to create cert file: %v", err)
+	}
+
+	// Create dummy key file
+	keyContent := []byte("-----BEGIN PRIVATE KEY-----\nDUMMY KEY\n-----END PRIVATE KEY-----")
+	if err := os.WriteFile("testdata/key.pem", keyContent, 0644); err != nil {
+		t.Fatalf("Failed to create key file: %v", err)
+	}
+}
+
+func cleanupTestSSLFiles(t *testing.T) {
+	if err := os.RemoveAll("testdata"); err != nil {
+		t.Logf("Failed to cleanup testdata directory: %v", err)
+	}
+}


### PR DESCRIPTION
The PR provide different way for user to launch `batch-gateway-apiserver` 

### Method 1: all from CLI arguments
`batch-gateway-apiserver -v 5 --host <host> --port <port> --ssl-cert-file <cert-file> --ssl-key-file <key-file>`
- all config from CLI
- user need to modify deployment to modify parameter

### Method 2: config comes from config files
`batch-gateway-apiserver -v 5 --config <config-file>`
- klog parameter still from CLI argument (see all arguments https://pkg.go.dev/k8s.io/klog)
- batch-gateway can load from `--config <config-file>`, which could be json, yml or yaml
- user can use configmap to provide the config file
- json format example
```
{
  "host": "0.0.0.0",
  "port": "8080",
  "sslCertFile": "testdata/cert.pem",
  "sslKeyFile": "testdata/key.pem"
}
```
- yaml format example
```
host: 0.0.0.0
port: "8080"
ssl_cert_file: testdata/cert.pem
ssl_key_file: testdata/key.pem
```