### PR TITLE
fix: simplify config load logic for api server

### DIFF
--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -1,0 +1,16 @@
+# Default configuration for batch-gateway API server
+# This file is used for local development and testing
+
+# Server host (empty string means all interfaces)
+host: ""
+
+# Server port
+port: "8000"
+
+# SSL certificate file path (optional)
+# Uncomment and set paths to enable HTTPS
+# ssl_cert_file: "path/to/cert.pem"
+# ssl_key_file: "path/to/key.pem"
+
+# Batch TTL in seconds (default: 30 days)
+batch_ttl_seconds: 2592000


### PR DESCRIPTION
The PR will simplify config load logic for api server
- Support only YAML config files; JSON file format support has been removed.
- Reduce the number of CLI arguments to only:
    - `--config`: path to the API server YAML config
    - klog CLI parameters: [klog/v2 docs](https://pkg.go.dev/k8s.io/klog/v2)


Unit test result
```
# make run-test TEST_FLAGS="-run TestAPIServerConfig"

========== Test Summary ==========
--- PASS: TestAPIServerConfig (0.01s)
    --- PASS: TestAPIServerConfig/LoadFromYAML (0.01s)
        --- PASS: TestAPIServerConfig/LoadFromYAML/valid_yaml_config (0.00s)
        --- PASS: TestAPIServerConfig/LoadFromYAML/valid_yml_extension (0.00s)
        --- PASS: TestAPIServerConfig/LoadFromYAML/yaml_config_without_ssl (0.00s)
        --- PASS: TestAPIServerConfig/LoadFromYAML/invalid_yaml (0.00s)
    --- PASS: TestAPIServerConfig/LoadNegative (0.00s)
        --- PASS: TestAPIServerConfig/LoadNegative/MissingConfigFile (0.00s)
        --- PASS: TestAPIServerConfig/LoadNegative/UnsupportedFormat (0.00s)
        --- PASS: TestAPIServerConfig/LoadNegative/FileNotFound (0.00s)

Passed: 10 | Failed: 0 | Skipped: 0

✅ All tests passed!

```