### PR TITLE
fix: use subtests in recovery middleware tests

### DIFF
--- a/internal/apiserver/middleware/recovery_middleware_test.go
+++ b/internal/apiserver/middleware/recovery_middleware_test.go
@@ -28,7 +28,12 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 )
 
-func TestRecoveryMiddleware_NoPanic(t *testing.T) {
+func TestRecoveryMiddleware(t *testing.T) {
+	t.Run("NoPanic", doTestRecoveryMiddlewareNoPanic)
+	t.Run("WithPanic", doTestRecoveryMiddlewareWithPanic)
+}
+
+func doTestRecoveryMiddlewareNoPanic(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("success"))
@@ -51,7 +56,7 @@ func TestRecoveryMiddleware_NoPanic(t *testing.T) {
 	}
 }
 
-func TestRecoveryMiddleware_WithPanic(t *testing.T) {
+func doTestRecoveryMiddlewareWithPanic(t *testing.T) {
 	tests := []struct {
 		name       string
 		panicValue interface{}


### PR DESCRIPTION
The PR will use subtests in recovery middleware tests

so we are able to run RecoveryMiddleware test cases sololy with `make run-test TEST_FLAGS="-race -run TestRecoveryMiddleware"`

output before:
```
--- PASS: TestRecoveryMiddleware_NoPanic (0.00s)
--- PASS: TestRecoveryMiddleware_WithPanic (0.00s)
    --- PASS: TestRecoveryMiddleware_WithPanic/string_panic (0.00s)
    --- PASS: TestRecoveryMiddleware_WithPanic/error_panic (0.00s)
    --- PASS: TestRecoveryMiddleware_WithPanic/int_panic (0.00s)
    --- PASS: TestRecoveryMiddleware_WithPanic/nil_panic (0.00s)
    --- PASS: TestRecoveryMiddleware_WithPanic/struct_panic (0.00s)
```

output after (cases shows as tree hierarchy)
```
--- PASS: TestRecoveryMiddleware (0.00s)
    --- PASS: TestRecoveryMiddleware/NoPanic (0.00s)
    --- PASS: TestRecoveryMiddleware/WithPanic (0.00s)
        --- PASS: TestRecoveryMiddleware/WithPanic/string_panic (0.00s)
        --- PASS: TestRecoveryMiddleware/WithPanic/error_panic (0.00s)
        --- PASS: TestRecoveryMiddleware/WithPanic/int_panic (0.00s)
        --- PASS: TestRecoveryMiddleware/WithPanic/nil_panic (0.00s)
        --- PASS: TestRecoveryMiddleware/WithPanic/struct_panic (0.00s)
```

