### PR TITLE
feat: Initial draft for helm chart

### DIFF
--- a/charts/batch-gateway/.helmignore
+++ b/charts/batch-gateway/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/batch-gateway/Chart.yaml
+++ b/charts/batch-gateway/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: batch-gateway
+description: A Helm chart for the Batch Gateway
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+keywords:
+  - batch-gateway
+  - api-server
+  - processor
+  - worker
+  - llm
+maintainers:
+  - name: llm-d
+    url: https://github.com/llm-d-incubation/batch-gateway

--- a/charts/batch-gateway/README.md
+++ b/charts/batch-gateway/README.md
@@ -1,0 +1,215 @@
+# Batch Gateway Helm Chart
+
+This Helm chart deploys the Batch Gateway on a Kubernetes cluster, which includes:
+- **API Server**: REST API server for file and batch management
+- **Processor**: Background processor for batch job execution
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+## Components
+
+### API Server (batch-gateway-apiserver)
+The API server provides a REST API for managing files and batch jobs.
+
+### Processor (batch-gateway-processor)
+The processor is a background worker component that polls for and processes batch jobs. 
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm install my-release ./charts/batch-gateway
+```
+
+This will deploy only the API server by default.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+helm uninstall my-release
+```
+
+## Upgrading the Chart
+
+To upgrade an existing release with new values:
+
+```bash
+# Upgrade with a values file
+helm upgrade my-release ./charts/batch-gateway -f my-values.yaml
+
+# Or use --set
+helm upgrade my-release ./charts/batch-gateway \
+  --set apiserver.replicaCount=5
+
+# View what would change before upgrading
+helm upgrade my-release ./charts/batch-gateway \
+  -f my-values.yaml \
+  --dry-run --debug
+```
+
+## Configuration
+For a complete list of parameters, see [values.yaml](./values.yaml).
+
+## Usage
+
+### Method 1: Using a Custom Values File
+
+```bash
+cat > my-values.yaml <<EOF
+apiserver:
+  replicaCount: 3
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 200m
+EOF
+
+helm install batch-gateway ./charts/batch-gateway -f my-values.yaml
+```
+
+### Method 2: Using --set Flags
+
+```bash
+helm install batch-gateway ./charts/batch-gateway \
+  --set apiserver.replicaCount=3 \
+  --set apiserver.resources.requests.memory=256Mi
+```
+
+### Install on OpenShift
+
+OpenShift uses Security Context Constraints (SCC) that assign UIDs dynamically. Override the podSecurityContext to use SCC-assigned UIDs:
+
+```bash
+cat > openshift-values.yaml <<EOF
+apiserver:
+  podSecurityContext: {}  # Let OpenShift SCC assign UIDs
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+processor:
+  podSecurityContext: {}  # Let OpenShift SCC assign UIDs
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+EOF
+
+helm install batch-gateway ./charts/batch-gateway -f openshift-values.yaml
+```
+
+The chart will work with OpenShift's `restricted` SCC by default when podSecurityContext is empty.
+
+## Accessing the Services
+
+### API Server
+
+For ClusterIP service type (default):
+
+```bash
+export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/component=apiserver" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward $POD_NAME 8080:8000
+curl http://localhost:8080/health
+```
+
+### Processor
+
+The processor is a background worker and does not expose a service. To view logs:
+
+```bash
+kubectl logs -l "app.kubernetes.io/component=processor" -f
+```
+
+## Exposing the API Server
+
+The chart creates a ClusterIP Service by default. To expose it externally, create your own Ingress or HTTPRoute.
+
+### Using Ingress
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: batch-gateway-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: <release-name>-batch-gateway-apiserver
+            port:
+              number: 8000
+  tls:
+  - hosts:
+    - api.example.com
+    secretName: batch-gateway-tls
+```
+
+### Using Gateway API HTTPRoute
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: batch-gateway-route
+spec:
+  parentRefs:
+  - name: my-gateway
+    namespace: gateway-system
+  hostnames:
+  - api.example.com
+  rules:
+  - backendRefs:
+    - name: <release-name>-batch-gateway-apiserver
+      port: 8000
+```
+
+## Health Checks
+
+### API Server
+- **Liveness Probe**: `GET /health` on port 8000
+- **Readiness Probe**: `GET /readyz` on port 8000
+
+### Processor
+- **Liveness Probe**: `GET /health` on port 9090
+- **Readiness Probe**: `GET /health` on port 9090
+
+## Security
+
+The chart follows security best practices:
+- Runs as non-root user (UID 65532 by default)
+- Uses read-only root filesystem
+- Drops all Linux capabilities
+- Prevents privilege escalation
+- Uses seccomp profile
+
+### OpenShift Compatibility
+
+The chart is compatible with OpenShift's Security Context Constraints (SCC):
+- Set `podSecurityContext: {}` to allow OpenShift to assign UIDs from the namespace range
+- The minimal `securityContext` (drop all capabilities, no privilege escalation, read-only filesystem) works with the `restricted` SCC
+- No additional SCC configuration is required
+
+## License
+
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0.

--- a/charts/batch-gateway/templates/_helpers.tpl
+++ b/charts/batch-gateway/templates/_helpers.tpl
@@ -1,0 +1,128 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "batch-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "batch-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "batch-gateway.labels" -}}
+helm.sh/chart: {{ include "batch-gateway.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* ========== API Server Helpers ========== */}}
+
+{{/*
+API Server fullname
+*/}}
+{{- define "batch-gateway.apiserver.fullname" -}}
+{{- if .Values.apiserver.fullnameOverride }}
+{{- .Values.apiserver.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.apiserver.nameOverride }}
+{{- printf "%s-%s-apiserver" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+API Server labels
+*/}}
+{{- define "batch-gateway.apiserver.labels" -}}
+{{ include "batch-gateway.labels" . }}
+app.kubernetes.io/name: {{ include "batch-gateway.name" . }}-apiserver
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: apiserver
+{{- end }}
+
+{{/*
+API Server selector labels
+*/}}
+{{- define "batch-gateway.apiserver.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "batch-gateway.name" . }}-apiserver
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: apiserver
+{{- end }}
+
+{{/*
+API Server service account name
+*/}}
+{{- define "batch-gateway.apiserver.serviceAccountName" -}}
+{{- if .Values.apiserver.serviceAccount.create }}
+{{- default (include "batch-gateway.apiserver.fullname" .) .Values.apiserver.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.apiserver.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+API Server image string
+*/}}
+{{- define "batch-gateway.apiserver.image" -}}
+{{- $tag := .Values.apiserver.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.apiserver.image.repository $tag }}
+{{- end }}
+
+{{/* ========== Processor Helpers ========== */}}
+
+{{/*
+Processor fullname
+*/}}
+{{- define "batch-gateway.processor.fullname" -}}
+{{- if .Values.processor.fullnameOverride }}
+{{- .Values.processor.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.processor.nameOverride }}
+{{- printf "%s-%s-processor" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Processor labels
+*/}}
+{{- define "batch-gateway.processor.labels" -}}
+{{ include "batch-gateway.labels" . }}
+app.kubernetes.io/name: {{ include "batch-gateway.name" . }}-processor
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: processor
+{{- end }}
+
+{{/*
+Processor selector labels
+*/}}
+{{- define "batch-gateway.processor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "batch-gateway.name" . }}-processor
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: processor
+{{- end }}
+
+{{/*
+Processor service account name
+*/}}
+{{- define "batch-gateway.processor.serviceAccountName" -}}
+{{- if .Values.processor.serviceAccount.create }}
+{{- default (include "batch-gateway.processor.fullname" .) .Values.processor.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.processor.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Processor image string
+*/}}
+{{- define "batch-gateway.processor.image" -}}
+{{- $tag := .Values.processor.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.processor.image.repository $tag }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-certificate.yaml
+++ b/charts/batch-gateway/templates/apiserver-certificate.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.apiserver.enabled .Values.apiserver.tls.enabled .Values.apiserver.tls.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "batch-gateway.apiserver.fullname" . }}-tls
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "batch-gateway.apiserver.fullname" . }}-tls
+  issuerRef:
+    name: {{ .Values.apiserver.tls.certManager.issuerName }}
+    kind: {{ .Values.apiserver.tls.certManager.issuerKind }}
+  dnsNames:
+    {{- range .Values.apiserver.ingress.hosts }}
+    - {{ .host }}
+    {{- end }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.apiserver.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "batch-gateway.apiserver.fullname" . }}-config
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    # API Server configuration
+    host: {{ .Values.apiserver.config.host | quote }}
+    port: {{ .Values.apiserver.config.port | quote }}
+    batch_ttl_seconds: {{ .Values.apiserver.config.batchTTLSeconds }}
+    {{- if .Values.apiserver.tls.enabled }}
+    ssl_cert_file: "/etc/tls/tls.crt"
+    ssl_key_file: "/etc/tls/tls.key"
+    {{- end }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-deployment.yaml
+++ b/charts/batch-gateway/templates/apiserver-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.apiserver.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "batch-gateway.apiserver.fullname" . }}
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.apiserver.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "batch-gateway.apiserver.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/apiserver-configmap.yaml") . | sha256sum }}
+        {{- with .Values.apiserver.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "batch-gateway.apiserver.labels" . | nindent 8 }}
+        {{- with .Values.apiserver.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "batch-gateway.apiserver.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.apiserver.podSecurityContext | nindent 8 }}
+      containers:
+      - name: apiserver
+        securityContext:
+          {{- toYaml .Values.apiserver.securityContext | nindent 12 }}
+        image: {{ include "batch-gateway.apiserver.image" . }}
+        imagePullPolicy: {{ .Values.apiserver.image.pullPolicy }}
+        args:
+        - --config=/etc/config/config.yaml
+        - --v={{ .Values.apiserver.logging.verbosity }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.apiserver.config.port }}
+          protocol: TCP
+        livenessProbe:
+          {{- toYaml .Values.apiserver.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.apiserver.readinessProbe | nindent 12 }}
+        resources:
+          {{- toYaml .Values.apiserver.resources | nindent 12 }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        {{- if .Values.apiserver.tls.enabled }}
+        - name: tls
+          mountPath: /etc/tls
+          readOnly: true
+        {{- end }}
+        {{- with .Values.apiserver.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "batch-gateway.apiserver.fullname" . }}-config
+      {{- if .Values.apiserver.tls.enabled }}
+      - name: tls
+        secret:
+          {{- if .Values.apiserver.tls.secretName }}
+          secretName: {{ .Values.apiserver.tls.secretName }}
+          {{- else if .Values.apiserver.tls.certManager.enabled }}
+          secretName: {{ include "batch-gateway.apiserver.fullname" . }}-tls
+          {{- else }}
+          secretName: {{ include "batch-gateway.apiserver.fullname" . }}-tls
+          {{- end }}
+      {{- end }}
+      {{- with .Values.apiserver.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.apiserver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiserver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.apiserver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-service.yaml
+++ b/charts/batch-gateway/templates/apiserver-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.apiserver.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "batch-gateway.apiserver.fullname" . }}
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+  {{- with .Values.apiserver.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.apiserver.service.type }}
+  ports:
+    - port: {{ .Values.apiserver.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "batch-gateway.apiserver.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-serviceaccount.yaml
+++ b/charts/batch-gateway/templates/apiserver-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.apiserver.enabled .Values.apiserver.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "batch-gateway.apiserver.serviceAccountName" . }}
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+  {{- with .Values.apiserver.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.apiserver.serviceAccount.automount }}
+{{- end }}

--- a/charts/batch-gateway/templates/apiserver-tls-secret.yaml
+++ b/charts/batch-gateway/templates/apiserver-tls-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.apiserver.enabled .Values.apiserver.tls.enabled (not .Values.apiserver.tls.secretName) (not .Values.apiserver.tls.certManager.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "batch-gateway.apiserver.fullname" . }}-tls
+  labels:
+    {{- include "batch-gateway.apiserver.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.apiserver.tls.cert | b64enc }}
+  tls.key: {{ .Values.apiserver.tls.key | b64enc }}
+{{- end }}

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.processor.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "batch-gateway.processor.fullname" . }}-config
+  labels:
+    {{- include "batch-gateway.processor.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    # Processor configuration
+    # NOTE: This is a placeholder - processor is not code-ready yet
+
+    addr: {{ .Values.processor.config.addr | quote }}
+    task_wait_time: {{ .Values.processor.config.taskWaitTime | quote }}
+    poll_interval: {{ .Values.processor.config.pollInterval | quote }}
+    num_workers: {{ .Values.processor.config.numWorkers }}
+    max_job_concurrency: {{ .Values.processor.config.maxJobConcurrency }}
+
+    queue_time_bucket:
+      bucket_start: {{ .Values.processor.config.queueTimeBucket.bucketStart }}
+      bucket_factor: {{ .Values.processor.config.queueTimeBucket.bucketFactor }}
+      bucket_count: {{ .Values.processor.config.queueTimeBucket.bucketCount }}
+
+    process_time_bucket:
+      bucket_start: {{ .Values.processor.config.processTimeBucket.bucketStart }}
+      bucket_factor: {{ .Values.processor.config.processTimeBucket.bucketFactor }}
+      bucket_count: {{ .Values.processor.config.processTimeBucket.bucketCount }}
+
+    {{- if .Values.processor.tls.enabled }}
+    ssl_cert_file: "/etc/tls/tls.crt"
+    ssl_key_file: "/etc/tls/tls.key"
+    {{- end }}
+
+    {{- if .Values.processor.database.url }}
+    database_url: {{ .Values.processor.database.url | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/batch-gateway/templates/processor-deployment.yaml
+++ b/charts/batch-gateway/templates/processor-deployment.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.processor.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "batch-gateway.processor.fullname" . }}
+  labels:
+    {{- include "batch-gateway.processor.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.processor.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "batch-gateway.processor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/processor-configmap.yaml") . | sha256sum }}
+        {{- with .Values.processor.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "batch-gateway.processor.labels" . | nindent 8 }}
+        {{- with .Values.processor.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "batch-gateway.processor.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.processor.podSecurityContext | nindent 8 }}
+      containers:
+      - name: processor
+        securityContext:
+          {{- toYaml .Values.processor.securityContext | nindent 12 }}
+        image: {{ include "batch-gateway.processor.image" . }}
+        imagePullPolicy: {{ .Values.processor.image.pullPolicy }}
+        args:
+        - --config=/etc/config/config.yaml
+        - --v={{ .Values.processor.logging.verbosity }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.processor.config.addr | trimPrefix ":" }}
+          protocol: TCP
+        livenessProbe:
+          {{- toYaml .Values.processor.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.processor.readinessProbe | nindent 12 }}
+        resources:
+          {{- toYaml .Values.processor.resources | nindent 12 }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        {{- if .Values.processor.tls.enabled }}
+        - name: tls
+          mountPath: /etc/tls
+          readOnly: true
+        {{- end }}
+        {{- with .Values.processor.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.processor.database.existingSecret }}
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.processor.database.existingSecret }}
+              key: {{ .Values.processor.database.secretKey }}
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "batch-gateway.processor.fullname" . }}-config
+      {{- if .Values.processor.tls.enabled }}
+      - name: tls
+        secret:
+          {{- if .Values.processor.tls.secretName }}
+          secretName: {{ .Values.processor.tls.secretName }}
+          {{- else }}
+          secretName: {{ include "batch-gateway.processor.fullname" . }}-tls
+          {{- end }}
+      {{- end }}
+      {{- with .Values.processor.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.processor.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.processor.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.processor.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/batch-gateway/templates/processor-serviceaccount.yaml
+++ b/charts/batch-gateway/templates/processor-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.processor.enabled .Values.processor.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "batch-gateway.processor.serviceAccountName" . }}
+  labels:
+    {{- include "batch-gateway.processor.labels" . | nindent 4 }}
+  {{- with .Values.processor.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.processor.serviceAccount.automount }}
+{{- end }}

--- a/charts/batch-gateway/templates/processor-tls-secret.yaml
+++ b/charts/batch-gateway/templates/processor-tls-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.processor.enabled .Values.processor.tls.enabled (not .Values.processor.tls.secretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "batch-gateway.processor.fullname" . }}-tls
+  labels:
+    {{- include "batch-gateway.processor.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.processor.tls.cert | b64enc }}
+  tls.key: {{ .Values.processor.tls.key | b64enc }}
+{{- end }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -1,0 +1,207 @@
+# Global settings
+global:
+  imagePullSecrets: []
+
+# API Server configuration
+apiserver:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/llm-d/batch-gateway-apiserver
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    automount: true
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+  podLabels: {}
+
+  # Pod security context
+  # For OpenShift, set podSecurityContext: {} to use SCC-assigned UIDs
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container security context (minimal, works with OpenShift)
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  service:
+    type: ClusterIP
+    port: 8000
+    targetPort: 8000
+    annotations: {}
+
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  # API Server specific configuration
+  config:
+    host: ""
+    port: "8000"
+    batchTTLSeconds: 2592000
+
+  # TLS/SSL Configuration
+  tls:
+    enabled: false
+    secretName: ""
+    cert: ""
+    key: ""
+    certManager:
+      enabled: false
+      issuerName: ""
+      issuerKind: ClusterIssuer
+
+  # Logging configuration
+  logging:
+    verbosity: 2
+
+# Processor configuration
+processor:
+  enabled: false
+  replicaCount: 1
+
+  image:
+    repository: ghcr.io/llm-d/batch-gateway-processor
+    pullPolicy: IfNotPresent
+    tag: ""
+
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    automount: true
+    annotations: {}
+    name: ""
+
+  podAnnotations: {}
+  podLabels: {}
+
+  # Pod security context
+  # For OpenShift, set podSecurityContext: {} to use SCC-assigned UIDs
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+  # Container security context (minimal, works with OpenShift)
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: metrics
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: metrics
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+  volumes: []
+  volumeMounts: []
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  # Processor specific configuration
+  config:
+    addr: ":9090"
+    taskWaitTime: "1s"
+    pollInterval: "5s"
+    numWorkers: 20
+    maxJobConcurrency: 10
+    queueTimeBucket:
+      bucketStart: 0.1
+      bucketFactor: 2
+      bucketCount: 10
+    processTimeBucket:
+      bucketStart: 0.1
+      bucketFactor: 2
+      bucketCount: 15
+
+  # TLS/SSL Configuration
+  tls:
+    enabled: false
+    secretName: ""
+    cert: ""
+    key: ""
+
+  # Logging configuration
+  logging:
+    verbosity: 2
+
+  # Database connection
+  database:
+    url: ""
+    existingSecret: ""
+    secretKey: "database-url"


### PR DESCRIPTION
Initial draft for helm charts
- will install configmap / deployment / service for processor and api server
- user need to manually setup ingress or gateway+httproute, provided guides in README.md

Not tested because I don't have image or cluster ready, just draft.