### PR TITLE
fix: improves job cancellation logic and error handling in batch handler

### DIFF
--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -186,6 +186,9 @@ func (c *BatchApiHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := c.queueClient.Enqueue(ctx, bjp); err != nil {
 		logger.Error(err, "failed to enqueue batch job priority")
+		if _, delErr := c.dbClient.Delete(ctx, []string{batchID}); delErr != nil {
+			logger.Error(delErr, "failed to cleanup batch job after enqueue failure", "batch_id", batchID)
+		}
 		common.WriteInternalServerError(ctx, w)
 		return
 	}
@@ -362,40 +365,56 @@ func (c *BatchApiHandler) CancelBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update status to cancelling
-	batch.Status = openai.BatchStatusCancelling
-	currentTime := time.Now().UTC().Unix()
-	batch.CancellingAt = &currentTime
+	// Try to remove from the priority queue first
+	jobPriority := &api.BatchJobPriority{
+		ID: batchID,
+	}
+	removed, err := c.queueClient.Remove(ctx, jobPriority)
+	if err != nil {
+		logger.Error(err, "failed to remove batch from queue", "batch_id", batchID)
+		common.WriteInternalServerError(ctx, w)
+		return
+	}
 
+	if removed > 0 {
+		// Job was in queue (not yet being processed) - directly cancel it
+		batch.Status = openai.BatchStatusCancelled
+		cancelledAt := time.Now().UTC().Unix()
+		batch.CancelledAt = &cancelledAt
+	} else {
+		// Job is being processed - mark as cancelling and send cancel event
+		batch.Status = openai.BatchStatusCancelling
+		cancellingAt := time.Now().UTC().Unix()
+		batch.CancellingAt = &cancellingAt
+
+		event := []api.BatchEvent{
+			{
+				ID:   batchID,
+				Type: api.BatchEventCancel,
+				TTL:  c.config.BatchTTLSeconds,
+			},
+		}
+		_, err = c.eventClient.ProducerSendEvents(ctx, event)
+		if err != nil {
+			logger.Error(err, "failed to send cancel event", "batch_id", batchID)
+			common.WriteInternalServerError(ctx, w)
+			return
+		}
+	}
+
+	// Update batch status in database
 	updatedStatusData, err := json.Marshal(batch.BatchStatusInfo)
 	if err != nil {
 		logger.Error(err, "failed to marshal updated status", "batch_id", batchID)
 		common.WriteInternalServerError(ctx, w)
 		return
 	}
-
 	job.Status = updatedStatusData
 	if err := c.dbClient.Update(ctx, job); err != nil {
 		logger.Error(err, "failed to update batch in database", "batch_id", batchID)
 		common.WriteInternalServerError(ctx, w)
 		return
 	}
-
-	// Remove the job id from the priority queue.
-	jobPriority := &api.BatchJobPriority{
-		ID: batchID,
-	}
-	c.queueClient.Remove(ctx, jobPriority)
-
-	// Send a cancel event on the event channel associated with the job.
-	event := []api.BatchEvent{
-		{
-			ID:   batchID,
-			Type: api.BatchEventCancel,
-			TTL:  c.config.BatchTTLSeconds,
-		},
-	}
-	c.eventClient.ProducerSendEvents(ctx, event)
 
 	common.WriteJSONResponse(ctx, w, http.StatusOK, batch)
 }

--- a/internal/database/api/database.go
+++ b/internal/database/api/database.go
@@ -119,8 +119,10 @@ type BatchPriorityQueueClient interface {
 	Dequeue(ctx context.Context, timeout time.Duration, maxObjs int) (
 		jobPriorities []*BatchJobPriority, err error)
 
-	// Remove deletes a job priority object from the queue.
-	Remove(ctx context.Context, jobPriority *BatchJobPriority) error
+	// Remove removes jobPriority from the queue.
+	// It returns the removed job numbers.
+	// An error is returned only if the removal operation fails.
+	Remove(ctx context.Context, jobPriority *BatchJobPriority) (int, error)
 }
 
 // -- Batch jobs events and channels --

--- a/internal/database/mock/mock_queue_client.go
+++ b/internal/database/mock/mock_queue_client.go
@@ -19,7 +19,6 @@ package mock
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -99,7 +98,7 @@ func (m *MockBatchPriorityQueueClient) Dequeue(ctx context.Context, timeout time
 	}
 }
 
-func (m *MockBatchPriorityQueueClient) Remove(ctx context.Context, jobPriority *api.BatchJobPriority) error {
+func (m *MockBatchPriorityQueueClient) Remove(ctx context.Context, jobPriority *api.BatchJobPriority) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -107,11 +106,11 @@ func (m *MockBatchPriorityQueueClient) Remove(ctx context.Context, jobPriority *
 		if jp.ID == jobPriority.ID {
 			// Remove the item
 			m.queue = append(m.queue[:i], m.queue[i+1:]...)
-			return nil
+			return 1, nil
 		}
 	}
 
-	return fmt.Errorf("job with ID '%s' not found in queue", jobPriority.ID)
+	return 0, nil
 }
 
 func (m *MockBatchPriorityQueueClient) GetContext(parentCtx context.Context, timeLimit time.Duration) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
The PR improves job cancellation logic and error handling in batch handler
- Updated `BatchApiHandler.CreateBatch()`, to delete batch job from DB if  enqueue fails
- Updated `BatchPriorityQueueClient.Remove()` to return `(bool, error)` instead of just `error`
    - true, nil → removed
    - false, nil → not found
    - false, err → failure
- Updated `BatchApiHandler.CancelBatch()`, to the logic we discussed
   https://github.com/llm-d-incubation/batch-gateway/pull/10#discussion_r2734173447
   https://github.com/llm-d-incubation/batch-gateway/wiki/Internal-designs#protocol-for-cancellation-of-a-batch-job
