### PR TITLE
fix: modify middleware order for rest server

### DIFF
--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -144,14 +144,14 @@ func (s *Server) buildHandler() http.Handler {
 	}
 
 	// register middlewares
-	var h http.Handler
-	h = middleware.RecoveryMiddleware(mux) // Innermost, catches panics from business logic
+	var h http.Handler = mux
 	//h = middleware.BodySizeLimitMiddleware(h) //  Limit request body size
 	//h = middleware.AuthorizationMiddleware(h) //  Check permissions
 	//h = middleware.AuthenticationMiddleware(h) // Verify API key/JWT
-	h = middleware.RequestMiddleware(h) // Request ID, logging, metrics
 	//h = middleware.RateLimitMiddleware(h)      // Early Rejection
-	h = middleware.SecurityHeadersMiddleware(h) // Outermost, affects all responses
+	h = middleware.SecurityHeadersMiddleware(h) // Add security headers
+	h = middleware.RequestMiddleware(h)         // 2nd Outermost, request monitoring
+	h = middleware.RecoveryMiddleware(h)        // Outermost - catches ALL panics
 
 	return h
 }


### PR DESCRIPTION
The PR will modify middleware order for rest server
- `RecoveryMiddleware` should be the outermost layer to catch ALL panic from the other middleware and handlers
- `RequestMiddleware` should be 2nd Outermost, which 
    - generate request id and put  `x-request-id` into resp headers
    - create request logger with request id for handlers
    - auto record prometheus metrics for the request