### PR TITLE
docs: fix BatchDBClient.Get() documentation to match actual behavior

### DIFF
--- a/internal/database/api/database.go
+++ b/internal/database/api/database.go
@@ -61,7 +61,7 @@ type BatchDBClient interface {
 	// Get gets the information (static and dynamic) of batch jobs.
 	// If IDs are specified, this function will get jobs by the specified IDs.
 	// If tags are specified, this function will get jobs by the specified tags.
-	// If no IDs nor tags are specified, the function will return an empty list of jobs.
+	// If no IDs nor tags are specified, the function will return all jobs (paginated).
 	// tagsLogicalCond specifies the logical condition to use for when searching for the tags per job.
 	// includeStatic specifies if to include the static part of a job in the returned output.
 	// start and limit specify the pagination details. This is relevant only for search by tags.


### PR DESCRIPTION
## Summary

The `BatchDBClient.Get()` documentation states that when no IDs or tags are specified, the function returns an empty list. However, the actual behavior (as implemented in the mock client and used by `ListBatches()`) returns all jobs with pagination.

This PR updates the documentation to match the current behavior.

## Discussion

There are two approaches we could take:

1. **Keep the current behavior** (this PR): Update docs and ensure all implementations return all jobs when no filters are specified. This aligns with how `ListBatches()` currently works.

2. **Introduce a new API**: Add a separate `List()` method for listing all jobs and keep `Get()` returning an empty list when no filters are specified (as originally documented).

Looking for feedback on which approach is preferred before implementing further changes.