### PR TITLE
fix: pass REGISTRY env var to docker bake action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,7 @@ jobs:
             *.cache-from=
             *.cache-to=
         env:
+          REGISTRY: ghcr.io/llm-d-incubation
           COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
           BUILD_DATE: ${{ steps.meta.outputs.build_date }}
           VERSION: ${{ steps.meta.outputs.version }}
@@ -99,6 +100,7 @@ jobs:
           targets: default
           push: true
         env:
+          REGISTRY: ghcr.io/llm-d-incubation
           COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
           BUILD_DATE: ${{ steps.meta.outputs.build_date }}
           VERSION: ${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Fixes Docker Bake action to receive the REGISTRY environment variable.

The docker bake action wasn't receiving the REGISTRY environment variable, causing it to fail with 400 Bad Request when trying to push to ghcr.io without the organization prefix.

Before: ghcr.io/batch-gateway-apiserver (fails)
After: ghcr.io/llm-d-incubation/batch-gateway-apiserver (correct)