### PR TITLE
🌱 Add Prow and stale/unstale governance workflows

### DIFF
--- a/.github/workflows/ci-signed-commits.yml
+++ b/.github/workflows/ci-signed-commits.yml
@@ -1,0 +1,9 @@
+name: Check Signed Commits
+on: pull_request_target
+
+jobs:
+  signed-commits:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -1,0 +1,11 @@
+name: Non-Main Gatekeeper
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  gatekeeper:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yml@main

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -1,0 +1,12 @@
+name: Prow Commands
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  prow:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yml@main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -1,0 +1,12 @@
+name: Prow Auto-merge
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yml@main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -1,0 +1,9 @@
+name: Prow Remove LGTM
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-lgtm:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,11 @@
+name: Mark Stale Issues
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -1,0 +1,12 @@
+name: Unstale Issues
+on:
+  issues:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  unstale:
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yml@main
+    permissions:
+      issues: write


### PR DESCRIPTION
## Summary

- Adds 7 standard Prow/governance workflows using reusable callers from `llm-d/llm-d-infra`
- All workflows include explicit permissions declarations
- Scope trimmed to governance-only (no Go/Docker/test changes)

### Workflows Added
| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `ci-signed-commits.yml` | `pull_request_target` | Verify signed commits |
| `non-main-gatekeeper.yml` | `pull_request` | Block PRs targeting non-main branches |
| `prow-github.yml` | `issue_comment` | Process Prow commands (/lgtm, /approve, etc.) |
| `prow-pr-automerge.yml` | schedule (15min) | Auto-merge approved PRs |
| `prow-pr-remove-lgtm.yml` | `pull_request` | Remove LGTM on PR update |
| `stale.yml` | schedule (daily) | Mark stale issues/PRs |
| `unstale.yml` | issue events | Remove stale label on activity |

## Test plan

- [ ] Workflows reference valid reusable workflows in llm-d-infra
- [ ] No conflicts with existing CI