### PR TITLE
docs: add development guide for local Kind deployment

### DIFF
--- a/docs/guides/DEVELOPMENT.md
+++ b/docs/guides/DEVELOPMENT.md
@@ -148,7 +148,7 @@ $ kubectl rollout restart deployment -l app.kubernetes.io/instance=batch-gateway
 ## 7. Cleanup
 
 ```bash
-# removes all resouces 
+# removes all resources 
 $ helm uninstall batch-gateway
 
 # deletes the Kind cluster


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR adds a development guide to deploy batch-gateway in a Kind cluster for local development. It also tests deploying the batch gateway using helm on a Kind cluster. 

**Testing deployment using helm**

Kind cluster is created successfully:
<img width="576" height="49" alt="image" src="https://github.com/user-attachments/assets/6cf4e57c-3dea-430e-9a3b-fd3586f6b003" />

make image-build successfully creates the docker images:
<img width="746" height="75" alt="image" src="https://github.com/user-attachments/assets/2cf935aa-31f2-4feb-87a5-c189ac74fd07" />

After loading the images to Kind cluster and running helm install, the deployment is successful:
<img width="834" height="203" alt="image" src="https://github.com/user-attachments/assets/7a1c0eb1-10c7-4ef5-96b6-7bf02eb4d2e8" />

Pods are deployed successfully:
<img width="740" height="63" alt="image" src="https://github.com/user-attachments/assets/4adb7890-8b07-41e2-a4b5-14c52c06aee6" />

apiserver service is deployed successfully:
<img width="698" height="45" alt="image" src="https://github.com/user-attachments/assets/654d8c31-5bd8-4b12-9592-7c7b983aff12" />

Health check shows ok:
<img width="719" height="31" alt="image" src="https://github.com/user-attachments/assets/c8dc01c6-1787-4bf0-8d91-75f2654feebf" />

Cleanups:
<img width="781" height="79" alt="image" src="https://github.com/user-attachments/assets/7b898538-28e4-4a9e-b62e-9d915e99175d" />
