### PR TITLE
feat: Add /ready endpoint and HTTP server timeout configuration

### DIFF
--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -14,10 +14,14 @@ data:
     {{- if .Values.apiserver.config.tenantHeader }}
     tenant_header: {{ .Values.apiserver.config.tenantHeader | quote }}
     {{- end }}
+    read_header_timeout_seconds: {{ .Values.apiserver.config.readHeaderTimeoutSeconds }}
+    read_timeout_seconds: {{ .Values.apiserver.config.readTimeoutSeconds }}
+    write_timeout_seconds: {{ .Values.apiserver.config.writeTimeoutSeconds }}
+    idle_timeout_seconds: {{ .Values.apiserver.config.idleTimeoutSeconds }}
     files_api:
-      default_expiration_seconds: {{ .Values.apiserver.config.fileAPI.defaultExpirationSeconds }}
-      max_size_bytes: {{ .Values.apiserver.config.fileAPI.maxSizeBytes }}
-      max_line_count: {{ .Values.apiserver.config.fileAPI.maxLineCount }}
+      default_expiration_seconds: {{ .Values.apiserver.config.filesAPI.defaultExpirationSeconds }}
+      max_size_bytes: {{ .Values.apiserver.config.filesAPI.maxSizeBytes }}
+      max_line_count: {{ .Values.apiserver.config.filesAPI.maxLineCount }}
     {{- if .Values.apiserver.tls.enabled }}
     ssl_cert_file: "/etc/tls/tls.crt"
     ssl_key_file: "/etc/tls/tls.key"

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -85,9 +85,12 @@ apiserver:
     host: ""
     port: "8000"
     batchTTLSeconds: 2592000
-    # HTTP header name for tenant ID (default: X-MaaS-User)
     tenantHeader: "X-MaaS-User"
-    fileAPI:
+    readHeaderTimeoutSeconds: 10
+    readTimeoutSeconds: 900
+    writeTimeoutSeconds: 120
+    idleTimeoutSeconds: 90
+    filesAPI:
       defaultExpirationSeconds: 7776000
       maxSizeBytes: 209715200
       maxLineCount: 50000

--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -18,6 +18,29 @@ batch_ttl_seconds: 2592000
 # HTTP header name for tenant ID (default: X-MaaS-User)
 tenant_header: "X-MaaS-User"
 
+# HTTP server timeout configurations (in seconds)
+# These values should accommodate large file uploads and batch operations
+# Set to 0 or omit to use defaults
+
+# Time allowed to read request headers (prevents Slowloris attacks)
+# Default: 10 seconds
+read_header_timeout_seconds: 10
+
+# Time allowed to read the entire request (headers + body)
+# Must be large enough for 200MB file uploads on slow networks
+# Supports upload speeds as low as ~2.8 Mbps
+# Default: 900 seconds (15 minutes)
+read_timeout_seconds: 900
+
+# Time allowed to write the response
+# Must accommodate large batch query results
+# Default: 120 seconds (2 minutes)
+write_timeout_seconds: 120
+
+# Time to wait for the next request on keep-alive connections
+# Default: 90 seconds
+idle_timeout_seconds: 90
+
 # File API configuration
 files_api:
   # Default expiration in seconds (default: 90 days)

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -37,12 +37,49 @@ const (
 	DefaultMaxFileLineCount = 50000
 	// DefaultTenantHeader is the default HTTP header name for tenant ID
 	DefaultTenantHeader = "X-MaaS-User"
+
+	// HTTP server timeout defaults
+	// DefaultReadHeaderTimeoutSeconds prevents slow-client attacks (Slowloris)
+	DefaultReadHeaderTimeoutSeconds = 10
+	// DefaultReadTimeoutSeconds includes reading request headers and body
+	// Must accommodate large file uploads (up to 200MB)
+	// Supports upload speeds as low as ~2.8 Mbps
+	DefaultReadTimeoutSeconds = 900 // 15 minutes
+	// DefaultWriteTimeoutSeconds includes writing response
+	// Must accommodate large batch query results
+	DefaultWriteTimeoutSeconds = 120 // 2 minutes
+	// DefaultIdleTimeoutSeconds for keep-alive connections
+	DefaultIdleTimeoutSeconds = 90
 )
 
 type FilesAPIConfig struct {
 	DefaultExpirationSeconds int64 `yaml:"default_expiration_seconds"`
 	MaxSizeBytes             int64 `yaml:"max_size_bytes"`
 	MaxLineCount             int64 `yaml:"max_line_count"`
+}
+
+// GetDefaultExpirationSeconds returns the configured value or default if invalid
+func (f *FilesAPIConfig) GetDefaultExpirationSeconds() int64 {
+	if f.DefaultExpirationSeconds <= 0 {
+		return DefaultFileExpirationSeconds
+	}
+	return f.DefaultExpirationSeconds
+}
+
+// GetMaxSizeBytes returns the configured value or default if invalid
+func (f *FilesAPIConfig) GetMaxSizeBytes() int64 {
+	if f.MaxSizeBytes <= 0 {
+		return DefaultMaxFileSizeBytes
+	}
+	return f.MaxSizeBytes
+}
+
+// GetMaxLineCount returns the configured value or default if invalid
+func (f *FilesAPIConfig) GetMaxLineCount() int64 {
+	if f.MaxLineCount <= 0 {
+		return DefaultMaxFileLineCount
+	}
+	return f.MaxLineCount
 }
 
 type ServerConfig struct {
@@ -53,6 +90,12 @@ type ServerConfig struct {
 	BatchTTLSeconds int            `yaml:"batch_ttl_seconds"`
 	TenantHeader    string         `yaml:"tenant_header"`
 	FilesAPI        FilesAPIConfig `yaml:"files_api"`
+
+	// HTTP server timeout configurations (in seconds)
+	ReadHeaderTimeoutSeconds int64 `yaml:"read_header_timeout_seconds"`
+	ReadTimeoutSeconds       int64 `yaml:"read_timeout_seconds"`
+	WriteTimeoutSeconds      int64 `yaml:"write_timeout_seconds"`
+	IdleTimeoutSeconds       int64 `yaml:"idle_timeout_seconds"`
 }
 
 func NewConfig() *ServerConfig {
@@ -123,42 +166,50 @@ func (c *ServerConfig) SSLEnabled() bool {
 	return (c.SSLCertFile != "" && c.SSLKeyFile != "")
 }
 
+// GetReadHeaderTimeoutSeconds returns the configured value or default if invalid
+func (c *ServerConfig) GetReadHeaderTimeoutSeconds() int64 {
+	if c.ReadHeaderTimeoutSeconds <= 0 {
+		return DefaultReadHeaderTimeoutSeconds
+	}
+	return c.ReadHeaderTimeoutSeconds
+}
+
+// GetReadTimeoutSeconds returns the configured value or default if invalid
+func (c *ServerConfig) GetReadTimeoutSeconds() int64 {
+	if c.ReadTimeoutSeconds <= 0 {
+		return DefaultReadTimeoutSeconds
+	}
+	return c.ReadTimeoutSeconds
+}
+
+// GetWriteTimeoutSeconds returns the configured value or default if invalid
+func (c *ServerConfig) GetWriteTimeoutSeconds() int64 {
+	if c.WriteTimeoutSeconds <= 0 {
+		return DefaultWriteTimeoutSeconds
+	}
+	return c.WriteTimeoutSeconds
+}
+
+// GetIdleTimeoutSeconds returns the configured value or default if invalid
+func (c *ServerConfig) GetIdleTimeoutSeconds() int64 {
+	if c.IdleTimeoutSeconds <= 0 {
+		return DefaultIdleTimeoutSeconds
+	}
+	return c.IdleTimeoutSeconds
+}
+
+// GetBatchTTLSeconds returns the configured value or default if invalid
 func (c *ServerConfig) GetBatchTTLSeconds() int {
-	if c.BatchTTLSeconds > 0 {
-		return c.BatchTTLSeconds
+	if c.BatchTTLSeconds <= 0 {
+		return DefaultBatchTTLSeconds
 	}
-	// Default to 30 days if not configured
-	return DefaultBatchTTLSeconds
+	return c.BatchTTLSeconds
 }
 
-func (c *ServerConfig) GetMaxFileSizeBytes() int64 {
-	if c.FilesAPI.MaxSizeBytes > 0 {
-		return c.FilesAPI.MaxSizeBytes
-	}
-	// The file can contain up to 50,000 requests, and can be up to 200 MB in size.
-	// Line counting is enforced via LineCountingReader in the file upload handler.
-	return DefaultMaxFileSizeBytes
-}
-
-func (c *ServerConfig) GetFileDefaultExpirationSeconds() int64 {
-	if c.FilesAPI.DefaultExpirationSeconds > 0 {
-		return c.FilesAPI.DefaultExpirationSeconds
-	}
-	// Default to 90 days if not configured
-	return DefaultFileExpirationSeconds
-}
-
-func (c *ServerConfig) GetMaxFileLineCount() int64 {
-	if c.FilesAPI.MaxLineCount > 0 {
-		return c.FilesAPI.MaxLineCount
-	}
-	// Default to 50,000 lines if not configured
-	return DefaultMaxFileLineCount
-}
-
+// GetTenantHeader returns the configured value or default if empty
 func (c *ServerConfig) GetTenantHeader() string {
-	if c.TenantHeader != "" {
-		return c.TenantHeader
+	if c.TenantHeader == "" {
+		return DefaultTenantHeader
 	}
-	return DefaultTenantHeader
+	return c.TenantHeader
 }

--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -199,7 +199,7 @@ func (c *FileApiHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	// The file can contain up to 50,000 requests, and can be up to 200 MB in size.
 
 	// Check Content-Length header before reading the body
-	maxFileSize := c.config.GetMaxFileSizeBytes()
+	maxFileSize := c.config.FilesAPI.GetMaxSizeBytes()
 	if r.ContentLength > maxFileSize {
 		logger.V(logging.DEBUG).Info("file size exceeds limit",
 			"contentLength", r.ContentLength, "limit", maxFileSize)
@@ -299,7 +299,7 @@ func (c *FileApiHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		logger.V(logging.DEBUG).Info("file expiration set from request", "anchor", expiresAfterAnchor, "seconds", expiresAfterSeconds, "expiresAt", expiresAt)
 	} else {
 		// Use default expire seconds from config if expires_after not provided
-		expiresAfterSeconds := c.config.GetFileDefaultExpirationSeconds()
+		expiresAfterSeconds := c.config.FilesAPI.GetDefaultExpirationSeconds()
 		expiresAt = createdAt + expiresAfterSeconds
 		logger.V(logging.DEBUG).Info("file expiration set from config default", "seconds", expiresAfterSeconds, "expiresAt", expiresAt)
 	}
@@ -315,7 +315,7 @@ func (c *FileApiHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	// Get tenant ID from context to use as folder name
 	tenantID := common.GetTenantIDFromContext(ctx)
 	folderName := tenantID
-	fileMeta, err := c.filesClient.Store(ctx, fileName, folderName, c.config.GetMaxFileSizeBytes(), c.config.GetMaxFileLineCount(), fileReader)
+	fileMeta, err := c.filesClient.Store(ctx, fileName, folderName, c.config.FilesAPI.GetMaxSizeBytes(), c.config.FilesAPI.GetMaxLineCount(), fileReader)
 	if err != nil {
 		logger.Error(err, "failed to store file content")
 		common.WriteInternalServerError(w, r)

--- a/internal/apiserver/readiness/readiness_handler.go
+++ b/internal/apiserver/readiness/readiness_handler.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The file provides HTTP handlers for readiness check endpoints.
+package readiness
+
+import (
+	"net/http"
+	"sync/atomic"
+
+	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/common"
+)
+
+const (
+	ReadyPath = "/ready"
+)
+
+type ReadinessApiHandler struct {
+	// serverReady indicates if the HTTP server has started accepting connections
+	serverReady *atomic.Bool
+}
+
+func NewReadinessApiHandler(serverReady *atomic.Bool) *ReadinessApiHandler {
+	return &ReadinessApiHandler{
+		serverReady: serverReady,
+	}
+}
+
+func (c *ReadinessApiHandler) GetRoutes() []common.Route {
+	return []common.Route{
+		{
+			Method:      http.MethodGet,
+			Pattern:     ReadyPath,
+			HandlerFunc: c.ReadyHandler,
+		},
+		{
+			Method:      http.MethodHead,
+			Pattern:     ReadyPath,
+			HandlerFunc: c.ReadyHandler,
+		},
+	}
+}
+
+func (c *ReadinessApiHandler) ReadyHandler(w http.ResponseWriter, r *http.Request) {
+	if !c.serverReady.Load() {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("not ready"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/batch"
@@ -31,14 +32,16 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/health"
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/middleware"
+	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/readiness"
 	mockdb "github.com/llm-d-incubation/batch-gateway/internal/database/mock"
 	mockfiles "github.com/llm-d-incubation/batch-gateway/internal/files_store/mock"
 	"k8s.io/klog/v2"
 )
 
 type Server struct {
-	logger klog.Logger
-	config *common.ServerConfig
+	logger      klog.Logger
+	config      *common.ServerConfig
+	serverReady *atomic.Bool
 }
 
 func New(config *common.ServerConfig) (*Server, error) {
@@ -46,7 +49,13 @@ func New(config *common.ServerConfig) (*Server, error) {
 		return nil, fmt.Errorf("config cannot be nil")
 	}
 	logger := klog.Background().WithName("api_server")
-	return &Server{config: config, logger: logger}, nil
+	serverReady := &atomic.Bool{}
+	serverReady.Store(false)
+	return &Server{
+		config:      config,
+		logger:      logger,
+		serverReady: serverReady,
+	}, nil
 }
 
 // Start the HTTP server.
@@ -58,11 +67,17 @@ func (s *Server) Start(ctx context.Context) error {
 		logger.Error(err, "failed to start")
 		return err
 	}
+	defer ln.Close()
 
 	handler := s.buildHandler()
 
 	httpserver := &http.Server{
-		Handler: handler,
+		Handler:           handler,
+		ReadHeaderTimeout: time.Duration(s.config.GetReadHeaderTimeoutSeconds()) * time.Second,
+		ReadTimeout:       time.Duration(s.config.GetReadTimeoutSeconds()) * time.Second,
+		WriteTimeout:      time.Duration(s.config.GetWriteTimeoutSeconds()) * time.Second,
+		IdleTimeout:       time.Duration(s.config.GetIdleTimeoutSeconds()) * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MB
 	}
 
 	// Enable TLS if cert and key are provided
@@ -74,44 +89,81 @@ func (s *Server) Start(ctx context.Context) error {
 		httpserver.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS12,
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			},
+			// CipherSuites omitted - use Go's secure defaults
+			// This allows TLS 1.3 to use its own cipher suites
 		}
-		s.logger.Info("server TLS configured")
+		s.logger.Info("server TLS configured", "minVersion", "TLS 1.2")
 	} else if s.config.SSLCertFile != "" || s.config.SSLKeyFile != "" {
 		err := fmt.Errorf("both tls-cert-file and tls-private-key-file must be provided to enable TLS")
 		return err
 	}
 
-	// graceful termination
-	go func() {
-		<-ctx.Done()
-		logger.Info("shutting down")
+	logger.Info("starting", "addr", ln.Addr().String())
 
+	// Start serving in a goroutine
+	serveDone := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error(nil, "server goroutine panicked", "panic", r)
+				serveDone <- fmt.Errorf("server panicked: %v", r)
+			}
+		}()
+		var err error
+		if s.config.SSLEnabled() {
+			err = httpserver.ServeTLS(ln, "", "")
+		} else {
+			err = httpserver.Serve(ln)
+		}
+		serveDone <- err
+	}()
+
+	// Wait for immediate startup failure or mark ready after 100ms
+	select {
+	case <-time.After(100 * time.Millisecond):
+		logger.Info("server is ready")
+		s.serverReady.Store(true)
+	case err := <-serveDone:
+		logger.Error(err, "server failed to start")
+		return err
+	case <-ctx.Done():
+		logger.Info("shutdown requested before server ready", "reason", ctx.Err())
+		return ctx.Err()
+	}
+
+	// Continue waiting for shutdown or failure after marking ready
+	select {
+	case <-ctx.Done():
+		// Normal shutdown path
+		s.serverReady.Store(false)
+		logger.Info("shutting down", "reason", ctx.Err())
+
+		// Gracefully shutdown the server
 		shutdownCtx, cancelFn := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancelFn()
 		if err := httpserver.Shutdown(shutdownCtx); err != nil {
 			logger.Error(err, "failed to gracefully shutdown")
-		} else {
-			logger.Info("shutdown complete")
 		}
-	}()
 
-	logger.Info("starting", "addr", ln.Addr().String())
-	if s.config.SSLEnabled() {
-		if err := httpserver.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
-			logger.Error(err, "failed to start")
-			return err
+		// Wait for server goroutine to finish with timeout
+		select {
+		case err = <-serveDone:
+			if err != nil && err != http.ErrServerClosed {
+				logger.Error(err, "server exited with error after shutdown")
+				return err
+			}
+		case <-time.After(5 * time.Second):
+			logger.Error(nil, "timeout waiting for server goroutine to exit")
+			return fmt.Errorf("server goroutine did not exit after shutdown")
 		}
-	} else {
-		if err := httpserver.Serve(ln); err != nil && err != http.ErrServerClosed {
-			logger.Error(err, "failed to start")
+
+		logger.Info("shutdown complete")
+
+	case err := <-serveDone:
+		// Server failed after becoming ready
+		s.serverReady.Store(false)
+		if err != nil && err != http.ErrServerClosed {
+			logger.Error(err, "server exited unexpectedly")
 			return err
 		}
 	}
@@ -131,12 +183,14 @@ func (s *Server) buildHandler() http.Handler {
 
 	// register handlers
 	healthHandler := health.NewHealthApiHandler()
+	readinessHandler := readiness.NewReadinessApiHandler(s.serverReady)
 	metricsHandler := metrics.NewMetricsApiHandler()
 	fileHandler := file.NewFileApiHandler(s.config, dbClient, filesClient)
 	batchHandler := batch.NewBatchApiHandler(s.config, dbClient, queueClient, eventClient, statusClient)
 
 	handlers := []common.ApiHandler{
 		healthHandler,
+		readinessHandler,
 		metricsHandler,
 		fileHandler,
 		batchHandler,


### PR DESCRIPTION
changes:
- Add `/ready` endpoint to track server readiness
- Add HTTP timeout configurations with defaults optimized for 200MB uploads
- Improve server startup and shutdown flow
- Update configs to Helm chart