### PR TITLE
fix: read sensitive data from secret instead of configmap

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -31,7 +31,6 @@ data:
     ssl_key_file: "/etc/tls/tls.key"
     {{- end }}
 
-    {{- if .Values.processor.database.url }}
-    database_url: {{ .Values.processor.database.url | quote }}
-    {{- end }}
+    database_url_file: {{ .Values.processor.database.secretKey | quote }}
+    inference_api_key_file: {{ .Values.processor.inference.apiKey.secretKey | quote }}
 {{- end }}

--- a/charts/batch-gateway/templates/processor-deployment.yaml
+++ b/charts/batch-gateway/templates/processor-deployment.yaml
@@ -61,13 +61,10 @@ spec:
         {{- with .Values.processor.volumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.processor.database.existingSecret }}
-        env:
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.processor.database.existingSecret }}
-              key: {{ .Values.processor.database.secretKey }}
+        {{- if .Values.processor.existingSecret }}
+        - name: secrets
+          mountPath: /etc/.secrets
+          readOnly: true
         {{- end }}
       volumes:
       - name: config
@@ -81,6 +78,13 @@ spec:
           {{- else }}
           secretName: {{ include "batch-gateway.processor.fullname" . }}-tls
           {{- end }}
+      {{- end }}
+      {{- if .Values.processor.existingSecret }}
+      - name: secrets
+        projected:
+          sources:
+          - secret:
+              name: {{ .Values.processor.existingSecret }}
       {{- end }}
       {{- with .Values.processor.volumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -209,8 +209,15 @@ processor:
   logging:
     verbosity: 2
 
+  # Name of an existing Secret containing sensitive values.
+  # The secret keys are configured per field below.
+  existingSecret: ""
+
   # Database connection
   database:
-    url: ""
-    existingSecret: ""
     secretKey: "database-url"
+
+  # Inference gateway credentials
+  inference:
+    apiKey:
+      secretKey: "inference-api-key"

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -1,6 +1,3 @@
-# Database Connection
-database_url: ""
-
 # Worker Settings - task wait time needs to be shorter than poll interval
 task_wait_time: "1s"
 worker_poll_interval: "5s"
@@ -23,10 +20,6 @@ inference_gateway_url: "http://localhost:8000"
 
 # Request timeout for individual inference requests
 inference_request_timeout: "5m"
-
-# Optional API key for authenticating with the inference gateway
-# Leave empty if no authentication is required
-inference_api_key: ""
 
 # Retry configuration for failed requests
 inference_max_retries: 3

--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -71,7 +71,6 @@ func run() error {
 		logger.V(logging.ERROR).Error(err, "Failed to load config file. Processor cannot start", "path", *cfgFilePath, "err", err)
 		return err
 	}
-
 	// metrics setup
 	if err := metrics.InitMetrics(*cfg); err != nil {
 		logger.V(logging.ERROR).Error(err, "Failed to initialize metrics")
@@ -140,10 +139,15 @@ func run() error {
 	var eventClient db.BatchEventChannelClient
 
 	// Initialize inference client with configuration
+	inferenceAPIKey, err := cfg.GetInferenceAPIKey()
+	if err != nil {
+		logger.Error(err, "Failed to read inference API key")
+		return err
+	}
 	inferenceClient, err := inference.NewHTTPClient(inference.HTTPClientConfig{
 		BaseURL:               cfg.InferenceGatewayURL,
 		Timeout:               cfg.InferenceRequestTimeout,
-		APIKey:                cfg.InferenceAPIKey,
+		APIKey:                inferenceAPIKey,
 		MaxRetries:            cfg.InferenceMaxRetries,
 		InitialBackoff:        cfg.InferenceInitialBackoff,
 		MaxBackoff:            cfg.InferenceMaxBackoff,

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -19,11 +19,15 @@ limitations under the License.
 package config
 
 import (
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+const secretsMountPath = "/etc/.secrets"
 
 type ProcessorConfig struct {
 	// TaskWaitTime is the timeout parameter used when dequeueing from the priority queue
@@ -45,6 +49,9 @@ type ProcessorConfig struct {
 	// ProcessTimeBucket defines exponential bucket configs for process time metric
 	ProcessTimeBucket BucketConfig `yaml:"process_time_bucket"`
 
+	// DatabaseURLFile is the filename within secretsMountPath containing the database connection URL.
+	DatabaseURLFile string `yaml:"database_url_file"`
+
 	Addr        string `yaml:"addr"`
 	SSLCertFile string `yaml:"ssl_cert_file"`
 	SSLKeyFile  string `yaml:"ssl_key_file"`
@@ -55,8 +62,8 @@ type ProcessorConfig struct {
 	// InferenceRequestTimeout is the timeout for individual inference requests
 	InferenceRequestTimeout time.Duration `yaml:"inference_request_timeout"`
 
-	// InferenceAPIKey is the optional API key for authenticating with the inference gateway
-	InferenceAPIKey string `yaml:"inference_api_key"`
+	// InferenceAPIKeyFile is the filename within secretsMountPath containing the inference gateway API key.
+	InferenceAPIKeyFile string `yaml:"inference_api_key_file"`
 
 	// InferenceMaxRetries is the maximum number of retry attempts for failed requests
 	InferenceMaxRetries int `yaml:"inference_max_retries"`
@@ -128,11 +135,37 @@ func NewConfig() *ProcessorConfig {
 
 		InferenceGatewayURL:     "http://localhost:8000",
 		InferenceRequestTimeout: 5 * time.Minute,
-		InferenceAPIKey:         "",
 		InferenceMaxRetries:     3,
 		InferenceInitialBackoff: 1 * time.Second,
 		InferenceMaxBackoff:     60 * time.Second,
 	}
+}
+
+func (pc *ProcessorConfig) GetDatabaseURL() (string, error) {
+	return readSecretFile(pc.DatabaseURLFile)
+}
+
+func (pc *ProcessorConfig) GetInferenceAPIKey() (string, error) {
+	return readSecretFile(pc.InferenceAPIKeyFile)
+}
+
+func readSecretFile(filename string) (string, error) {
+	if filename == "" {
+		return "", nil
+	}
+	f, err := os.OpenInRoot(secretsMountPath, filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
 }
 
 func (c *ProcessorConfig) Validate() error {


### PR DESCRIPTION
## Summary

  Moves sensitive processor credentials out of ConfigMap into a user-managed Kubernetes Secret,
  mounted Secret as files into the pod instead of exported as environment variables.

  ## Changes

  **Security**
  - `database-url` and `inference-api-key` are no longer stored in ConfigMap
  - Secret is mounted at `/etc/.secrets` (read-only) as a projected volume
  - File reads use `os.OpenInRoot` to prevent path traversal attacks

  **Helm chart**
  - Added `processor.existingSecret` to reference a user-provided Secret
  - Added `processor.database.secretKey` and `processor.inference.apiKey.secretKey`
    to configure the key names within the Secret
  - Removed `processor.database.url` — database URL must now come from the Secret

  **Go**
  - Added `ProcessorConfig.GetDatabaseURL()` and `ProcessorConfig.GetInferenceAPIKey()`
    which read from `/etc/.secrets/<key>` on every call
  - Sensitive values are never stored in struct fields or loaded from YAML

  ## Usage

  **1. Create the Secret**
  ```yaml
  apiVersion: v1
  kind: Secret
  metadata:
    name: my-processor-secret
    namespace: my-namespace
  stringData:
    database-url: "postgres://user:password@host:5432/dbname"
    inference-api-key: "sk-xxxxxxxxxxxx"
```

  **2. Update values.yaml**
  ```yaml
  processor:
    enabled: true
    existingSecret: "my-processor-secret"
    database:
      secretKey: "database-url"          # must match the key name in the Secret
    inference:
      apiKey:
        secretKey: "inference-api-key"   # must match the key name in the Secret
```

  **3. Deploy**
   ```yaml
  kubectl apply -f secret.yaml -n my-namespace
  helm install batch-gateway ./charts/batch-gateway -f values.yaml -n my-namespace
```
  Once deployed, Secret keys are available as files inside the pod:
```
  /etc/.secrets/
    ├── database-url        # content: postgres://user:password@host:5432/dbname
    └── inference-api-key   # content: sk-xxxxxxxxxxxx
```

## Future Work

  `GetDatabaseURL()` and `GetInferenceAPIKey()` read from disk on every call, so they
  automatically reflect Secret updates without a pod restart. A follow-up can add a
  background goroutine to propagate live credential changes to the inference client.
