### PR TITLE
chore: update helm chart default docker image

### DIFF
--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -8,9 +8,9 @@ apiserver:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/llm-d/batch-gateway-apiserver
-    pullPolicy: IfNotPresent
-    tag: ""
+    repository: ghcr.io/llm-d-incubation/batch-gateway-apiserver
+    pullPolicy: Always
+    tag: "latest"
 
   nameOverride: ""
   fullnameOverride: ""
@@ -116,9 +116,9 @@ processor:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/llm-d/batch-gateway-processor
-    pullPolicy: IfNotPresent
-    tag: ""
+    repository: ghcr.io/llm-d-incubation/batch-gateway-processor
+    pullPolicy: Always
+    tag: "latest"
 
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
The github workflow will generate 2 images for processor and apiserver after each commit
https://github.com/llm-d-incubation/batch-gateway/actions/runs/22375347120/job/64764150052

I will use the `latest` image for helm chart, so it will be easier for testing.
```
  - ghcr.io/llm-d-incubation/batch-gateway-apiserver:<commit-id>
  - ghcr.io/llm-d-incubation/batch-gateway-apiserver:latest
  - ghcr.io/llm-d-incubation/batch-gateway-processor:<commit-id>
  - ghcr.io/llm-d-incubation/batch-gateway-processor:latest
```