### PR TITLE
feat: sanitize tenant ID for safe folder name

### DIFF
--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -32,6 +32,7 @@ import (
 	fsapi "github.com/llm-d-incubation/batch-gateway/internal/files_store/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/converter"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
+	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
 )
 
@@ -270,7 +271,12 @@ func (c *FileApiHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 
 	// Get tenant ID from context to use as folder name
 	tenantID := common.GetTenantIDFromContext(ctx)
-	folderName := tenantID
+	folderName, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		logger.Error(err, "failed to get folder name from tenant ID", "tenantID", tenantID)
+		common.WriteInternalServerError(w, r)
+		return
+	}
 	fileMeta, err := c.filesClient.Store(ctx, fileName, folderName, c.config.FilesAPI.GetMaxSizeBytes(), c.config.FilesAPI.GetMaxLineCount(), fileReader)
 	if err != nil {
 		logger.Error(err, "failed to store file content")
@@ -511,7 +517,12 @@ func (c *FileApiHandler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		common.WriteInternalServerError(w, r)
 		return
 	}
-	folderName := item.TenantID
+	folderName, err := ucom.GetFolderNameByTenantID(item.TenantID)
+	if err != nil {
+		logger.Error(err, "failed to get folder name from tenant ID", "tenantID", item.TenantID)
+		common.WriteInternalServerError(w, r)
+		return
+	}
 
 	// Retrieve file content from storage
 	fileReader, fileMeta, err := c.filesClient.Retrieve(ctx, fileObj.Filename, folderName)
@@ -555,7 +566,12 @@ func (c *FileApiHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 		common.WriteInternalServerError(w, r)
 		return
 	}
-	folderName := item.TenantID
+	folderName, err := ucom.GetFolderNameByTenantID(item.TenantID)
+	if err != nil {
+		logger.Error(err, "failed to get folder name from tenant ID", "tenantID", item.TenantID)
+		common.WriteInternalServerError(w, r)
+		return
+	}
 
 	// Delete physical file from storage
 	err = c.filesClient.Delete(ctx, fileObj.Filename, folderName)

--- a/internal/apiserver/file/file_handler_test.go
+++ b/internal/apiserver/file/file_handler_test.go
@@ -34,6 +34,7 @@ import (
 	dbmock "github.com/llm-d-incubation/batch-gateway/internal/database/mock"
 	fsmock "github.com/llm-d-incubation/batch-gateway/internal/files_store/mock"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
+	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
 	"k8s.io/klog/v2"
 )
 
@@ -179,7 +180,10 @@ func doTestCreateFile(t *testing.T) {
 	// Verify file was actually uploaded to storage
 	// Mock stores files at /tmp/batch-gateway-files/{folderName}/{fileName}
 	fileName := fileObj.Filename
-	folderName := common.DefaultTenantID
+	folderName, err := ucom.GetFolderNameByTenantID(common.DefaultTenantID)
+	if err != nil {
+		t.Fatalf("failed to get folder name from tenant ID: %v", err)
+	}
 	fileReader, fileMeta, err := filesClient.Retrieve(ctx, fileName, folderName)
 	if err != nil {
 		t.Fatalf("failed to retrieve file from storage: %v", err)
@@ -633,7 +637,11 @@ func doTestDeleteFile(t *testing.T) {
 		}
 
 		// Verify physical file is deleted from storage
-		_, _, err = filesClient.Retrieve(ctx, createdFile.Filename, common.DefaultTenantID)
+		folderName, err := ucom.GetFolderNameByTenantID(common.DefaultTenantID)
+		if err != nil {
+			t.Fatalf("failed to get folder name from tenant ID: %v", err)
+		}
+		_, _, err = filesClient.Retrieve(ctx, createdFile.Filename, folderName)
 		if err == nil {
 			t.Errorf("expected physical file to be deleted, but still exists")
 		}

--- a/internal/util/com/common.go
+++ b/internal/util/com/common.go
@@ -18,7 +18,12 @@ limitations under the License.
 
 package com
 
-import "math/rand"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+)
 
 var (
 	letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -30,4 +35,21 @@ func RandString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+// GetFolderNameByTenantID converts a tenant ID into a filesystem and S3-safe folder name.
+// It generates a deterministic SHA256-based name that is guaranteed to be valid for both
+// filesystem paths and S3 bucket naming requirements (63 characters max).
+func GetFolderNameByTenantID(tenantID string) (string, error) {
+	if tenantID == "" {
+		return "", fmt.Errorf("tenantID cannot be empty")
+	}
+
+	// Generate SHA256 hash of the tenant ID for a deterministic, filesystem-safe name
+	hash := sha256.Sum256([]byte(tenantID))
+	hashStr := hex.EncodeToString(hash[:])
+
+	// Use "t-" prefix + 61 hex chars = 63 chars total (S3 maximum)
+	// This provides virtually collision-free tenant ID mapping while staying under S3's 63-char limit
+	return "t-" + hashStr[:61], nil
 }


### PR DESCRIPTION
The tenant ID from MaaS is actually a service account name, for example:
`system:serviceaccount:maas-default-gateway-tier-premium:testuser-45c571a1`

It cannot be used directly as folder name

I implemented a normalization function that:
- Generates a SHA hash of the tenant ID to eliminate invalid characters
- Trims the result hash to ensure it does not exceed 63 characters (S3 bucket naming limit)
- Adds a "t-" prefix for easier identification

The resulting folder name will look like (63 characters total):
`t-4d35b8be18e16155f16c119f3bb5e131ab9e07596296c02dafcc26f573910`

@j-mok-dev , please also use this function in processor to get folder name as well