### PR TITLE
feat: support pass-through headers from batch creation to inference r…

### DIFF
--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -30,6 +30,12 @@ data:
         use_path_style: {{ .Values.global.fileClient.s3.usePathStyle }}
     batch_api:
       batch_event_ttl_seconds: {{ .Values.apiserver.config.batchAPI.batchEventTTLSeconds }}
+      {{- if .Values.apiserver.config.batchAPI.passThroughHeaders }}
+      pass_through_headers:
+        {{- range .Values.apiserver.config.batchAPI.passThroughHeaders }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
     file_api:
       default_expiration_seconds: {{ .Values.apiserver.config.fileAPI.defaultExpirationSeconds }}
       max_size_bytes: {{ .Values.apiserver.config.fileAPI.maxSizeBytes }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -120,6 +120,7 @@ apiserver:
     idleTimeoutSeconds: 90
     batchAPI:
       batchEventTTLSeconds: 2592000
+      passThroughHeaders: []
     fileAPI:
       defaultExpirationSeconds: 7776000
       maxSizeBytes: 209715200

--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -65,6 +65,10 @@ file_client:
 batch_api:
   # Batch event TTL in seconds (default: 30 days)
   batch_event_ttl_seconds: 2592000
+  # HTTP headers to capture from batch creation requests and forward to inference.
+  # pass_through_headers:
+  #   - "X-MaaS-Username"
+  #   - "X-MaaS-Group"
 
 # File API configuration
 file_api:

--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -172,6 +172,13 @@ func (c *BatchAPIHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
+	// Capture configured pass-through headers into tags with "pth:" prefix
+	for _, headerName := range c.config.BatchAPI.PassThroughHeaders {
+		if value := r.Header.Get(headerName); value != "" {
+			tags["pth:"+headerName] = value
+		}
+	}
+
 	// Convert to database item
 	dbItem, err := converter.BatchToDBItem(batch, tenantID, tags)
 	if err != nil {

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -55,7 +55,8 @@ const (
 )
 
 type BatchAPIConfig struct {
-	BatchEventTTLSeconds int `yaml:"batch_event_ttl_seconds"`
+	BatchEventTTLSeconds int      `yaml:"batch_event_ttl_seconds"`
+	PassThroughHeaders   []string `yaml:"pass_through_headers"`
 }
 
 func (b *BatchAPIConfig) applyDefaults() {

--- a/internal/inference/client.go
+++ b/internal/inference/client.go
@@ -176,6 +176,11 @@ func (c *HTTPClient) Generate(ctx context.Context, req *GenerateRequest) (*Gener
 		restyReq.SetHeader("X-Request-ID", req.RequestID)
 	}
 
+	// Set pass-through headers
+	for k, v := range req.Headers {
+		restyReq.SetHeader(k, v)
+	}
+
 	// Set request body (resty handles JSON marshaling)
 	restyReq.SetBody(req.Params)
 

--- a/internal/inference/interface.go
+++ b/internal/inference/interface.go
@@ -28,6 +28,7 @@ type GenerateRequest struct {
 	RequestID string                 // unique request id set by user
 	Endpoint  string                 // API endpoint (e.g., "/v1/chat/completions")
 	Params    map[string]interface{} // parameters (must include "model")
+	Headers   map[string]string      // extra headers to forward to the inference endpoint
 }
 
 // Request Params example openai chat completion with tool calls:

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -157,9 +157,18 @@ func (p *Processor) executeJob(
 	//   - PerModelConcurrency (max in-flight requests per model)
 	//   - Starvation prevention: models drained mid-turn are removed from rotation
 	// See: docs/design/batch_processor_architecture.md (Phase 2 Scheduling)
+	passThroughHeaders := jobInfo.PassThroughHeaders
+	if len(passThroughHeaders) > 0 {
+		headerNames := make([]string, 0, len(passThroughHeaders))
+		for k := range passThroughHeaders {
+			headerNames = append(headerNames, k)
+		}
+		logger.V(logging.DEBUG).Info("pass-through headers attached to job", "headerNames", headerNames)
+	}
+
 	for safeModelID, modelID := range modelMap.SafeToModel {
 		go func(safeModelID, modelID string) {
-			err := p.processModel(execCtx, inputFile, plansDir, safeModelID, modelID, writer, &writerMu, cancelRequested, progress)
+			err := p.processModel(execCtx, inputFile, plansDir, safeModelID, modelID, writer, &writerMu, cancelRequested, progress, passThroughHeaders)
 			if err != nil {
 				execCancel()
 			}
@@ -209,6 +218,7 @@ func (p *Processor) processModel(
 	writerMu *sync.Mutex,
 	cancelRequested *atomic.Bool,
 	progress *executionProgress,
+	passThroughHeaders map[string]string,
 ) error {
 	logger := klog.FromContext(ctx).WithValues("model", modelID)
 	ctx = klog.NewContext(ctx, logger)
@@ -228,7 +238,7 @@ func (p *Processor) processModel(
 			return err
 		}
 
-		result, execErr := p.executeOneRequest(ctx, inputFile, entry, modelID)
+		result, execErr := p.executeOneRequest(ctx, inputFile, entry, modelID, passThroughHeaders)
 		if execErr != nil {
 			return execErr
 		}
@@ -262,6 +272,7 @@ func (p *Processor) executeOneRequest(
 	inputFile *os.File,
 	entry planEntry,
 	modelID string,
+	passThroughHeaders map[string]string,
 ) (*outputLine, error) {
 	// read the request line from input.jsonl at the given offset and length
 	buf := make([]byte, entry.Length)
@@ -293,6 +304,7 @@ func (p *Processor) executeOneRequest(
 		RequestID: requestID,
 		Endpoint:  req.URL,
 		Params:    req.Body,
+		Headers:   passThroughHeaders,
 	}
 
 	start := time.Now()

--- a/internal/processor/worker/worker_phase_2_test.go
+++ b/internal/processor/worker/worker_phase_2_test.go
@@ -254,7 +254,7 @@ func TestExecuteOneRequest_Success(t *testing.T) {
 	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
 
 	ctx := testLoggerCtx()
-	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1")
+	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1", nil)
 	if err != nil {
 		t.Fatalf("executeOneRequest error: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestExecuteOneRequest_InferenceError(t *testing.T) {
 	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
 
 	ctx := testLoggerCtx()
-	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1")
+	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1", nil)
 	if err != nil {
 		t.Fatalf("executeOneRequest should not return error for inference failure, got: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestExecuteOneRequest_BadOffset(t *testing.T) {
 
 	badEntry := planEntry{Offset: 99999, Length: 10}
 	ctx := testLoggerCtx()
-	_, err := env.p.executeOneRequest(ctx, inputFile, badEntry, "m1")
+	_, err := env.p.executeOneRequest(ctx, inputFile, badEntry, "m1", nil)
 	if err == nil {
 		t.Fatalf("expected error for bad offset")
 	}
@@ -378,7 +378,7 @@ func TestProcessModel_Success(t *testing.T) {
 	}
 
 	ctx := testLoggerCtx()
-	err := env.p.processModel(ctx, inputFile, plansDir, "m1", "m1", writer, &writerMu, cancelReq, progress)
+	err := env.p.processModel(ctx, inputFile, plansDir, "m1", "m1", writer, &writerMu, cancelReq, progress, nil)
 	if err != nil {
 		t.Fatalf("processModel error: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestProcessModel_CancelRequested(t *testing.T) {
 	}
 
 	ctx := testLoggerCtx()
-	err := env.p.processModel(ctx, inputFile, plansDir, "m1", "m1", writer, &writerMu, cancelReq, progress)
+	err := env.p.processModel(ctx, inputFile, plansDir, "m1", "m1", writer, &writerMu, cancelReq, progress, nil)
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got: %v", err)
 	}

--- a/internal/shared/batch_utils/job_info_builder.go
+++ b/internal/shared/batch_utils/job_info_builder.go
@@ -18,6 +18,8 @@ limitations under the License.
 package batch_utils
 
 import (
+	"strings"
+
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/converter"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
@@ -38,6 +40,16 @@ func FromDBItemToJobInfoObject(job *db.BatchItem) (*batch_types.JobInfo, error) 
 
 	jobInfo.BatchJob = batchJob
 	jobInfo.TenantID = job.TenantID
+
+	// Extract pass-through headers from tags with "pth:" prefix
+	for key, value := range job.Tags {
+		if strings.HasPrefix(key, "pth:") {
+			if jobInfo.PassThroughHeaders == nil {
+				jobInfo.PassThroughHeaders = make(map[string]string)
+			}
+			jobInfo.PassThroughHeaders[strings.TrimPrefix(key, "pth:")] = value
+		}
+	}
 
 	return jobInfo, nil
 }

--- a/internal/shared/types/job.go
+++ b/internal/shared/types/job.go
@@ -22,9 +22,10 @@ import (
 )
 
 type JobInfo struct {
-	JobID    string        `json:"job_id"`
-	TenantID string        `json:"tenant_id"`
-	BatchJob *openai.Batch `json:"batch_job"`
+	JobID              string            `json:"job_id"`
+	TenantID           string            `json:"tenant_id"`
+	BatchJob           *openai.Batch     `json:"batch_job"`
+	PassThroughHeaders map[string]string `json:"pass_through_headers,omitempty"`
 }
 
 // Request represents a line in input jsonl file

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -362,6 +362,7 @@ install_batch_gateway() {
         --set "processor.config.inferenceConfig.gatewayUrl=${vllm_sim_url}"
         --set "processor.logging.verbosity=${LOG_VERBOSITY}"
         --set "apiserver.logging.verbosity=${LOG_VERBOSITY}"
+        --set "apiserver.config.batchAPI.passThroughHeaders={X-E2E-Pass-Through-1,X-E2E-Pass-Through-2}"
         --namespace "${NAMESPACE}"
     )
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -32,10 +33,23 @@ import (
 )
 
 var (
-	baseURL  = getEnvOrDefault("TEST_BASE_URL", "http://localhost:8000")
-	tenantID = getEnvOrDefault("TEST_TENANT_ID", "default")
+	baseURL     = getEnvOrDefault("TEST_BASE_URL", "http://localhost:8000")
+	tenantID    = getEnvOrDefault("TEST_TENANT_ID", "default")
+	namespace   = getEnvOrDefault("TEST_NAMESPACE", "default")
+	helmRelease = getEnvOrDefault("TEST_HELM_RELEASE", "batch-gateway")
 
 	testRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// kubectlAvailable is set once at TestE2E startup; when false,
+	// verifications that require kubectl (e.g. log grepping) are skipped.
+	kubectlAvailable bool
+
+	// testPassThroughHeaders lists the headers configured in the apiserver's
+	// pass_through_headers setting (set via dev-deploy.sh).
+	testPassThroughHeaders = map[string]string{
+		"X-E2E-Pass-Through-1": "test-value-1",
+		"X-E2E-Pass-Through-2": "test-value-2",
+	}
 )
 
 func getEnvOrDefault(key, def string) string {
@@ -51,6 +65,8 @@ var testJSONL = strings.Join([]string{
 	`{"custom_id":"req-2","method":"POST","url":"/v1/chat/completions","body":{"model":"sim-model","messages":[{"role":"user","content":"World"}]}}`,
 }, "\n")
 
+// ── Helpers ────────────────────────────────────────────────────────────
+
 func newClient() *openai.Client {
 	c := openai.NewClient(
 		option.WithBaseURL(baseURL+"/v1/"),
@@ -58,6 +74,100 @@ func newClient() *openai.Client {
 		option.WithHeader("X-MaaS-Username", tenantID),
 	)
 	return &c
+}
+
+func mustCreateFile(t *testing.T, filename, content string) string {
+	t.Helper()
+
+	file, err := newClient().Files.New(context.Background(),
+		openai.FileNewParams{
+			File:    openai.File(strings.NewReader(content), filename, "application/jsonl"),
+			Purpose: openai.FilePurposeBatch,
+		})
+	if err != nil {
+		t.Fatalf("create file failed: %v", err)
+	}
+	if file.ID == "" {
+		t.Fatal("create file response has empty ID")
+	}
+	if file.Filename != filename {
+		t.Errorf("expected filename %q, got %q", filename, file.Filename)
+	}
+	if file.Purpose != openai.FileObjectPurposeBatch {
+		t.Errorf("expected purpose %q, got %q", openai.FileObjectPurposeBatch, file.Purpose)
+	}
+	return file.ID
+}
+
+func mustCreateBatch(t *testing.T, fileID string, opts ...option.RequestOption) string {
+	t.Helper()
+
+	batch, err := newClient().Batches.New(context.Background(),
+		openai.BatchNewParams{
+			InputFileID:      fileID,
+			Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
+			CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+		},
+		opts...,
+	)
+	if err != nil {
+		t.Fatalf("create batch failed: %v", err)
+	}
+	if batch.ID == "" {
+		t.Fatal("create batch response has empty ID")
+	}
+	if batch.InputFileID != fileID {
+		t.Errorf("expected input_file_id %q, got %q", fileID, batch.InputFileID)
+	}
+	if batch.Endpoint != "/v1/chat/completions" {
+		t.Errorf("expected endpoint %q, got %q", "/v1/chat/completions", batch.Endpoint)
+	}
+	if batch.CompletionWindow != "24h" {
+		t.Errorf("expected completion_window %q, got %q", "24h", batch.CompletionWindow)
+	}
+	return batch.ID
+}
+
+// waitForBatchCompletion polls a batch by ID until it reaches a terminal state
+// and returns the final batch object. Fatals if the batch does not complete
+// within 5 minutes or the test deadline (whichever comes first).
+func waitForBatchCompletion(t *testing.T, batchID string) *openai.Batch {
+	t.Helper()
+
+	client := newClient()
+
+	const (
+		pollInterval = 5 * time.Second
+		maxWait      = 5 * time.Minute
+	)
+
+	var finalBatch *openai.Batch
+	deadline := time.Now().Add(maxWait)
+	if d, ok := t.Deadline(); ok && d.Before(deadline) {
+		deadline = d.Add(-5 * time.Second)
+	}
+	for time.Now().Before(deadline) {
+		b, err := client.Batches.Get(context.Background(), batchID)
+		if err != nil {
+			t.Fatalf("retrieve batch failed: %v", err)
+		}
+		finalBatch = b
+
+		t.Logf("batch %s status: %s (completed=%d, failed=%d)",
+			batchID, b.Status,
+			b.RequestCounts.Completed, b.RequestCounts.Failed)
+
+		switch b.Status {
+		case openai.BatchStatusCompleted, openai.BatchStatusFailed,
+			openai.BatchStatusExpired, openai.BatchStatusCancelled:
+			return finalBatch
+		}
+		time.Sleep(pollInterval)
+	}
+
+	t.Fatalf("batch %s did not reach a final state within %v (last status: %q)",
+		batchID, maxWait, finalBatch.Status)
+	return nil // unreachable
 }
 
 func validateAndLogJSONL(t *testing.T, label string, content string) {
@@ -84,56 +194,6 @@ func validateAndLogJSONL(t *testing.T, label string, content string) {
 		}
 	}
 	t.Logf("=== %s ===\n%s", label, strings.TrimSpace(pretty.String()))
-}
-
-func mustCreateFile(t *testing.T, filename, content string) string {
-	t.Helper()
-
-	file, err := newClient().Files.New(context.Background(),
-		openai.FileNewParams{
-			File:    openai.File(strings.NewReader(content), filename, "application/jsonl"),
-			Purpose: openai.FilePurposeBatch,
-		})
-	if err != nil {
-		t.Fatalf("create file failed: %v", err)
-	}
-	if file.ID == "" {
-		t.Fatal("create file response has empty ID")
-	}
-	if file.Filename != filename {
-		t.Errorf("expected filename %q, got %q", filename, file.Filename)
-	}
-	if file.Purpose != openai.FileObjectPurposeBatch {
-		t.Errorf("expected purpose %q, got %q", openai.FileObjectPurposeBatch, file.Purpose)
-	}
-	return file.ID
-}
-
-func mustCreateBatch(t *testing.T, fileID string) string {
-	t.Helper()
-
-	batch, err := newClient().Batches.New(context.Background(),
-		openai.BatchNewParams{
-			InputFileID:      fileID,
-			Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
-			CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
-		})
-	if err != nil {
-		t.Fatalf("create batch failed: %v", err)
-	}
-	if batch.ID == "" {
-		t.Fatal("create batch response has empty ID")
-	}
-	if batch.InputFileID != fileID {
-		t.Errorf("expected input_file_id %q, got %q", fileID, batch.InputFileID)
-	}
-	if batch.Endpoint != "/v1/chat/completions" {
-		t.Errorf("expected endpoint %q, got %q", "/v1/chat/completions", batch.Endpoint)
-	}
-	if batch.CompletionWindow != "24h" {
-		t.Errorf("expected completion_window %q, got %q", "24h", batch.CompletionWindow)
-	}
-	return batch.ID
 }
 
 // ── Files subtests ────────────────────────────────────────────────────────────
@@ -245,11 +305,6 @@ func doTestBatchLifecycle(t *testing.T) {
 		t.Fatalf("list batches failed: %v", err)
 	}
 	t.Logf("list batches: got %d items", len(page.Data))
-	/*
-		for _, b := range page.Data {
-			t.Logf("  batch: id=%s status=%s", b.ID, b.Status)
-		}
-	*/
 
 	// Retrieve
 	batch, err := client.Batches.Get(context.Background(), batchID)
@@ -269,89 +324,75 @@ func doTestBatchLifecycle(t *testing.T) {
 		t.Errorf("expected completion_window %q, got %q", "24h", batch.CompletionWindow)
 	}
 
-	// Wait until complete
-	const (
-		pollInterval = 5 * time.Second
-		maxWait      = 5 * time.Minute
-	)
-
-	isTerminal := func(s openai.BatchStatus) bool {
-		switch s {
-		case openai.BatchStatusCompleted, openai.BatchStatusFailed,
-			openai.BatchStatusExpired, openai.BatchStatusCancelled:
-			return true
-		}
-		return false
-	}
-
-	var finalBatch *openai.Batch
-
-	deadline := time.Now().Add(maxWait)
-	if d, ok := t.Deadline(); ok && d.Before(deadline) {
-		deadline = d.Add(-5 * time.Second) // leave margin for cleanup
-	}
-	for time.Now().Before(deadline) {
-		batch, err := client.Batches.Get(context.Background(), batchID)
-		if err != nil {
-			t.Fatalf("retrieve batch failed: %v", err)
-		}
-		finalBatch = batch
-
-		t.Logf("batch %s status: %s (completed=%d, failed=%d)",
-			batchID, batch.Status,
-			batch.RequestCounts.Completed, batch.RequestCounts.Failed)
-
-		if isTerminal(batch.Status) {
-			break
-		}
-		time.Sleep(pollInterval)
-	}
-
-	if finalBatch == nil || !isTerminal(finalBatch.Status) {
-		t.Fatalf("batch %s did not reach a final state within %v (last status: %q)",
-			batchID, maxWait, finalBatch.Status)
-	}
-	t.Logf("batch %s reached terminal state: status=%s total=%d completed=%d failed=%d output_file_id=%q error_file_id=%q",
-		batchID, finalBatch.Status,
-		finalBatch.RequestCounts.Total, finalBatch.RequestCounts.Completed, finalBatch.RequestCounts.Failed,
-		finalBatch.OutputFileID, finalBatch.ErrorFileID)
+	// Poll until completion
+	finalBatch := waitForBatchCompletion(t, batchID)
 
 	if finalBatch.Status != openai.BatchStatusCompleted {
-		t.Errorf("expected batch status %q, got %q", openai.BatchStatusCompleted, finalBatch.Status)
-	}
-	if finalBatch.OutputFileID == "" {
-		t.Error("completed batch has empty output_file_id")
-	}
-	if finalBatch.ErrorFileID != "" {
-		t.Error("completed batch has non-empty error_file_id")
-	}
-	if finalBatch.RequestCounts.Total != 2 {
-		t.Errorf("expected request_counts.total=2, got %d", finalBatch.RequestCounts.Total)
-	}
-	if finalBatch.RequestCounts.Completed != 2 {
-		t.Errorf("expected request_counts.completed=2, got %d (failed=%d)",
-			finalBatch.RequestCounts.Completed, finalBatch.RequestCounts.Failed)
+		t.Fatalf("expected batch status %q, got %q", openai.BatchStatusCompleted, finalBatch.Status)
 	}
 
-	// Download output/error
+	// Download and log output file
 	if finalBatch.OutputFileID != "" {
 		resp, err := client.Files.Content(context.Background(), finalBatch.OutputFileID)
 		if err != nil {
-			t.Errorf("failed to download output file %q: %v", finalBatch.OutputFileID, err)
-		} else {
-			content, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			validateAndLogJSONL(t, "output file "+finalBatch.OutputFileID, string(content))
+			t.Fatalf("download output file failed: %v", err)
 		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		validateAndLogJSONL(t, "output file", string(body))
 	}
+
+	// Download and log error file (if any)
 	if finalBatch.ErrorFileID != "" {
 		resp, err := client.Files.Content(context.Background(), finalBatch.ErrorFileID)
 		if err != nil {
-			t.Errorf("failed to download error file %q: %v", finalBatch.ErrorFileID, err)
-		} else {
-			content, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			validateAndLogJSONL(t, "error file "+finalBatch.ErrorFileID, string(content))
+			t.Fatalf("download error file failed: %v", err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		validateAndLogJSONL(t, "error file", string(body))
+	}
+}
+
+// doTestPassThroughHeaders creates a batch with pass-through headers, waits for
+// completion, then verifies the processor logged the expected header names.
+func doTestPassThroughHeaders(t *testing.T) {
+	t.Helper()
+
+	// Verify processor logs contain the pass-through header names
+	if !kubectlAvailable {
+		t.Skip("kubectl not available, skipping processor log verification")
+	}
+
+	// Create batch with pass-through headers
+	fileID := mustCreateFile(t, fmt.Sprintf("test-pass-through-headers-%s.jsonl", testRunID), testJSONL)
+
+	var headerOpts []option.RequestOption
+	for k, v := range testPassThroughHeaders {
+		headerOpts = append(headerOpts, option.WithHeader(k, v))
+	}
+
+	batchID := mustCreateBatch(t, fileID, headerOpts...)
+
+	finalBatch := waitForBatchCompletion(t, batchID)
+
+	if finalBatch.Status != openai.BatchStatusCompleted {
+		t.Fatalf("expected batch status %q, got %q", openai.BatchStatusCompleted, finalBatch.Status)
+	}
+
+	out, err := exec.Command("kubectl", "logs",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", helmRelease),
+		"-n", namespace,
+		"--tail=500",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl logs failed: %v\n%s", err, out)
+	}
+
+	logs := string(out)
+	for headerName := range testPassThroughHeaders {
+		if !strings.Contains(logs, headerName) {
+			t.Errorf("expected processor logs to contain header name %q, but it was not found", headerName)
 		}
 	}
 }
@@ -359,6 +400,13 @@ func doTestBatchLifecycle(t *testing.T) {
 // ── Entry point ──────────────────────────────────────────────────────────
 
 func TestE2E(t *testing.T) {
+	// Check K8s cluster connectivity
+	if out, err := exec.Command("kubectl", "cluster-info").CombinedOutput(); err != nil {
+		t.Logf("kubectl cluster-info failed, kubectl based verifications will be skipped: %v\n%s", err, out)
+	} else {
+		kubectlAvailable = true
+	}
+
 	const readyTimeout = 30 * time.Second
 	readyDeadline := time.Now().Add(readyTimeout)
 	for {
@@ -396,5 +444,6 @@ func TestE2E(t *testing.T) {
 	t.Run("Batches", func(t *testing.T) {
 		t.Run("Lifecycle", func(t *testing.T) { doTestBatchLifecycle(t) })
 		t.Run("Cancel", func(t *testing.T) { doTestBatchCancel(t) })
+		t.Run("PassThroughHeaders", func(t *testing.T) { doTestPassThroughHeaders(t) })
 	})
 }


### PR DESCRIPTION

- Add new conf to api server, to configure pass-through header names
```
pass_through_headers:
   - "X-MaaS-Username"
   - "X-MaaS-Group"
```
-  api server will extract those header values from user request, and store in DB
- processor will send inference requests with those headers
- E2E test is updated to cover this.