### PR TITLE
feat: validate expires_after[seconds] range for file uploads

### DIFF
--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -259,6 +259,18 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if expiresAfterSeconds < openai.MinExpirationSeconds || expiresAfterSeconds > openai.MaxExpirationSeconds {
+			logger.V(logging.DEBUG).Info("expires_after seconds out of range", "seconds", expiresAfterSeconds)
+			apiErr := openai.NewAPIError(
+				http.StatusBadRequest,
+				"",
+				fmt.Sprintf("expires_after[seconds] must be between %d (1 hour) and %d (30 days)", openai.MinExpirationSeconds, openai.MaxExpirationSeconds),
+				nil,
+			)
+			common.WriteAPIError(w, r, apiErr)
+			return
+		}
+
 		expiresAt = createdAt + expiresAfterSeconds
 
 		logger.V(logging.DEBUG).Info("file expiration set from request", "anchor", expiresAfterAnchor, "seconds", expiresAfterSeconds, "expiresAt", expiresAt)

--- a/internal/apiserver/file/file_handler_test.go
+++ b/internal/apiserver/file/file_handler_test.go
@@ -130,6 +130,11 @@ func createTestFile(t *testing.T, handler *FileAPIHandler, ctx context.Context, 
 }
 
 func doTestCreateFile(t *testing.T) {
+	t.Run("Success", doTestCreateFileSuccess)
+	t.Run("ExpiresAfterValidation", doTestCreateFileExpiresAfter)
+}
+
+func doTestCreateFileSuccess(t *testing.T) {
 	ctx := context.Background()
 	handler := setupTestHandler(t)
 
@@ -217,6 +222,82 @@ func doTestCreateFile(t *testing.T) {
 	if string(uploadedContent) != expectedStoredContent {
 		t.Errorf("uploaded content doesn't match expected.\nExpected:\n%s\nGot:\n%s",
 			expectedStoredContent, string(uploadedContent))
+	}
+}
+
+func doTestCreateFileExpiresAfter(t *testing.T) {
+	ctx := context.Background()
+	handler := setupTestHandler(t)
+	fileContent := `{"custom_id":"request-1","method":"POST","url":"/v1/chat/completions","body":{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}}`
+
+	buildRequest := func(name, anchor, seconds string) *http.Request {
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+
+		fileWriter, err := writer.CreateFormFile("file", name+".jsonl")
+		if err != nil {
+			t.Fatalf("failed to create form file: %v", err)
+		}
+		if _, err := io.WriteString(fileWriter, fileContent); err != nil {
+			t.Fatalf("failed to write file content: %v", err)
+		}
+		if err := writer.WriteField("purpose", "batch"); err != nil {
+			t.Fatalf("failed to write purpose field: %v", err)
+		}
+		if anchor != "" {
+			if err := writer.WriteField("expires_after[anchor]", anchor); err != nil {
+				t.Fatalf("failed to write anchor field: %v", err)
+			}
+		}
+		if seconds != "" {
+			if err := writer.WriteField("expires_after[seconds]", seconds); err != nil {
+				t.Fatalf("failed to write seconds field: %v", err)
+			}
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("failed to close multipart writer: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/files", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		return req.WithContext(ctx)
+	}
+
+	tests := []struct {
+		name           string
+		anchor         string
+		seconds        string
+		expectedStatus int
+	}{
+		{"valid min boundary", "created_at", "3600", http.StatusOK},
+		{"valid max boundary", "created_at", "2592000", http.StatusOK},
+		{"valid mid range", "created_at", "86400", http.StatusOK},
+		{"too small", "created_at", "3599", http.StatusBadRequest},
+		{"too large", "created_at", "2592001", http.StatusBadRequest},
+		{"negative", "created_at", "-1", http.StatusBadRequest},
+		{"zero", "created_at", "0", http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := buildRequest(tc.name, tc.anchor, tc.seconds)
+			w := httptest.NewRecorder()
+			handler.CreateFile(w, req)
+
+			if w.Code != tc.expectedStatus {
+				t.Errorf("expected status %d, got %d, body: %s", tc.expectedStatus, w.Code, w.Body.String())
+			}
+
+			if tc.expectedStatus == http.StatusOK {
+				var fileObj openai.FileObject
+				if err := json.Unmarshal(w.Body.Bytes(), &fileObj); err != nil {
+					t.Fatalf("failed to parse response: %v", err)
+				}
+				if fileObj.ExpiresAt <= fileObj.CreatedAt {
+					t.Errorf("expected expiresAt > createdAt, got expiresAt=%d, createdAt=%d", fileObj.ExpiresAt, fileObj.CreatedAt)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/shared/openai/batch.go
+++ b/internal/shared/openai/batch.go
@@ -19,6 +19,7 @@ package openai
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -281,8 +282,8 @@ func (r *CreateBatchRequest) Validate() error {
 			return errors.New("output_expires_after.anchor must be 'created_at'")
 		}
 
-		if r.OutputExpiresAfter.Seconds < 3600 || r.OutputExpiresAfter.Seconds > 2592000 {
-			return errors.New("output_expires_after.seconds must be between 3600 (1 hour) and 2592000 (30 days)")
+		if r.OutputExpiresAfter.Seconds < MinExpirationSeconds || r.OutputExpiresAfter.Seconds > MaxExpirationSeconds {
+			return fmt.Errorf("output_expires_after.seconds must be between %d (1 hour) and %d (30 days)", MinExpirationSeconds, MaxExpirationSeconds)
 		}
 	}
 

--- a/internal/shared/openai/const.go
+++ b/internal/shared/openai/const.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openai
+
+const (
+	// MinExpirationSeconds is the minimum allowed expiration time (1 hour)
+	MinExpirationSeconds = 3600
+	// MaxExpirationSeconds is the maximum allowed expiration time (30 days)
+	MaxExpirationSeconds = 2592000
+)


### PR DESCRIPTION
Add range validation for expires_after[seconds] in POST /v1/files — must be between 3600 (1 hour) and 2592000 (30 days)