### PR TITLE
feat: add multi-gateway inference endpoint support

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -24,6 +24,16 @@ data:
 
     inference_config:
       gateway_url: {{ .Values.processor.config.inferenceConfig.gatewayUrl | quote }}
+      {{- with .Values.processor.config.inferenceConfig.modelGateways }}
+      model_gateways:
+        {{- range $model, $cfg := . }}
+        {{ $model | quote }}:
+          url: {{ $cfg.url | quote }}
+          {{- if $cfg.apiKeyName }}
+          api_key_name: {{ $cfg.apiKeyName | quote }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
       request_timeout: {{ .Values.processor.config.inferenceConfig.requestTimeout | quote }}
       max_retries: {{ .Values.processor.config.inferenceConfig.maxRetries }}
       initial_backoff: {{ .Values.processor.config.inferenceConfig.initialBackoff | quote }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -263,7 +263,16 @@ processor:
     shutdownTimeout: "30s"
     workDir: "/var/lib/batch-gateway/processor"
     inferenceConfig:
-      gatewayUrl: "http://localhost:8000"
+      gatewayUrl: "http://localhost:8000"  # default for all models
+      # Per-model overrides. Lookup: modelGateways[model] -> gatewayUrl (fallback).
+      # apiKeyName is a key name in the app secret (mounted at /etc/.secrets/).
+      # When omitted, the default inference-api-key is used.
+      # modelGateways:
+      #   "llama-3":
+      #     url: "http://gateway-a:8000"
+      #   "mistral":
+      #     url: "http://gateway-b:8000"
+      #     apiKeyName: "gateway-b-api-key"
       requestTimeout: "5m"
       maxRetries: 3
       initialBackoff: "1s"

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -28,8 +28,19 @@ work_dir: "/var/lib/batch-gateway/processor"
 
 # Inference Client Configuration
 inference_config:
-  # Base URL of the inference gateway (llm-d or other OpenAI-compatible endpoint)
+  # Default inference gateway endpoint, used for all models unless overridden below.
   gateway_url: "http://localhost:8000"
+
+  # Per-model gateway overrides (optional).
+  # Lookup order: model_gateways[model] -> gateway_url (fallback).
+  # api_key_name is a key name in /etc/.secrets/; when omitted, the default
+  # inference-api-key secret is used.
+  # model_gateways:
+  #   "llama-3":
+  #     url: "http://gateway-a:8000"
+  #   "mistral":
+  #     url: "http://gateway-b:8000"
+  #     api_key_name: "gateway-b-api-key"
 
   # Request timeout for individual inference requests
   request_timeout: "5m"

--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -287,7 +288,7 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 		EnableTracing: cfg.OTel.RedisTracing,
 	}
 
-	inferenceCfg := &inference.HTTPClientConfig{
+	inferenceHTTPCfg := &inference.HTTPClientConfig{
 		BaseURL:               cfg.InferenceConfig.GatewayURL,
 		Timeout:               cfg.InferenceConfig.RequestTimeout,
 		MaxRetries:            cfg.InferenceConfig.MaxRetries,
@@ -298,6 +299,16 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 		TLSClientCertFile:     cfg.InferenceConfig.TLSClientCertFile,
 		TLSClientKeyFile:      cfg.InferenceConfig.TLSClientKeyFile,
 	}
+
+	modelEndpoints := make(map[string]inference.GatewayEndpoint, len(cfg.InferenceConfig.ModelGateways))
+	for model, gw := range cfg.InferenceConfig.ModelGateways {
+		ep, err := inference.NewGatewayEndpoint(gw.URL, gw.APIKeyName)
+		if err != nil {
+			return nil, fmt.Errorf("resolve gateway for model %q: %w", model, err)
+		}
+		modelEndpoints[model] = ep
+	}
+
 	clients, err := clientset.NewClientset(
 		ctx,
 		cfg.DatabaseType,
@@ -306,7 +317,8 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 		cfg.FileClientCfg.Type,
 		&cfg.FileClientCfg.FSConfig,
 		&cfg.FileClientCfg.S3Config,
-		inferenceCfg,
+		inferenceHTTPCfg,
+		modelEndpoints,
 	)
 	if err != nil {
 		logger.Error(err, "Failed to create clients")

--- a/docs/design/batch_processor_architecture.md
+++ b/docs/design/batch_processor_architecture.md
@@ -424,8 +424,29 @@ Approaches:
 
 #### Executor
 -   Read request via offset/length
+-   Resolve per-model inference client via `GatewayResolver`
 -   Call inference backend
 -   Return result
+
+###### Multi-Gateway Routing
+The processor supports routing requests to different inference gateway endpoints based on the model name. Configuration uses a **default + override** pattern with optional per-gateway API keys:
+
+```yaml
+inference_config:
+  gateway_url: "http://gateway-a:8000"       # default for all models
+  model_gateways:                             # optional per-model overrides
+    "llama-3":
+      url: "http://gateway-a:8000"
+    "mistral":
+      url: "http://gateway-b:8000"
+      api_key_name: "gateway-b-api-key"       # key name in /etc/.secrets/
+```
+
+**Lookup order:** `model_gateways[model]` -> `gateway_url` (fallback).
+
+Each entry in `model_gateways` has a `url` and an optional `api_key_name`. The `api_key_name` is a key name within the mounted app secret (`/etc/.secrets/`). API key resolution follows the same fallback chain as other secrets: per-gateway key → default `inference-api-key` → no auth.
+
+`GatewayResolver` (in `internal/inference/gateway_resolver.go`) manages the client pool. Clients sharing the same URL **and** API key reuse a single `HTTPClient` instance to reuse connection pools. When `model_gateways` is empty or absent, all models use `gateway_url` (backward compatible).
 
 #### ResultWriter
 

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -63,6 +63,7 @@ func buildClients(ctx context.Context, config *common.ServerConfig) (*clientset.
 		&config.FileClientCfg.FSConfig,
 		&config.FileClientCfg.S3Config,
 		nil,
+		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients: %w", err)

--- a/internal/inference/gateway_resolver.go
+++ b/internal/inference/gateway_resolver.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inference
+
+import (
+	"fmt"
+
+	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
+)
+
+// GatewayEndpoint holds a resolved per-model gateway configuration.
+// APIKey is the actual key value (not a file path). If empty, the base
+// config's API key is inherited.
+type GatewayEndpoint struct {
+	URL    string
+	APIKey string
+}
+
+// NewGatewayEndpoint creates a GatewayEndpoint by resolving the optional API
+// key from the mounted secrets directory (/etc/.secrets/).
+// If apiKeyName is empty or the secret does not exist, the returned endpoint
+// inherits the default API key from the base config at resolver construction time.
+func NewGatewayEndpoint(url, apiKeyName string) (GatewayEndpoint, error) {
+	ep := GatewayEndpoint{URL: url}
+	if apiKeyName != "" {
+		key, err := ucom.ReadSecretFile(apiKeyName)
+		if err != nil {
+			return GatewayEndpoint{}, fmt.Errorf("read secret %q: %w", apiKeyName, err)
+		}
+		ep.APIKey = key
+	}
+	return ep, nil
+}
+
+// GatewayResolver routes inference requests to the correct gateway client
+// based on the model name. Models without an explicit mapping fall back to
+// the default client.
+//
+// This is a concrete struct rather than an interface because there is only one
+// routing strategy. Tests inject mock Client instances via NewSingleClientResolver.
+// TODO: Extract an interface if multiple routing strategies are needed
+//
+// GatewayResolver is immutable after construction — safe for concurrent reads.
+// TODO: When dynamic config reload is added, wrap with atomic.Pointer[GatewayResolver]
+// and swap the entire resolver on reload.
+type GatewayResolver struct {
+	defaultClient Client
+	modelClients  map[string]Client
+}
+
+// clientKey is a deduplication key for the HTTP client pool.
+// Gateways sharing both the same URL and API key reuse a single client.
+type clientKey struct {
+	url    string
+	apiKey string
+}
+
+// NewGatewayResolver creates a GatewayResolver from a base config and per-model
+// gateway overrides. Clients with the same URL and API key share a single
+// HTTPClient instance to reuse connection pools.
+func NewGatewayResolver(baseCfg HTTPClientConfig, modelGateways map[string]GatewayEndpoint) (*GatewayResolver, error) {
+	defaultClient, err := NewHTTPClient(baseCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create default inference client: %w", err)
+	}
+
+	// Pool of clients for reuse. The key is the URL + API key.
+	// This covers the case where multiple models share the same URL but different API keys.
+	pool := map[clientKey]Client{
+		{baseCfg.BaseURL, baseCfg.APIKey}: defaultClient,
+	}
+	modelClients := make(map[string]Client, len(modelGateways))
+
+	for model, gatewayEndpoint := range modelGateways {
+		cfg := baseCfg
+		cfg.BaseURL = gatewayEndpoint.URL
+
+		if gatewayEndpoint.APIKey != "" {
+			cfg.APIKey = gatewayEndpoint.APIKey
+		}
+
+		key := clientKey{cfg.BaseURL, cfg.APIKey}
+
+		// Reuse existing client if it already exists
+		if client, ok := pool[key]; ok {
+			modelClients[model] = client
+			continue
+		}
+
+		client, err := NewHTTPClient(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create inference client for model %q (url %s): %w", model, gatewayEndpoint.URL, err)
+		}
+		pool[key] = client
+		modelClients[model] = client
+	}
+
+	return &GatewayResolver{
+		defaultClient: defaultClient,
+		modelClients:  modelClients,
+	}, nil
+}
+
+// ClientFor returns the inference client for the given model.
+// Falls back to the default client if no model-specific mapping exists.
+func (r *GatewayResolver) ClientFor(modelID string) Client {
+	if c, ok := r.modelClients[modelID]; ok {
+		return c
+	}
+	return r.defaultClient
+}
+
+// NewSingleClientResolver wraps a single Client in a GatewayResolver
+// where all models resolve to that client. Currently used only in tests
+// to inject mock inference clients into Clientset.
+func NewSingleClientResolver(c Client) *GatewayResolver {
+	return &GatewayResolver{defaultClient: c}
+}

--- a/internal/inference/gateway_resolver_test.go
+++ b/internal/inference/gateway_resolver_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inference
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	if handler == nil {
+		handler = func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	return httptest.NewServer(handler)
+}
+
+type stubClient struct{ id string }
+
+func (s *stubClient) Generate(_ context.Context, _ *GenerateRequest) (*GenerateResponse, *ClientError) {
+	return &GenerateResponse{RequestID: s.id}, nil
+}
+
+func TestNewSingleClientResolver(t *testing.T) {
+	c := &stubClient{id: "default"}
+	r := NewSingleClientResolver(c)
+
+	got := r.ClientFor("any-model-without-override")
+	if got != c {
+		t.Fatalf("expected default client for any model without override")
+	}
+}
+
+func TestGatewayResolver_ClientFor_DefaultFallback(t *testing.T) {
+	defaultC := &stubClient{id: "default"}
+	modelC := &stubClient{id: "model-a"}
+
+	r := &GatewayResolver{
+		defaultClient: defaultC,
+		modelClients:  map[string]Client{"model-a": modelC},
+	}
+
+	if got := r.ClientFor("model-a"); got != modelC {
+		t.Fatalf("expected model-specific client for model-a, got %v", got)
+	}
+	if got := r.ClientFor("unknown"); got != defaultC {
+		t.Fatalf("expected default client for unknown model, got %v", got)
+	}
+}
+
+func TestNewGatewayResolver_SharesClientsForSameURL(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	baseCfg := HTTPClientConfig{BaseURL: srv.URL}
+	modelGateways := map[string]GatewayEndpoint{
+		"model-a": {URL: srv.URL},
+		"model-b": {URL: srv.URL},
+		"model-c": {URL: "test-base-url"},
+	}
+
+	r, err := NewGatewayResolver(baseCfg, modelGateways)
+	if err != nil {
+		t.Fatalf("NewGatewayResolver: %v", err)
+	}
+
+	cA := r.ClientFor("model-a")
+	cB := r.ClientFor("model-b")
+	cC := r.ClientFor("model-c")
+	cDefault := r.ClientFor("unknown")
+
+	if cA != cB {
+		t.Fatal("expected model-a and model-b to share the same client since they have the same URL")
+	}
+	if cA != cDefault {
+		t.Fatal("expected models with base URL to share the default client")
+	}
+	if cC == cDefault {
+		t.Fatal("expected model-c to have a different client since it has a different URL")
+	}
+}
+
+func TestNewGatewayResolver_DifferentURLs(t *testing.T) {
+	srvA := newTestServer(t, nil)
+	defer srvA.Close()
+	srvB := newTestServer(t, nil)
+	defer srvB.Close()
+
+	baseCfg := HTTPClientConfig{BaseURL: srvA.URL}
+	modelGateways := map[string]GatewayEndpoint{
+		"model-b": {URL: srvB.URL},
+	}
+
+	r, err := NewGatewayResolver(baseCfg, modelGateways)
+	if err != nil {
+		t.Fatalf("NewGatewayResolver: %v", err)
+	}
+
+	cDefault := r.ClientFor("model-a")
+	cB := r.ClientFor("model-b")
+
+	if cDefault == cB {
+		t.Fatal("expected different clients for different gateway URLs")
+	}
+}
+
+func TestNewGatewayResolver_NilModelGateways(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	baseCfg := HTTPClientConfig{BaseURL: srv.URL}
+
+	r, err := NewGatewayResolver(baseCfg, nil)
+	if err != nil {
+		t.Fatalf("NewGatewayResolver: %v", err)
+	}
+
+	c := r.ClientFor("any-model")
+	if c == nil {
+		t.Fatal("expected non-nil default client")
+	}
+}
+
+func TestNewGatewayResolver_PerGatewayAPIKey(t *testing.T) {
+	srvA := newTestServer(t, nil)
+	defer srvA.Close()
+	srvB := newTestServer(t, nil)
+	defer srvB.Close()
+
+	baseCfg := HTTPClientConfig{BaseURL: srvA.URL, APIKey: "default-key"}
+	modelGateways := map[string]GatewayEndpoint{
+		"model-a": {URL: srvB.URL, APIKey: "key-a"},
+		"model-b": {URL: srvB.URL, APIKey: "key-b"},
+		"model-c": {URL: srvB.URL, APIKey: "key-a"},
+	}
+
+	r, err := NewGatewayResolver(baseCfg, modelGateways)
+	if err != nil {
+		t.Fatalf("NewGatewayResolver: %v", err)
+	}
+
+	cA := r.ClientFor("model-a")
+	cB := r.ClientFor("model-b")
+	cC := r.ClientFor("model-c")
+	cDefault := r.ClientFor("unknown")
+
+	// model-a and model-c share URL + API key → same client
+	if cA != cC {
+		t.Fatal("expected model-a and model-c to share client (same URL + API key)")
+	}
+	// model-b has same URL but different API key → different client
+	if cA == cB {
+		t.Fatal("expected model-a and model-b to have different clients (different API keys)")
+	}
+	// all differ from default (different URL)
+	if cA == cDefault || cB == cDefault {
+		t.Fatal("expected per-gateway clients to differ from default")
+	}
+}
+
+func TestNewGatewayResolver_SameURLInheritsDefaultKey(t *testing.T) {
+	srv := newTestServer(t, nil)
+	defer srv.Close()
+
+	baseCfg := HTTPClientConfig{BaseURL: srv.URL, APIKey: "default-key"}
+	modelGateways := map[string]GatewayEndpoint{
+		"model-a": {URL: srv.URL},
+	}
+
+	r, err := NewGatewayResolver(baseCfg, modelGateways)
+	if err != nil {
+		t.Fatalf("NewGatewayResolver: %v", err)
+	}
+
+	cA := r.ClientFor("model-a")
+	cDefault := r.ClientFor("unknown")
+
+	// same URL + inherited API key → should share default client
+	if cA != cDefault {
+		t.Fatal("expected model with same URL and no API key override to share default client")
+	}
+}

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -102,9 +102,20 @@ type RetryConfig struct {
 	MaxBackoff     time.Duration `yaml:"max_backoff"`
 }
 
+// ModelGatewayConfig describes a per-model gateway override.
+type ModelGatewayConfig struct {
+	URL        string `yaml:"url"`
+	APIKeyName string `yaml:"api_key_name"` // key name in /etc/.secrets/; empty = use default inference-api-key
+}
+
 type InferenceConfig struct {
-	// GatewayURL is the base URL of the inference gateway (llm-d or GAIE)
+	// GatewayURL is the default inference gateway endpoint, used for all models
+	// unless overridden by ModelGateways.
 	GatewayURL string `yaml:"gateway_url"`
+
+	// ModelGateways optionally maps model names to specific gateway endpoints.
+	// Lookup order: ModelGateways[model] -> GatewayURL (fallback).
+	ModelGateways map[string]ModelGatewayConfig `yaml:"model_gateways"`
 
 	// RequestTimeout is the timeout for individual inference requests
 	RequestTimeout time.Duration `yaml:"request_timeout"`
@@ -248,6 +259,11 @@ func (c *ProcessorConfig) Validate() error {
 
 	if c.InferenceConfig.GatewayURL == "" {
 		return fmt.Errorf("inference_config.gateway_url cannot be empty")
+	}
+	for model, gw := range c.InferenceConfig.ModelGateways {
+		if gw.URL == "" {
+			return fmt.Errorf("inference_config.model_gateways[%s].url cannot be empty", model)
+		}
 	}
 	if c.InferenceConfig.RequestTimeout <= 0 {
 		return fmt.Errorf("inference_config.request_timeout must be > 0")

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -359,7 +359,8 @@ func (p *Processor) executeOneRequest(
 	// Add batch.id to the current span so the otelhttp transport child span can be correlated
 	trace.SpanFromContext(ctx).SetAttributes(attribute.String(uotel.AttrBatchID, batchID))
 
-	inferResp, inferErr := p.clients.Inference.Generate(ctx, inferReq)
+	inferClient := p.clients.Inference.ClientFor(modelID)
+	inferResp, inferErr := inferClient.Generate(ctx, inferReq)
 
 	metrics.DecModelInflightRequests(modelID)
 	metrics.DecProcessorInflightRequests()

--- a/internal/processor/worker/worker_core_test.go
+++ b/internal/processor/worker/worker_core_test.go
@@ -26,7 +26,7 @@ func validProcessorClients() *clientset.Clientset {
 		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
 		Status:    mockdb.NewMockBatchStatusClient(),
 		Event:     mockdb.NewMockBatchEventChannelClient(),
-		Inference: &fakeInferenceClient{},
+		Inference: inference.NewSingleClientResolver(&fakeInferenceClient{}),
 	}
 }
 

--- a/internal/processor/worker/worker_phase_2_test.go
+++ b/internal/processor/worker/worker_phase_2_test.go
@@ -133,7 +133,7 @@ func newTestProcessorEnv(t *testing.T, cfg *config.ProcessorConfig, inferClient 
 		Queue:     pqClient,
 		Status:    statusClient,
 		Event:     mockdb.NewMockBatchEventChannelClient(),
-		Inference: inferClient,
+		Inference: inference.NewSingleClientResolver(inferClient),
 	})
 	p.poller = NewPoller(pqClient, dbClient)
 

--- a/internal/util/clientset/clientset.go
+++ b/internal/util/clientset/clientset.go
@@ -44,7 +44,7 @@ type Clientset struct {
 	Queue     dbapi.BatchPriorityQueueClient
 	Event     dbapi.BatchEventChannelClient
 	Status    dbapi.BatchStatusClient
-	Inference inference.Client
+	Inference *inference.GatewayResolver
 }
 
 // NewClientset creates all clients.
@@ -56,7 +56,8 @@ func NewClientset(
 	fileClientType string,
 	fsCfg *fsclient.Config,
 	s3Cfg *s3client.Config,
-	inferenceCfg *inference.HTTPClientConfig,
+	inferenceHTTPCfg *inference.HTTPClientConfig,
+	modelGateways map[string]inference.GatewayEndpoint,
 ) (*Clientset, error) {
 
 	logger := klog.FromContext(ctx)
@@ -156,21 +157,21 @@ func NewClientset(
 		return nil, fmt.Errorf("unsupported database.type: %s (supported values: redis, postgresql)", dbType)
 	}
 
-	// build inference client
-	if inferenceCfg != nil {
-		if inferenceCfg.APIKey == "" {
+	// build inference client(s)
+	if inferenceHTTPCfg != nil {
+		if inferenceHTTPCfg.APIKey == "" {
 			apiKey, err := ucom.ReadSecretFile(ucom.SecretKeyInferenceAPI)
 			if err != nil {
 				return nil, err
 			}
-			inferenceCfg.APIKey = apiKey
+			inferenceHTTPCfg.APIKey = apiKey
 		}
-		ic, err := inference.NewHTTPClient(*inferenceCfg)
+		modelGatewaysResolver, err := inference.NewGatewayResolver(*inferenceHTTPCfg, modelGateways)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create inference client: %w", err)
+			return nil, fmt.Errorf("failed to create inference client(s): %w", err)
 		}
-		logger.Info("Inference client created")
-		cs.Inference = ic
+		logger.Info("Inference client(s) created", "numModelOverrides", len(modelGateways))
+		cs.Inference = modelGatewaysResolver
 	}
 
 	return cs, nil


### PR DESCRIPTION
## Summary

Adds per-model inference gateway routing with optional per-gateway API keys.
When a batch contains requests for multiple models served on different endpoints,
the processor can now route each request to the correct gateway instead of
sending everything to a single URL.

## How it works

**Configuration** uses a default + override pattern:
```
inference_config:
  gateway_url: "http://gateway-a:8000"       # default for all models
  model_gateways:                             # optional per-model overrides
    "llama-3":
      url: "http://gateway-a:8000"
    "mistral":
      url: "http://gateway-b:8000"
      api_key_name: "gateway-b-api-key"       # key name in /etc/.secrets/
```