### PR TITLE
chore: use PostgreSQL as default database backend

### DIFF
--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -13,7 +13,7 @@ global:
   appSecretName: "batch-gateway-secrets"
 
   # Database backend type: "redis", or "postgresql"
-  databaseType: "redis"
+  databaseType: "postgresql"
 
   # OpenTelemetry configuration
   otel:

--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -301,7 +301,7 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 	clients, err := clientset.NewClientset(
 		ctx,
 		cfg.DatabaseType,
-		nil,
+		&cfg.PostgreSQLCfg,
 		redisCfg,
 		cfg.FileClientCfg.Type,
 		&cfg.FileClientCfg.FSConfig,

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/llm-d-incubation/batch-gateway/internal/database/postgresql"
 	fsclient "github.com/llm-d-incubation/batch-gateway/internal/files_store/fs"
 	s3client "github.com/llm-d-incubation/batch-gateway/internal/files_store/s3"
 	"gopkg.in/yaml.v3"
@@ -123,8 +124,11 @@ type ServerConfig struct {
 		S3Config s3client.Config `yaml:"s3"`
 	} `yaml:"file_client"`
 
-	// DatabaseType specifies the database backend: "mock", "redis", or "postgresql" (not yet implemented).
+	// DatabaseType specifies the database backend: "mock", "redis", or "postgresql".
 	DatabaseType string `yaml:"database_type"`
+
+	// PostgreSQLCfg holds PostgreSQL connection settings (used when DatabaseType is "postgresql").
+	PostgreSQLCfg postgresql.PostgreSQLConfig `yaml:"postgresql"`
 
 	// OTel holds OpenTelemetry-related settings.
 	OTel struct {

--- a/internal/apiserver/common/rest.go
+++ b/internal/apiserver/common/rest.go
@@ -98,6 +98,9 @@ func otelInstrumentHandler(spanName string, next http.HandlerFunc) http.HandlerF
 	}
 }
 
+// Compile-time check: otelStatusWriter implements StatusRecorder.
+var _ StatusRecorder = (*otelStatusWriter)(nil)
+
 // otelStatusWriter is a minimal StatusRecorder used only when no upstream
 // wrapper (e.g. request middleware) is present.
 type otelStatusWriter struct {

--- a/internal/apiserver/middleware/request_middleware.go
+++ b/internal/apiserver/middleware/request_middleware.go
@@ -124,6 +124,9 @@ func RequestMiddleware(config *common.ServerConfig) func(http.Handler) http.Hand
 	}
 }
 
+// Compile-time check: responseWriter implements common.StatusRecorder.
+var _ common.StatusRecorder = (*responseWriter)(nil)
+
 // responseWriter wraps http.ResponseWriter to capture status code
 type responseWriter struct {
 	http.ResponseWriter

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -57,7 +57,7 @@ func buildClients(ctx context.Context, config *common.ServerConfig) (*clientset.
 	clients, err := clientset.NewClientset(
 		ctx,
 		config.DatabaseType,
-		nil,
+		&config.PostgreSQLCfg,
 		redisCfg,
 		config.FileClientCfg.Type,
 		&config.FileClientCfg.FSConfig,

--- a/internal/database/postgresql/db_postgresql.go
+++ b/internal/database/postgresql/db_postgresql.go
@@ -39,7 +39,7 @@ type pgxPool interface {
 // PostgreSQLConfig holds the configuration for a PostgreSQL connection.
 type PostgreSQLConfig struct {
 	// Url is a PostgreSQL connection string (e.g., "postgres://user:pass@host:5432/dbname?sslmode=disable").
-	Url string
+	Url string `yaml:"-"`
 }
 
 // Validate checks that the required configuration fields are set.

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/llm-d-incubation/batch-gateway/internal/database/postgresql"
 	fsclient "github.com/llm-d-incubation/batch-gateway/internal/files_store/fs"
 	s3client "github.com/llm-d-incubation/batch-gateway/internal/files_store/s3"
 	"gopkg.in/yaml.v3"
@@ -53,8 +54,11 @@ type ProcessorConfig struct {
 	// ProcessTimeBucket defines exponential bucket configs for process time metric
 	ProcessTimeBucket BucketConfig `yaml:"process_time_bucket"`
 
-	// DatabaseType specifies the database backend: "mock", "redis", or "postgresql" (not yet implemented).
+	// DatabaseType specifies the database backend: "mock", "redis", or "postgresql".
 	DatabaseType string `yaml:"database_type"`
+
+	// PostgreSQLCfg holds PostgreSQL connection settings (used when DatabaseType is "postgresql").
+	PostgreSQLCfg postgresql.PostgreSQLConfig `yaml:"postgresql"`
 
 	Addr        string `yaml:"addr"`
 	SSLCertFile string `yaml:"ssl_cert_file"`

--- a/internal/util/clientset/clientset.go
+++ b/internal/util/clientset/clientset.go
@@ -68,6 +68,10 @@ func NewClientset(
 
 	cs := &Clientset{}
 
+	// TODO: The exchange interfaces (priority queue, events, status) currently always use Redis.
+	// Consider adding a separate type parameter for these if we need alternative backends.
+	// See: https://github.com/llm-d-incubation/batch-gateway/pull/102#discussion_r2906181334
+
 	// build redis client
 	if redisCfg.Url == "" {
 		redisURL, err := ucom.ReadSecretFile(ucom.SecretKeyRedisURL)
@@ -142,7 +146,7 @@ func NewClientset(
 		logger.Info("Redis-based database client created")
 	case "postgresql":
 		if postgreSQLCfg == nil {
-			return nil, fmt.Errorf("postgreSQLCfg cannot be nil")
+			return nil, fmt.Errorf("postgreSQLCfg cannot be nil when database.type is \"postgresql\"")
 		}
 		if postgreSQLCfg.Url == "" {
 			postgreSQLURL, err := ucom.ReadSecretFile(ucom.SecretKeyPostgreSQLURL)
@@ -151,7 +155,17 @@ func NewClientset(
 			}
 			postgreSQLCfg.Url = postgreSQLURL
 		}
-		return nil, fmt.Errorf("database_type %q is not yet implemented", dbType)
+		batchDB, err := postgresql.NewPostgresBatchDBClient(ctx, postgreSQLCfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create postgresql batch-db client: %w", err)
+		}
+		fileDB, err := postgresql.NewPostgresFileDBClient(ctx, postgreSQLCfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create postgresql file-db client: %w", err)
+		}
+		cs.BatchDB = batchDB
+		cs.FileDB = fileDB
+		logger.Info("PostgreSQL-based database client created")
 	default:
 		return nil, fmt.Errorf("unsupported database.type: %s (supported values: redis, postgresql)", dbType)
 	}

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -161,22 +161,18 @@ install_postgresql() {
 create_secret() {
     step "Creating secret '${APP_SECRET_NAME}'..."
 
-    if kubectl get secret "${APP_SECRET_NAME}" -n "${NAMESPACE}" &>/dev/null; then
-        log "Secret '${APP_SECRET_NAME}' already exists. Skipping."
-        return
-    fi
-
     local redis_url="redis://${REDIS_RELEASE}-master.${NAMESPACE}.svc.cluster.local:6379/0"
-    local postgresql_url="postgresql://postgres:${POSTGRESQL_PASSWORD}@${POSTGRESQL_RELEASE}-postgresql.${NAMESPACE}.svc.cluster.local:5432/postgres"
+    local postgresql_url="postgresql://postgres:${POSTGRESQL_PASSWORD}@${POSTGRESQL_RELEASE}.${NAMESPACE}.svc.cluster.local:5432/postgres"
 
     kubectl create secret generic "${APP_SECRET_NAME}" \
         --namespace "${NAMESPACE}" \
         --from-literal=redis-url="${redis_url}" \
         --from-literal=postgresql-url="${postgresql_url}" \
         --from-literal=inference-api-key="${INFERENCE_API_KEY}" \
-        --from-literal=s3-secret-access-key="${S3_SECRET_ACCESS_KEY}"
+        --from-literal=s3-secret-access-key="${S3_SECRET_ACCESS_KEY}" \
+        --dry-run=client -o yaml | kubectl apply -f -
 
-    log "Secret '${APP_SECRET_NAME}' created."
+    log "Secret '${APP_SECRET_NAME}' applied."
 }
 
 # ── Images ────────────────────────────────────────────────────────────────────
@@ -443,6 +439,7 @@ install_batch_gateway() {
         --set "global.otel.endpoint=http://${JAEGER_NAME}.${NAMESPACE}.svc.cluster.local:4317"
         --set "global.otel.insecure=true"
         --set "global.otel.redisTracing=true"
+        --set "global.databaseType=postgresql"
         --namespace "${NAMESPACE}"
     )
 


### PR DESCRIPTION
## The PR will:
- update helm charts to use PostgreSQL as default database backend
- update `dev-deploy.sh`  to force dev deployment use PostgreSQL

## Unit test on my laptop:
### 1) Run `make dev-deploy` to deploy full stack in kind cluster
postgresql is successfully deployed after that
```
# oc get sts postgresql
NAME         READY   AGE
postgresql   1/1     64s

# oc logs postgresql-0
postgresql 00:35:07.68 INFO  ==>
postgresql 00:35:07.68 INFO  ==> Welcome to the Bitnami postgresql container
postgresql 00:35:07.72 INFO  ==>
```
### 2) Run `make test-e2e` to trigger E2E tests
All cases passed.
```
========== E2E Test Summary ==========
--- PASS: TestE2E (18.36s)
    --- PASS: TestE2E/Health (0.00s)
    --- PASS: TestE2E/Files (0.02s)
        --- PASS: TestE2E/Files/Lifecycle (0.02s)
    --- PASS: TestE2E/Batches (10.16s)
        --- PASS: TestE2E/Batches/Lifecycle (5.04s)
        --- PASS: TestE2E/Batches/Cancel (0.01s)
        --- PASS: TestE2E/Batches/PassThroughHeaders (5.12s)
    --- PASS: TestE2E/Observability (8.07s)
        --- PASS: TestE2E/Observability/OtelTraces (8.07s)

Passed: 10 | Failed: 0 | Skipped: 0
```
### 3) Simple check on postgresql
Records are inserted into postgresql
```
# kubectl exec -it postgresql-0 -n default -- env PGPASSWORD=postgres psql -U postgres -c '\dt'
             List of tables
 Schema |    Name     | Type  |  Owner
--------+-------------+-------+----------
 public | batch_items | table | postgres
 public | file_items  | table | postgres
(2 rows)

# kubectl exec -it postgresql-0 -n default -- env PGPASSWORD=postgres psql -U postgres -c 'SELECT (SELECT count(*) FROM batch_items) AS batches, (SELECT count(*) FROM file_items) AS files;'
 batches | files
---------+-------
       4 |     7
(1 row)
```