### PR TITLE
fix: failed e2e test for cancellation fix

### DIFF
--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -78,6 +78,7 @@ func (p *Processor) handleCancelled(
 	ctx context.Context,
 	jobItem *db.BatchItem,
 	updater *StatusUpdater,
+	requestCounts *openai.BatchRequestCounts,
 ) error {
 	logger := klog.FromContext(ctx)
 
@@ -85,7 +86,7 @@ func (p *Processor) handleCancelled(
 	p.cleanupJobArtifacts(ctx, jobItem.ID, jobItem.TenantID)
 
 	// update persistent status -> cancelled
-	if err := updater.UpdatePersistentStatus(ctx, jobItem, openai.BatchStatusCancelled, nil, nil); err != nil {
+	if err := updater.UpdatePersistentStatus(ctx, jobItem, openai.BatchStatusCancelled, requestCounts, nil); err != nil {
 		logger.V(logging.ERROR).Error(err, "Failed to update status to cancelled")
 		return err
 	}

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -255,7 +255,7 @@ func (p *Processor) executeJob(
 			return nil, ctx.Err() // parent-context error (e.g. pod shutdown)
 		}
 		if cancelRequested.Load() {
-			return nil, ErrCancelled // user-initiated cancel
+			return progress.counts(), ErrCancelled // user-initiated cancel
 		}
 		// SLO deadline exceeded: sloCtx deadline fired during execution.
 		// processModel already drained undispatched entries to error file; flush and return partial counts.
@@ -284,6 +284,12 @@ func (p *Processor) executeJob(
 	counts := progress.counts()
 	logger.V(logging.INFO).Info("Phase 2: execution completed",
 		"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
+
+	// Cancel may have arrived after all requests were already dispatched and completed normally
+	// (i.e. checkAbortCondition never fired). Honour the cancellation even in this case.
+	if cancelRequested.Load() {
+		return counts, ErrCancelled
+	}
 
 	return counts, nil
 }
@@ -361,6 +367,14 @@ dispatch:
 			if execErr != nil {
 				logger.Error(execErr, "Fatal error executing request", "offset", entry.Offset)
 				errOnce.Do(func() { firstErr = execErr })
+				return
+			}
+
+			// If cancel was requested while this request was in-flight, count it as
+			// failed and discard the result — cancelled requests are not written to
+			// the output file.
+			if cancelRequested.Load() {
+				progress.record(ctx, false)
 				return
 			}
 

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -124,7 +124,7 @@ func (p *Processor) runJob(
 	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "pre-process failed")
-		p.handleJobError(ctx, err, jobItem, updater, task)
+		p.handleJobError(ctx, err, nil, jobItem, updater, task)
 		return
 	}
 
@@ -152,7 +152,7 @@ func (p *Processor) runJob(
 		} else {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "execution failed")
-			p.handleJobError(ctx, err, jobItem, updater, task)
+			p.handleJobError(ctx, err, requestCounts, jobItem, updater, task)
 		}
 		return
 	}
@@ -179,6 +179,7 @@ func (p *Processor) runJob(
 func (p *Processor) handleJobError(
 	ctx context.Context,
 	err error,
+	requestCounts *openai.BatchRequestCounts,
 	jobItem *db.BatchItem,
 	updater *StatusUpdater,
 	task *db.BatchJobPriority,
@@ -187,7 +188,7 @@ func (p *Processor) handleJobError(
 
 	switch {
 	case errors.Is(err, ErrCancelled):
-		if cancelErr := p.handleCancelled(ctx, jobItem, updater); cancelErr != nil {
+		if cancelErr := p.handleCancelled(ctx, jobItem, updater, requestCounts); cancelErr != nil {
 			logger.V(logging.ERROR).Error(cancelErr, "Failed to handle cancelled event")
 		}
 

--- a/internal/processor/worker/worker_phase_1_test.go
+++ b/internal/processor/worker/worker_phase_1_test.go
@@ -755,7 +755,7 @@ func TestHandleCancelled_CleansDir_UpdatesCancelled(t *testing.T) {
 
 	updater := NewStatusUpdater(dbClient, statusClient, 86400)
 
-	if err := p.handleCancelled(ctx, jobItem, updater); err != nil {
+	if err := p.handleCancelled(ctx, jobItem, updater, nil); err != nil {
 		t.Fatalf("handleCancelled: %v", err)
 	}
 

--- a/internal/processor/worker/worker_phase_2_test.go
+++ b/internal/processor/worker/worker_phase_2_test.go
@@ -727,6 +727,37 @@ func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	}
 }
 
+// TestExecuteJob_CancelFlagSetAfterAllRequestsComplete verifies that if the cancel flag is set
+// after all requests have already been dispatched and completed successfully (i.e.
+// checkAbortCondition never fired during dispatch), executeJob still returns ErrCancelled
+// rather than nil, preventing the job from being finalized as "completed".
+func TestExecuteJob_CancelFlagSetAfterAllRequestsComplete(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	cancelReq := &atomic.Bool{}
+
+	// The mock sets cancelRequested=true only after the inference call returns, simulating
+	// the race where the cancel event arrives while (or just after) the last request completes.
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			cancelReq.Store(true)
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupPhase2Job(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	ctx := testLoggerCtx()
+	_, err := env.p.executeJob(ctx, ctx, env.updater, jobInfo, cancelReq)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled when cancel flag set after all requests complete, got: %v", err)
+	}
+}
+
 // TestExecuteJob_SLOExpiredBeforeDispatch verifies that when the SLO deadline has already
 // passed before Phase 2 begins, executeJob returns ErrExpired immediately with the total
 // request count and no output/error files are written (early-exit fast path).
@@ -1027,7 +1058,7 @@ func TestHandleJobError_ErrCancelled(t *testing.T) {
 	dbJob := seedDBJob(t, env.dbClient, "job-cancel")
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, ErrCancelled, dbJob, env.updater, nil)
+	env.p.handleJobError(ctx, ErrCancelled, nil, dbJob, env.updater, nil)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-cancel"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1050,7 +1081,7 @@ func TestHandleJobError_ContextCanceled_ReEnqueues(t *testing.T) {
 	task := &db.BatchJobPriority{ID: "job-ctx"}
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, context.Canceled, dbJob, env.updater, task)
+	env.p.handleJobError(ctx, context.Canceled, nil, dbJob, env.updater, task)
 
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
 	if err != nil {
@@ -1071,7 +1102,7 @@ func TestHandleJobError_DeadlineExceeded_ReEnqueues(t *testing.T) {
 	task := &db.BatchJobPriority{ID: "job-deadline"}
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, context.DeadlineExceeded, dbJob, env.updater, task)
+	env.p.handleJobError(ctx, context.DeadlineExceeded, nil, dbJob, env.updater, task)
 
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
 	if err != nil {
@@ -1092,7 +1123,7 @@ func TestHandleJobError_ContextCanceled_NilTask(t *testing.T) {
 
 	ctx := testLoggerCtx()
 	// task is nil — should not panic, and job status should remain unchanged
-	env.p.handleJobError(ctx, context.Canceled, dbJob, env.updater, nil)
+	env.p.handleJobError(ctx, context.Canceled, nil, dbJob, env.updater, nil)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-ctx-nil"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1116,7 +1147,7 @@ func TestHandleJobError_Default_MarksFailed(t *testing.T) {
 	dbJob := seedDBJob(t, env.dbClient, "job-fail")
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, errors.New("some error"), dbJob, env.updater, nil)
+	env.p.handleJobError(ctx, errors.New("some error"), nil, dbJob, env.updater, nil)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-fail"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {


### PR DESCRIPTION
**Summary**
Fixes a race condition in the batch processor where cancelling a job during inference could result in the wrong terminal status (completed instead of cancelled) and incorrect request counts (0/0/0).

**Root Cause**
1. executeJob missing cancel check on the happy path
cancelRequested was only checked inside if firstErr != nil. When cancel arrived after all requests were already dispatched and completed normally (i.e. checkAbortCondition never fired during dispatch), executeJob returned nil error → finalizeJob was called → status became completed.

2. In-flight goroutines didn't recognize cancellation
Even when cancel arrived during inference, completed requests were counted as completed rather than failed. The test expects that requests in-flight at cancellation time are counted as failed (per OpenAI batch API semantics — cancelled requests appear as failed, not completed).

3. Request counts not propagated to handleCancelled
handleCancelled always received nil counts, so UpdatePersistentStatus stored total=0, completed=0, failed=0 in the DB.

**Fix:**
- executor.go: Added cancelRequested.Load() check at the end of executeJob (after the happy-path flush) so cancellation is always honoured even if all requests happened to complete. Also added a per-goroutine check: after executeOneRequest returns, if cancel was requested while the request was in-flight, the result is discarded and counted as failed.
- cancel.go: Updated handleCancelled to accept and persist requestCounts.
- job_runner.go: Threaded requestCounts from executeJob through handleJobError → handleCancelled.


All E2E tests passed.