### PR TITLE
enh: Increase robustness of `make dev-deploy`

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -537,50 +537,90 @@ kill_stale_port_forwards() {
 
 start_apiserver_port_forward() {
     local svc="svc/${HELM_RELEASE}-apiserver"
+    local max_retries=3
+    local health_check_attempts=30
 
     kill_stale_port_forwards "${LOCAL_PORT}" "${LOCAL_OBS_PORT}"
 
-    step "Starting port-forward: ${svc} ${LOCAL_PORT}:8000 ${LOCAL_OBS_PORT}:8081 -n ${NAMESPACE}..."
-    kubectl port-forward "${svc}" "${LOCAL_PORT}:8000" "${LOCAL_OBS_PORT}:8081" -n "${NAMESPACE}" &
-    local pf_pid=$!
-    disown "${pf_pid}"
-    log "Port-forward PID: ${pf_pid}  (stop with: kill ${pf_pid})"
+    for retry in $(seq 1 ${max_retries}); do
+        step "Starting port-forward: ${svc} ${LOCAL_PORT}:8000 ${LOCAL_OBS_PORT}:8081 -n ${NAMESPACE} (attempt ${retry}/${max_retries})..."
+        kubectl port-forward "${svc}" "${LOCAL_PORT}:8000" "${LOCAL_OBS_PORT}:8081" -n "${NAMESPACE}" &
+        local pf_pid=$!
+        disown "${pf_pid}"
+        log "Port-forward PID: ${pf_pid}  (stop with: kill ${pf_pid})"
 
-    log "Waiting for http://localhost:${LOCAL_OBS_PORT}/health ..."
+        log "Waiting for http://localhost:${LOCAL_OBS_PORT}/health ..."
 
-    for i in $(seq 1 30); do
-        if curl -sf "http://localhost:${LOCAL_OBS_PORT}/health" >/dev/null 2>&1; then
-            log "API server is ready at https://localhost:${LOCAL_PORT}"
+        local success=false
+        for i in $(seq 1 ${health_check_attempts}); do
+            if curl -sf "http://localhost:${LOCAL_OBS_PORT}/health" >/dev/null 2>&1; then
+                log "API server is ready at https://localhost:${LOCAL_PORT}"
+                success=true
+                break
+            fi
+            sleep 1
+        done
+
+        if [ "${success}" = true ]; then
             return 0
         fi
-        sleep 1
+
+        # Health check failed - kill the port-forward and retry
+        warn "Port-forward health check failed on attempt ${retry}/${max_retries}"
+        kill "${pf_pid}" 2>/dev/null || true
+        kill_stale_port_forwards "${LOCAL_PORT}" "${LOCAL_OBS_PORT}"
+
+        if [ ${retry} -lt ${max_retries} ]; then
+            log "Retrying port-forward in 2 seconds..."
+            sleep 2
+        fi
     done
 
-    die "Timed out waiting for API server to become ready"
+    die "Timed out waiting for API server to become ready after ${max_retries} attempts"
 }
 
 start_processor_port_forward() {
     local deploy="deployment/${HELM_RELEASE}-processor"
+    local max_retries=3
+    local health_check_attempts=30
 
     kill_stale_port_forwards "${LOCAL_PROCESSOR_PORT}"
 
-    step "Starting port-forward: ${deploy} ${LOCAL_PROCESSOR_PORT}:9090 -n ${NAMESPACE}..."
-    kubectl port-forward "${deploy}" "${LOCAL_PROCESSOR_PORT}:9090" -n "${NAMESPACE}" &
-    local pf_pid=$!
-    disown "${pf_pid}"
-    log "Processor port-forward PID: ${pf_pid}  (stop with: kill ${pf_pid})"
+    for retry in $(seq 1 ${max_retries}); do
+        step "Starting port-forward: ${deploy} ${LOCAL_PROCESSOR_PORT}:9090 -n ${NAMESPACE} (attempt ${retry}/${max_retries})..."
+        kubectl port-forward "${deploy}" "${LOCAL_PROCESSOR_PORT}:9090" -n "${NAMESPACE}" &
+        local pf_pid=$!
+        disown "${pf_pid}"
+        log "Processor port-forward PID: ${pf_pid}  (stop with: kill ${pf_pid})"
 
-    log "Waiting for http://localhost:${LOCAL_PROCESSOR_PORT}/health ..."
+        log "Waiting for http://localhost:${LOCAL_PROCESSOR_PORT}/health ..."
 
-    for i in $(seq 1 30); do
-        if curl -sf "http://localhost:${LOCAL_PROCESSOR_PORT}/health" >/dev/null 2>&1; then
-            log "Processor is ready at http://localhost:${LOCAL_PROCESSOR_PORT}"
+        local success=false
+        for i in $(seq 1 ${health_check_attempts}); do
+            if curl -sf "http://localhost:${LOCAL_PROCESSOR_PORT}/health" >/dev/null 2>&1; then
+                log "Processor is ready at http://localhost:${LOCAL_PROCESSOR_PORT}"
+                success=true
+                break
+            fi
+            sleep 1
+        done
+
+        if [ "${success}" = true ]; then
             return 0
         fi
-        sleep 1
+
+        # Health check failed - kill the port-forward and retry
+        warn "Port-forward health check failed on attempt ${retry}/${max_retries}"
+        kill "${pf_pid}" 2>/dev/null || true
+        kill_stale_port_forwards "${LOCAL_PROCESSOR_PORT}"
+
+        if [ ${retry} -lt ${max_retries} ]; then
+            log "Retrying port-forward in 2 seconds..."
+            sleep 2
+        fi
     done
 
-    die "Timed out waiting for Processor to become ready"
+    die "Timed out waiting for Processor to become ready after ${max_retries} attempts"
 }
 
 start_jaeger_port_forward() {


### PR DESCRIPTION
## Problem

There is currently a timing race condition during pod restart:
The dev-deploy.sh script does (lines 484-486):
```
kubectl rollout restart deployment ... 
```
This triggers a rolling restart of the processor pod. The flow is:
- kubectl rollout restart → starts replacing pods
- wait_for_deployment → waits for rollout to complete
- start_processor_port_forward → tries to port-forward immediately

**The problem:** Even though the pod shows as "Ready", there's a small window where:
- The pod's readiness probe passes (/ready endpoint responds)
- But the HTTP server hasn't fully started accepting connections on all routes/ports
- Port-forward tries to connect during this window and fails

## Solution implemented

More robust retry logic for port-forward functions.

### Changes Made

Modified both `start_apiserver_port_forward()` and `start_processor_port_forward()` functions in `scripts/dev-deploy.sh`:

### Key Improvements

- Retry Loop: Port-forward now retries up to 3 times (configurable via max_retries)

- Graceful Failure Handling: If health check fails:

   - Kills the failed port-forward process
   - Cleans up any stale port-forwards
   - Waits 2 seconds before retrying
- Better Logging: Shows attempt number (e.g., "attempt 1/3") so users know progress

- Same Logic for Both Functions: Applied consistent retry pattern to both apiserver and processor port-forwards

### How It Works


For each retry (1 to 3):
  1. Start port-forward in background
  2. Try health check 30 times (30 seconds total)
  3. If health check succeeds → return success
  4. If health check fails → kill port-forward, cleanup, wait 2s, retry
  5. After 3 failed attempts → exit with error

This handles the race condition where the pod is "Ready" but the HTTP server hasn't fully started accepting connections yet. The retry logic gives the service additional time to fully initialize.
The script will now gracefully handle timing issues during pod restarts.