### PR TITLE
refactor: worker job execution parameter handling

### DIFF
--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -17,7 +17,6 @@ limitations under the License.
 package worker
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 
@@ -26,20 +25,22 @@ import (
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
-	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
 )
 
-func (p *Processor) watchCancel(
-	ctx context.Context,
-	eventWatcher *db.BatchEventsChan,
-	updater *StatusUpdater,
-	jobItem *db.BatchItem,
-	cancelRequested *atomic.Bool,
-	cancellingOnce *sync.Once,
-	inferCancelFn func(),
-) {
+func (p *Processor) watchCancel(params *jobExecutionParams) {
+	ctx := params.ctx
+	eventWatcher := params.eventWatcher
+	updater := params.updater
+	jobItem := params.jobItem
+
 	logger := klog.FromContext(ctx)
+	if params.cancelRequested == nil {
+		params.cancelRequested = &atomic.Bool{}
+	}
+	if params.cancellingOnce == nil {
+		params.cancellingOnce = &sync.Once{}
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -56,14 +57,14 @@ func (p *Processor) watchCancel(
 				logger.V(logging.INFO).Info("watchCancel: cancel event received")
 
 				// signal
-				cancelRequested.Store(true)
+				params.cancelRequested.Store(true)
 
 				// cancel the inference context to abort in-flight HTTP requests immediately,
 				// freeing downstream resources.
-				inferCancelFn()
+				params.inferCancelFn()
 
 				// update status to cancelling
-				cancellingOnce.Do(func() {
+				params.cancellingOnce.Do(func() {
 					err := updater.UpdatePersistentStatus(
 						ctx,
 						jobItem,
@@ -84,13 +85,13 @@ func (p *Processor) watchCancel(
 // When called after executeJob (execution), requestCounts and jobInfo are non-nil and partial
 // results are uploaded. When called before executeJob (ingestion), both are nil and only
 // cleanup + status transition is performed.
-func (p *Processor) handleCancelled(
-	ctx context.Context,
-	updater *StatusUpdater,
-	jobItem *db.BatchItem,
-	jobInfo *batch_types.JobInfo,
-	requestCounts *openai.BatchRequestCounts,
-) error {
+func (p *Processor) handleCancelled(params *jobExecutionParams) error {
+	ctx := params.ctx
+	updater := params.updater
+	jobItem := params.jobItem
+	jobInfo := params.jobInfo
+	requestCounts := params.requestCounts
+
 	logger := klog.FromContext(ctx)
 
 	var outputFileID, errorFileID string

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -135,14 +135,18 @@ func (ep *executionProgress) counts() *openai.BatchRequestCounts {
 // cancelRequested polling is partially redundant for stopping dispatch. Refactor so that context
 // cancellation is the sole dispatch-abort mechanism and cancelRequested is only used to distinguish
 // the cancellation reason (user cancel vs SLO vs pod shutdown) in the error-handling path.
-func (p *Processor) executeJob(
-	ctx context.Context,
-	sloCtx context.Context,
-	inferCtx context.Context,
-	updater *StatusUpdater,
-	jobInfo *batch_types.JobInfo,
-	cancelRequested *atomic.Bool,
-) (*openai.BatchRequestCounts, error) {
+func (p *Processor) executeJob(params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
+	ctx := params.ctx
+	sloCtx := params.sloCtx
+	inferCtx := params.inferCtx
+	updater := params.updater
+	jobInfo := params.jobInfo
+	cancelRequested := params.cancelRequested
+	if cancelRequested == nil {
+		cancelRequested = &atomic.Bool{}
+		params.cancelRequested = cancelRequested
+	}
+
 	logger := klog.FromContext(ctx)
 	logger.V(logging.INFO).Info("Starting execution: executing job")
 

--- a/internal/processor/worker/job_execution.go
+++ b/internal/processor/worker/job_execution.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
+	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
+	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
+)
+
+// jobExecutionParams holds the job-scoped state shared across processing stages.
+type jobExecutionParams struct {
+	ctx      context.Context
+	sloCtx   context.Context
+	inferCtx context.Context
+
+	updater *StatusUpdater
+	jobItem *db.BatchItem
+	jobInfo *batch_types.JobInfo
+	task    *db.BatchJobPriority
+
+	eventWatcher  *db.BatchEventsChan
+	inferCancelFn context.CancelFunc
+
+	cancelRequested *atomic.Bool
+	cancellingOnce  *sync.Once
+
+	requestCounts *openai.BatchRequestCounts
+}

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -40,13 +40,13 @@ import (
 	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
 )
 
-func (p *Processor) runJob(
-	ctx context.Context,
-	updater *StatusUpdater,
-	jobItem *db.BatchItem,
-	jobInfo *batch_types.JobInfo,
-	task *db.BatchJobPriority,
-) {
+func (p *Processor) runJob(params *jobExecutionParams) {
+	ctx := params.ctx
+	updater := params.updater
+	jobItem := params.jobItem
+	jobInfo := params.jobInfo
+	task := params.task
+
 	// Restore parent trace context propagated from the apiserver via Redis tags
 	if len(jobInfo.TraceContext) > 0 {
 		propagator := otel.GetTextMapPropagator()
@@ -63,10 +63,18 @@ func (p *Processor) runJob(
 	ctx, span := uotel.StartSpan(ctx, "process-batch",
 		trace.WithAttributes(spanAttrs...),
 	)
+	params.ctx = ctx
 	defer span.End()
 
 	// this logger includes job ID in the context
 	logger := klog.FromContext(ctx)
+
+	if params.cancelRequested == nil {
+		params.cancelRequested = &atomic.Bool{}
+	}
+	if params.cancellingOnce == nil {
+		params.cancellingOnce = &sync.Once{}
+	}
 
 	defer p.wg.Done()
 	defer p.release()
@@ -87,7 +95,7 @@ func (p *Processor) runJob(
 	// If an SLO deadline is set, create a child context that cancels when the deadline fires.
 	// This context is passed to executeJob to bound dispatch and trigger expiration handling.
 	sloCtx, sloCancel := ctx, func() {}
-	if !task.SLO.IsZero() {
+	if task != nil && !task.SLO.IsZero() {
 		sloCtx, sloCancel = context.WithDeadline(ctx, task.SLO)
 	}
 	defer sloCancel()
@@ -113,24 +121,22 @@ func (p *Processor) runJob(
 	}
 	defer eventWatcher.CloseFn()
 
-	// cancel requested flag and cancelling once
-	var cancelRequested atomic.Bool
-	var cancellingOnce sync.Once
-
 	// inferCtx is cancelled when the user requests batch cancellation, propagating
 	// the signal to all in-flight inference HTTP requests so they abort promptly.
 	// It is derived from sloCtx so the SLO deadline is also respected.
-	inferCtx, inferCancelFn := context.WithCancel(sloCtx)
-	defer inferCancelFn()
+	params.sloCtx = sloCtx
+	params.inferCtx, params.inferCancelFn = context.WithCancel(sloCtx)
+	defer params.inferCancelFn()
 
 	// watch for cancel event
-	go p.watchCancel(ctx, eventWatcher, updater, jobItem, &cancelRequested, &cancellingOnce, inferCancelFn)
+	params.eventWatcher = eventWatcher
+	go p.watchCancel(params)
 
 	// ingestion: pre-process job
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo, params.cancelRequested); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "pre-process failed")
-		p.handleJobError(ctx, err, jobItem, updater, task, nil, nil)
+		p.handleJobError(params, err)
 		return
 	}
 
@@ -146,7 +152,8 @@ func (p *Processor) runJob(
 	}
 
 	// execution: execute inference requests
-	requestCounts, err := p.executeJob(ctx, sloCtx, inferCtx, updater, jobInfo, &cancelRequested)
+	requestCounts, err := p.executeJob(params)
+	params.requestCounts = requestCounts
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrExpired):
@@ -158,7 +165,7 @@ func (p *Processor) runJob(
 			metrics.RecordJobProcessingDuration(time.Since(jobStart), jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
 
 		case errors.Is(err, ErrCancelled):
-			if cancelErr := p.handleCancelled(ctx, updater, jobItem, jobInfo, requestCounts); cancelErr != nil {
+			if cancelErr := p.handleCancelled(params); cancelErr != nil {
 				logger.V(logging.ERROR).Error(cancelErr, "Failed to finalize cancelled job")
 				span.RecordError(cancelErr)
 				span.SetStatus(codes.Error, "cancelled finalization failed")
@@ -170,7 +177,7 @@ func (p *Processor) runJob(
 		default:
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "execution failed")
-			p.handleJobError(ctx, err, jobItem, updater, task, requestCounts, jobInfo)
+			p.handleJobError(params, err)
 		}
 		return
 	}
@@ -197,21 +204,23 @@ func (p *Processor) runJob(
 
 // handleJobError routes an error to the appropriate handler (cancel, re-enqueue, or fail).
 // requestCounts and jobInfo are non-nil only when the error originates from execution (executeJob).
-func (p *Processor) handleJobError(
-	ctx context.Context,
-	err error,
-	jobItem *db.BatchItem,
-	updater *StatusUpdater,
-	task *db.BatchJobPriority,
-	requestCounts *openai.BatchRequestCounts,
-	jobInfo *batch_types.JobInfo,
-) {
+func (p *Processor) handleJobError(params *jobExecutionParams, err error) {
+	ctx := params.ctx
+	jobItem := params.jobItem
+	updater := params.updater
+	task := params.task
+	requestCounts := params.requestCounts
+	jobInfo := params.jobInfo
+
 	logger := klog.FromContext(ctx)
 
 	switch {
 	case errors.Is(err, ErrCancelled):
 		// Ingestion cancel: no output files exist yet
-		if cancelErr := p.handleCancelled(ctx, updater, jobItem, nil, nil); cancelErr != nil {
+		cancelParams := *params
+		cancelParams.jobInfo = nil
+		cancelParams.requestCounts = nil
+		if cancelErr := p.handleCancelled(&cancelParams); cancelErr != nil {
 			logger.V(logging.ERROR).Error(cancelErr, "Failed to handle cancelled event")
 		}
 

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -36,13 +36,12 @@ func TestRunJob_EventWatcherError_ReturnsSafely(t *testing.T) {
 	}
 	p.wg.Add(1)
 
-	p.runJob(
-		testLoggerCtx(),
-		NewStatusUpdater(newMockBatchDBClient(), mockdb.NewMockBatchStatusClient(), 86400),
-		&db.BatchItem{BaseIndexes: db.BaseIndexes{ID: "job-1", TenantID: "tenantA"}},
-		&batch_types.JobInfo{JobID: "job-1"},
-		nil,
-	)
+	p.runJob(&jobExecutionParams{
+		ctx:     testLoggerCtx(),
+		updater: NewStatusUpdater(newMockBatchDBClient(), mockdb.NewMockBatchStatusClient(), 86400),
+		jobItem: &db.BatchItem{BaseIndexes: db.BaseIndexes{ID: "job-1", TenantID: "tenantA"}},
+		jobInfo: &batch_types.JobInfo{JobID: "job-1"},
+	})
 }
 
 func TestRunJob_PreProcessError_HandlesFailedStatus(t *testing.T) {
@@ -87,9 +86,15 @@ func TestRunJob_PreProcessError_HandlesFailedStatus(t *testing.T) {
 		t.Fatalf("expected token acquire before runJob")
 	}
 	p.wg.Add(1)
-	p.runJob(ctx, NewStatusUpdater(dbClient, statusClient, 86400), jobItem, jobInfo, &db.BatchJobPriority{
-		ID:  "job-fail",
-		SLO: time.Now().Add(1 * time.Hour),
+	p.runJob(&jobExecutionParams{
+		ctx:     ctx,
+		updater: NewStatusUpdater(dbClient, statusClient, 86400),
+		jobItem: jobItem,
+		jobInfo: jobInfo,
+		task: &db.BatchJobPriority{
+			ID:  "job-fail",
+			SLO: time.Now().Add(1 * time.Hour),
+		},
 	})
 
 	items, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-fail"}}}, true, 0, 1)

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -52,6 +52,8 @@ func NewProcessor(
 	clients *clientset.Clientset,
 ) *Processor {
 	// TODO: need to group clients by usecase (poller, updater, etc.)
+	// Eliminate p.clients by extracting role-specific wrappers (e.g. FileManager for File+FileDB),
+	// moving Event and Inference to dedicated fields, so Clientset is not leaked into Processor.
 	poller := NewPoller(clients.Queue, clients.BatchDB)
 	updater := NewStatusUpdater(clients.BatchDB, clients.Status, cfg.ProgressTTLSeconds)
 	// TODO: Handle errors from semaphore.New().
@@ -215,7 +217,13 @@ func (p *Processor) runPollingLoop(ctx context.Context) error {
 
 		// process job
 		p.wg.Add(1)
-		go p.runJob(jctx, p.updater, jobItem, jobInfo, task)
+		go p.runJob(&jobExecutionParams{
+			ctx:     jctx,
+			updater: p.updater,
+			jobItem: jobItem,
+			jobInfo: jobInfo,
+			task:    task,
+		})
 	}
 }
 

--- a/internal/processor/worker/worker_execution_test.go
+++ b/internal/processor/worker/worker_execution_test.go
@@ -626,7 +626,14 @@ func TestExecuteJob_SingleModel(t *testing.T) {
 	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx()
-	counts, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	counts, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
 	}
@@ -670,7 +677,14 @@ func TestExecuteJob_MultipleModels(t *testing.T) {
 	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx()
-	counts, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	counts, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
 	}
@@ -702,7 +716,14 @@ func TestExecuteJob_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(testLoggerCtx())
 	cancel()
 
-	_, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	_, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if err == nil {
 		t.Fatalf("expected error on cancelled context")
 	}
@@ -721,7 +742,14 @@ func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	cancelReq.Store(true)
 
 	ctx := testLoggerCtx()
-	_, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	_, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled, got: %v", err)
 	}
@@ -752,7 +780,14 @@ func TestExecuteJob_CancelFlagSetAfterAllRequestsComplete(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx()
-	_, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	_, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if !errors.Is(err, ErrCancelled) {
 		t.Fatalf("expected ErrCancelled when cancel flag set after all requests complete, got: %v", err)
 	}
@@ -794,7 +829,14 @@ func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, ctx, inferCtx, env.updater, jobInfo, cancelReq)
+		counts, err := env.p.executeJob(&jobExecutionParams{
+			ctx:             ctx,
+			sloCtx:          ctx,
+			inferCtx:        inferCtx,
+			updater:         env.updater,
+			jobInfo:         jobInfo,
+			cancelRequested: cancelReq,
+		})
 		resCh <- result{counts, err}
 	}()
 
@@ -844,7 +886,14 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 	sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer cancel()
 
-	counts, err := env.p.executeJob(ctx, sloCtx, sloCtx, env.updater, jobInfo, cancelReq)
+	counts, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          sloCtx,
+		inferCtx:        sloCtx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if !errors.Is(err, ErrExpired) {
 		t.Fatalf("expected ErrExpired, got: %v", err)
 	}
@@ -982,7 +1031,14 @@ func TestExecuteJob_SeparatesSuccessAndErrors(t *testing.T) {
 	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx()
-	counts, err := env.p.executeJob(ctx, ctx, ctx, env.updater, jobInfo, cancelReq)
+	counts, err := env.p.executeJob(&jobExecutionParams{
+		ctx:             ctx,
+		sloCtx:          ctx,
+		inferCtx:        ctx,
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
 	}
@@ -1124,7 +1180,11 @@ func TestHandleJobError_ErrCancelled(t *testing.T) {
 	dbJob := seedDBJob(t, env.dbClient, "job-cancel")
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, ErrCancelled, dbJob, env.updater, nil, nil, nil)
+	env.p.handleJobError(&jobExecutionParams{
+		ctx:     ctx,
+		updater: env.updater,
+		jobItem: dbJob,
+	}, ErrCancelled)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-cancel"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1147,7 +1207,12 @@ func TestHandleJobError_ContextCanceled_ReEnqueues(t *testing.T) {
 	task := &db.BatchJobPriority{ID: "job-ctx"}
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, context.Canceled, dbJob, env.updater, task, nil, nil)
+	env.p.handleJobError(&jobExecutionParams{
+		ctx:     ctx,
+		updater: env.updater,
+		jobItem: dbJob,
+		task:    task,
+	}, context.Canceled)
 
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
 	if err != nil {
@@ -1168,7 +1233,12 @@ func TestHandleJobError_DeadlineExceeded_ReEnqueues(t *testing.T) {
 	task := &db.BatchJobPriority{ID: "job-deadline"}
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, context.DeadlineExceeded, dbJob, env.updater, task, nil, nil)
+	env.p.handleJobError(&jobExecutionParams{
+		ctx:     ctx,
+		updater: env.updater,
+		jobItem: dbJob,
+		task:    task,
+	}, context.DeadlineExceeded)
 
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
 	if err != nil {
@@ -1189,7 +1259,11 @@ func TestHandleJobError_ContextCanceled_NilTask(t *testing.T) {
 
 	ctx := testLoggerCtx()
 	// task is nil — should not panic, and job status should remain unchanged
-	env.p.handleJobError(ctx, context.Canceled, dbJob, env.updater, nil, nil, nil)
+	env.p.handleJobError(&jobExecutionParams{
+		ctx:     ctx,
+		updater: env.updater,
+		jobItem: dbJob,
+	}, context.Canceled)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-ctx-nil"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1213,7 +1287,11 @@ func TestHandleJobError_Default_MarksFailed(t *testing.T) {
 	dbJob := seedDBJob(t, env.dbClient, "job-fail")
 
 	ctx := testLoggerCtx()
-	env.p.handleJobError(ctx, errors.New("some error"), dbJob, env.updater, nil, nil, nil)
+	env.p.handleJobError(&jobExecutionParams{
+		ctx:     ctx,
+		updater: env.updater,
+		jobItem: dbJob,
+	}, errors.New("some error"))
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-fail"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1274,7 +1352,13 @@ func TestHandleCancelled_Execution_UploadsPartialOutput(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 5, Completed: 3, Failed: 2}
 
 	ctx := testLoggerCtx()
-	if err := env.p.handleCancelled(ctx, env.updater, dbJob, jobInfo, counts); err != nil {
+	if err := env.p.handleCancelled(&jobExecutionParams{
+		ctx:           ctx,
+		updater:       env.updater,
+		jobItem:       dbJob,
+		jobInfo:       jobInfo,
+		requestCounts: counts,
+	}); err != nil {
 		t.Fatalf("handleCancelled: %v", err)
 	}
 

--- a/internal/processor/worker/worker_ingestion_test.go
+++ b/internal/processor/worker/worker_ingestion_test.go
@@ -603,7 +603,16 @@ func TestWatchCancel_SetsFlag_AndUpdatesCancellingOnce(t *testing.T) {
 	var cancellingOnce sync.Once
 
 	// Start watching cancel in background
-	go p.watchCancel(ctx, evCh, updater, jobItem, &cancelRequested, &cancellingOnce, func() {})
+	params := &jobExecutionParams{
+		ctx:             ctx,
+		eventWatcher:    evCh,
+		updater:         updater,
+		jobItem:         jobItem,
+		inferCancelFn:   func() {},
+		cancelRequested: &cancelRequested,
+		cancellingOnce:  &cancellingOnce,
+	}
+	go p.watchCancel(params)
 
 	// Send cancel twice; status update should still happen once due to sync.Once.
 	_, _ = eventClient.ECProducerSendEvents(ctx, []db.BatchEvent{
@@ -614,10 +623,10 @@ func TestWatchCancel_SetsFlag_AndUpdatesCancellingOnce(t *testing.T) {
 	})
 
 	deadline := time.Now().Add(2 * time.Second)
-	for !cancelRequested.Load() && time.Now().Before(deadline) {
+	for !params.cancelRequested.Load() && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if !cancelRequested.Load() {
+	if !params.cancelRequested.Load() {
 		t.Fatalf("cancelRequested was not set")
 	}
 
@@ -664,7 +673,16 @@ func TestWatchCancel_CancelsInferContext(t *testing.T) {
 
 	inferCtx, inferCancelFn := context.WithCancel(ctx)
 
-	go p_watchCancelHelper(t, ctx, evCh, updater, jobItem, &cancelRequested, &cancellingOnce, inferCancelFn)
+	params := &jobExecutionParams{
+		ctx:             ctx,
+		eventWatcher:    evCh,
+		updater:         updater,
+		jobItem:         jobItem,
+		inferCancelFn:   inferCancelFn,
+		cancelRequested: &cancelRequested,
+		cancellingOnce:  &cancellingOnce,
+	}
+	go p_watchCancelHelper(t, params)
 
 	// Send cancel event
 	_, _ = eventClient.ECProducerSendEvents(ctx, []db.BatchEvent{
@@ -679,25 +697,16 @@ func TestWatchCancel_CancelsInferContext(t *testing.T) {
 		t.Fatal("inferCtx was not cancelled within 2s after cancel event")
 	}
 
-	if !cancelRequested.Load() {
+	if !params.cancelRequested.Load() {
 		t.Fatal("cancelRequested was not set")
 	}
 }
 
 // p_watchCancelHelper is a test helper that calls watchCancel on a fresh Processor.
-func p_watchCancelHelper(
-	t *testing.T,
-	ctx context.Context,
-	evCh *db.BatchEventsChan,
-	updater *StatusUpdater,
-	jobItem *db.BatchItem,
-	cancelRequested *atomic.Bool,
-	cancellingOnce *sync.Once,
-	inferCancelFn func(),
-) {
+func p_watchCancelHelper(t *testing.T, params *jobExecutionParams) {
 	t.Helper()
 	p := NewProcessor(config.NewConfig(), &clientset.Clientset{})
-	p.watchCancel(ctx, evCh, updater, jobItem, cancelRequested, cancellingOnce, inferCancelFn)
+	p.watchCancel(params)
 }
 
 func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
@@ -825,7 +834,11 @@ func TestHandleCancelled_CleansDir_UpdatesCancelled(t *testing.T) {
 
 	updater := NewStatusUpdater(dbClient, statusClient, 86400)
 
-	if err := p.handleCancelled(ctx, updater, jobItem, nil, nil); err != nil {
+	if err := p.handleCancelled(&jobExecutionParams{
+		ctx:     ctx,
+		updater: updater,
+		jobItem: jobItem,
+	}); err != nil {
 		t.Fatalf("handleCancelled: %v", err)
 	}
 


### PR DESCRIPTION
Bundle worker job execution state into jobExecutionParams to simplify processor flow and reduce long function signatures. This keeps cancellation and error-handling paths aligned while making follow-up refactors easier.