### PR TITLE
fix: add method/path labels to http_requests_in_flight

### DIFF
--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -11,7 +11,7 @@ The API server exposes the following Prometheus metrics:
 
 - `http_requests_total{method,path,status}` (Counter) - Total HTTP requests by method, path, and status code.
 - `http_request_duration_seconds{method,path,status}` (Histogram) - HTTP request latency histogram.
-- `http_requests_in_flight{method,path,status}` (Gauge) - Current number of HTTP requests being processed by the api server.
+- `http_requests_in_flight{method,path}` (Gauge) - Current number of HTTP requests being processed by the api server.
 
 ## Processor
 

--- a/internal/apiserver/common/rest.go
+++ b/internal/apiserver/common/rest.go
@@ -24,21 +24,9 @@ import (
 	"io"
 	"net/http"
 
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
-	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
 )
-
-// StatusRecorder is implemented by http.ResponseWriter wrappers that capture the status code.
-// This allows downstream handlers (e.g. OTel instrumentation) to read the status
-// without adding another wrapper layer.
-type StatusRecorder interface {
-	http.ResponseWriter
-	StatusCode() int
-}
 
 type Route struct {
 	Method      string
@@ -51,77 +39,39 @@ type ApiHandler interface {
 	GetRoutes() []Route
 }
 
-func RegisterHandler(mux *http.ServeMux, h ApiHandler) {
+// RouteMiddleware produces a middleware wrapper for a given route.
+// It receives the Route so it can use route-specific information (e.g. Pattern for metrics).
+type RouteMiddleware func(route Route, next http.HandlerFunc) http.HandlerFunc
+
+// RegisterHandler registers all routes from h on mux, wrapping each handler
+// with the provided middleware chain. Middleware is applied in order: the first
+// middleware is the outermost wrapper (executes first on request, last on response).
+func RegisterHandler(mux *http.ServeMux, h ApiHandler, middlewares ...RouteMiddleware) {
 	routes := h.GetRoutes()
 	for _, route := range routes {
 		pattern := route.Method + " " + route.Pattern
 		handler := route.HandlerFunc
-		if route.SpanName != "" {
-			handler = otelInstrumentHandler(route.SpanName, handler)
+		// Apply middleware in reverse order so the first middleware is outermost
+		for i := len(middlewares) - 1; i >= 0; i-- {
+			handler = middlewares[i](route, handler)
 		}
 		mux.HandleFunc(pattern, handler)
 	}
 }
 
-// otelInstrumentHandler wraps a handler to create an OTel span with the given name.
-// It sets tenant.id, file.id, and batch.id span attributes from the request context and path values.
-// It reads the HTTP status code from the upstream StatusRecorder (e.g. the request middleware's
-// response writer) instead of adding another wrapper layer.
-func otelInstrumentHandler(spanName string, next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, span := uotel.StartSpan(r.Context(), spanName)
-		defer span.End()
-
-		span.SetAttributes(attribute.String(uotel.AttrTenantID, GetTenantIDFromContext(ctx)))
-		if fileID := r.PathValue(PathParamFileID); fileID != "" {
-			span.SetAttributes(attribute.String(uotel.AttrInputFileID, fileID))
-		}
-		if batchID := r.PathValue(PathParamBatchID); batchID != "" {
-			span.SetAttributes(attribute.String(uotel.AttrBatchID, batchID))
-		}
-
-		sr, ok := w.(StatusRecorder)
-		if !ok {
-			// No upstream StatusRecorder (e.g. request middleware absent) — add one.
-			fw := &otelStatusWriter{ResponseWriter: w}
-			sr = fw
-			w = fw
-		}
-
-		next(w, r.WithContext(ctx))
-
-		status := sr.StatusCode()
-		span.SetAttributes(attribute.Int("http.status_code", status))
-		if status >= 500 {
-			span.SetStatus(codes.Error, http.StatusText(status))
-		}
+// RegisterNotFoundHandler registers a catch-all "/" route that returns a JSON 404
+// response for any request not matched by more specific routes. The handler is
+// wrapped with the same middleware chain as business routes.
+func RegisterNotFoundHandler(mux *http.ServeMux, middlewares ...RouteMiddleware) {
+	route := Route{Pattern: "/"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oaiErr := openai.NewAPIError(http.StatusNotFound, "", fmt.Sprintf("Unknown request URL: %s %s", r.Method, r.URL.Path), nil)
+		WriteAPIError(w, r, oaiErr)
+	})
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](route, handler)
 	}
-}
-
-// Compile-time check: otelStatusWriter implements StatusRecorder.
-var _ StatusRecorder = (*otelStatusWriter)(nil)
-
-// otelStatusWriter is a minimal StatusRecorder used only when no upstream
-// wrapper (e.g. request middleware) is present.
-type otelStatusWriter struct {
-	http.ResponseWriter
-	status int
-}
-
-func (w *otelStatusWriter) WriteHeader(code int) {
-	w.status = code
-	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *otelStatusWriter) Write(b []byte) (int, error) {
-	if w.status == 0 {
-		w.status = http.StatusOK
-	}
-	return w.ResponseWriter.Write(b)
-}
-
-func (w *otelStatusWriter) StatusCode() int {
-	return w.status
+	mux.HandleFunc("/", handler)
 }
 
 func DecodeJSON(r io.Reader, obj any) error {

--- a/internal/apiserver/metrics/metrics.go
+++ b/internal/apiserver/metrics/metrics.go
@@ -37,11 +37,12 @@ var (
 		},
 		[]string{"method", "path", "status"},
 	)
-	httpRequestsInFlight = prometheus.NewGauge(
+	httpRequestsInFlight = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "http_requests_in_flight",
 			Help: "Current number of HTTP requests being processed by the api server",
 		},
+		[]string{"method", "path"},
 	)
 )
 
@@ -51,12 +52,12 @@ func init() {
 	prometheus.MustRegister(httpRequestsInFlight)
 }
 
-func RecordRequestStart() {
-	httpRequestsInFlight.Inc()
+func RecordRequestStart(method, path string) {
+	httpRequestsInFlight.WithLabelValues(method, path).Inc()
 }
 
 func RecordRequestFinish(method, path, status string, durationSeconds float64) {
-	httpRequestsInFlight.Dec()
+	httpRequestsInFlight.WithLabelValues(method, path).Dec()
 	httpRequestsTotal.WithLabelValues(method, path, status).Inc()
 	httpRequestDuration.WithLabelValues(method, path, status).Observe(durationSeconds)
 }

--- a/internal/apiserver/middleware/recovery_middleware.go
+++ b/internal/apiserver/middleware/recovery_middleware.go
@@ -27,9 +27,9 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
 )
 
-// RecoveryMiddleware recovers from panics and returns a JSON error response
-func RecoveryMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// Recovery returns a RouteMiddleware that recovers from panics and returns a JSON error response.
+func Recovery(_ common.Route, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
 				var panicErr error
@@ -47,7 +47,6 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 					logger.Error(panicErr, "handler panic",
 						"method", r.Method,
 						"path", r.URL.Path,
-						//"stack", string(debug.Stack()),
 					)
 				}
 
@@ -57,6 +56,6 @@ func RecoveryMiddleware(next http.Handler) http.Handler {
 			}
 		}()
 
-		next.ServeHTTP(w, r)
-	})
+		next(w, r)
+	}
 }

--- a/internal/apiserver/middleware/recovery_middleware_test.go
+++ b/internal/apiserver/middleware/recovery_middleware_test.go
@@ -29,23 +29,23 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 )
 
+var dummyRoute = common.Route{Method: http.MethodGet, Pattern: "/test"}
+
 func TestRecoveryMiddleware(t *testing.T) {
 	t.Run("NoPanic", doTestRecoveryMiddlewareNoPanic)
 	t.Run("WithPanic", doTestRecoveryMiddlewareWithPanic)
 }
 
 func doTestRecoveryMiddlewareNoPanic(t *testing.T) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recovery(dummyRoute, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("success"))
 	})
 
-	middleware := RecoveryMiddleware(handler)
-
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
-	middleware.ServeHTTP(w, req)
+	handler.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
@@ -86,11 +86,9 @@ func doTestRecoveryMiddlewareWithPanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := Recovery(dummyRoute, func(w http.ResponseWriter, r *http.Request) {
 				panic(tt.panicValue)
 			})
-
-			middleware := RecoveryMiddleware(handler)
 
 			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			ctx := context.WithValue(req.Context(), common.RequestIDKey, "test-request-id-123")
@@ -98,7 +96,7 @@ func doTestRecoveryMiddlewareWithPanic(t *testing.T) {
 
 			w := httptest.NewRecorder()
 
-			middleware.ServeHTTP(w, req)
+			handler.ServeHTTP(w, req)
 
 			// Check status code
 			if w.Code != http.StatusInternalServerError {
@@ -144,31 +142,27 @@ func doTestRecoveryMiddlewareWithPanic(t *testing.T) {
 }
 
 func BenchmarkRecoveryMiddleware_NoPanic(b *testing.B) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recovery(dummyRoute, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-
-	middleware := RecoveryMiddleware(handler)
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		w := httptest.NewRecorder()
-		middleware.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 	}
 }
 
 func BenchmarkRecoveryMiddleware_WithPanic(b *testing.B) {
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := Recovery(dummyRoute, func(w http.ResponseWriter, r *http.Request) {
 		panic("benchmark panic")
 	})
-
-	middleware := RecoveryMiddleware(handler)
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		w := httptest.NewRecorder()
-		middleware.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 	}
 }

--- a/internal/apiserver/middleware/request_middleware.go
+++ b/internal/apiserver/middleware/request_middleware.go
@@ -14,22 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The file implements request middleware for generating request IDs, logging requests and recording metrics.
+// The file implements request-level observability middleware:
+// request ID generation, tenant extraction, structured logging, metrics, and OTel tracing.
 package middleware
 
 import (
 	"context"
 	"net/http"
-	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/common"
-	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/health"
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
+	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
 	"k8s.io/klog/v2"
 )
 
@@ -37,24 +40,16 @@ const (
 	RequestIdHeaderKey = "x-request-id"
 )
 
-var (
-	fileIDRegex  = regexp.MustCompile(`^/v1/files/([^/]+)`)
-	batchIDRegex = regexp.MustCompile(`^/v1/batches/([^/]+)`)
-)
-
-func RequestMiddleware(config *common.ServerConfig) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			path := r.URL.Path
-			// Skip /metrics and /health endpoints to avoid noise in logs and metrics
-			if path == metrics.MetricsPath || path == health.HealthPath {
-				next.ServeHTTP(w, r)
-				return
-			}
-
-			start := time.Now()
-			metrics.RecordRequestStart()
-
+// NewRequestMiddleware returns a RouteMiddleware that adds request ID generation,
+// tenant extraction, structured logging, metrics recording, and OTel tracing.
+// It uses route.Pattern (e.g. "/v1/batches/{batch_id}") as the metric path label,
+// avoiding high-cardinality issues from raw paths with resource IDs.
+// OTel spans are created when route.SpanName is non-empty.
+func NewRequestMiddleware(config *common.ServerConfig) common.RouteMiddleware {
+	return func(route common.Route, next http.HandlerFunc) http.HandlerFunc {
+		metricsPath := route.Pattern
+		spanName := route.SpanName
+		return func(w http.ResponseWriter, r *http.Request) {
 			// Extract request ID from header
 			requestID := r.Header.Get(RequestIdHeaderKey)
 			if requestID == "" {
@@ -78,15 +73,9 @@ func RequestMiddleware(config *common.ServerConfig) func(http.Handler) http.Hand
 				tenantID = common.DefaultTenantID
 			}
 
-			// Extract file ID and batch ID from path for logging
-			fileID := ""
-			if m := fileIDRegex.FindStringSubmatch(path); len(m) > 1 {
-				fileID = m[1]
-			}
-			batchID := ""
-			if m := batchIDRegex.FindStringSubmatch(path); len(m) > 1 {
-				batchID = m[1]
-			}
+			// Extract file ID and batch ID from path values for logging
+			fileID := r.PathValue(common.PathParamFileID)
+			batchID := r.PathValue(common.PathParamBatchID)
 
 			// Create request logger with request ID and tenant ID
 			logger := klog.FromContext(r.Context())
@@ -103,9 +92,6 @@ func RequestMiddleware(config *common.ServerConfig) func(http.Handler) http.Hand
 			ctx = context.WithValue(ctx, common.RequestIDKey, requestID)
 			ctx = context.WithValue(ctx, common.TenantIDKey, tenantID)
 
-			// Wrap response writer to capture status code
-			rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-
 			// Log incoming request
 			logger.V(logging.TRACE).Info("incoming request",
 				"method", r.Method,
@@ -113,19 +99,41 @@ func RequestMiddleware(config *common.ServerConfig) func(http.Handler) http.Hand
 				"remoteAddr", r.RemoteAddr,
 			)
 
+			rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+			// Metrics
+			start := time.Now()
+			metrics.RecordRequestStart(r.Method, metricsPath)
 			defer func() {
 				duration := time.Since(start).Seconds()
 				status := strconv.Itoa(rw.statusCode)
-				metrics.RecordRequestFinish(r.Method, r.URL.Path, status, duration)
+				metrics.RecordRequestFinish(r.Method, metricsPath, status, duration)
 			}()
 
-			next.ServeHTTP(rw, r.WithContext(ctx))
-		})
+			// OTel tracing (skipped when route has no SpanName)
+			if spanName != "" {
+				var span trace.Span
+				ctx, span = uotel.StartSpan(ctx, spanName)
+				span.SetAttributes(attribute.String(uotel.AttrTenantID, tenantID))
+				if fileID != "" {
+					span.SetAttributes(attribute.String(uotel.AttrInputFileID, fileID))
+				}
+				if batchID != "" {
+					span.SetAttributes(attribute.String(uotel.AttrBatchID, batchID))
+				}
+				defer func() {
+					span.SetAttributes(attribute.Int("http.status_code", rw.statusCode))
+					if rw.statusCode >= 500 {
+						span.SetStatus(codes.Error, http.StatusText(rw.statusCode))
+					}
+					span.End()
+				}()
+			}
+
+			next(rw, r.WithContext(ctx))
+		}
 	}
 }
-
-// Compile-time check: responseWriter implements common.StatusRecorder.
-var _ common.StatusRecorder = (*responseWriter)(nil)
 
 // responseWriter wraps http.ResponseWriter to capture status code
 type responseWriter struct {

--- a/internal/apiserver/middleware/request_middleware_test.go
+++ b/internal/apiserver/middleware/request_middleware_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/common"
-	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/health"
-	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/metrics"
 )
 
 // newTestConfig returns a minimal ServerConfig suitable for middleware tests.
@@ -36,14 +34,12 @@ func newTestConfig(tenantHeader string) *common.ServerConfig {
 	}
 }
 
-// captureHandler returns an http.Handler that captures the tenant ID from context.
-func captureHandler(captured *string) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if v, ok := r.Context().Value(common.TenantIDKey).(string); ok {
-			*captured = v
-		}
-		w.WriteHeader(http.StatusOK)
-	})
+var batchesRoute = common.Route{Method: http.MethodGet, Pattern: "/v1/batches"}
+
+// wrapWithRequestMiddleware creates a handler wrapped by NewRequestMiddleware for testing.
+func wrapWithRequestMiddleware(config *common.ServerConfig, inner http.HandlerFunc) http.HandlerFunc {
+	mw := NewRequestMiddleware(config)
+	return mw(batchesRoute, inner)
 }
 
 func TestRequestMiddleware_TenantHeader(t *testing.T) {
@@ -88,7 +84,12 @@ func TestRequestMiddleware_TenantHeader(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			config := newTestConfig(tenantHeader)
 			var captured string
-			handler := RequestMiddleware(config)(captureHandler(&captured))
+			handler := wrapWithRequestMiddleware(config, func(w http.ResponseWriter, r *http.Request) {
+				if v, ok := r.Context().Value(common.TenantIDKey).(string); ok {
+					captured = v
+				}
+				w.WriteHeader(http.StatusOK)
+			})
 
 			req := httptest.NewRequest(http.MethodGet, "/v1/batches", nil)
 			for _, v := range tt.headerValues {
@@ -110,12 +111,12 @@ func TestRequestMiddleware_RequestID(t *testing.T) {
 
 	t.Run("preserves existing request ID", func(t *testing.T) {
 		var captured string
-		handler := RequestMiddleware(config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := wrapWithRequestMiddleware(config, func(w http.ResponseWriter, r *http.Request) {
 			if v, ok := r.Context().Value(common.RequestIDKey).(string); ok {
 				captured = v
 			}
 			w.WriteHeader(http.StatusOK)
-		}))
+		})
 
 		req := httptest.NewRequest(http.MethodGet, "/v1/batches", nil)
 		req.Header.Set(RequestIdHeaderKey, "my-request-id")
@@ -132,12 +133,12 @@ func TestRequestMiddleware_RequestID(t *testing.T) {
 
 	t.Run("generates request ID when absent", func(t *testing.T) {
 		var captured string
-		handler := RequestMiddleware(config)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := wrapWithRequestMiddleware(config, func(w http.ResponseWriter, r *http.Request) {
 			if v, ok := r.Context().Value(common.RequestIDKey).(string); ok {
 				captured = v
 			}
 			w.WriteHeader(http.StatusOK)
-		}))
+		})
 
 		req := httptest.NewRequest(http.MethodGet, "/v1/batches", nil)
 		w := httptest.NewRecorder()
@@ -154,31 +155,4 @@ func TestRequestMiddleware_RequestID(t *testing.T) {
 			t.Errorf("expected context request ID %q to match response header %q", captured, headerID)
 		}
 	})
-}
-
-func TestRequestMiddleware_SkipsMetricsAndHealth(t *testing.T) {
-	config := newTestConfig("X-MaaS-Username")
-	called := false
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		// If the middleware processed this, there would be a request ID in context.
-		// For skipped paths, the middleware delegates directly without enriching context.
-		if _, ok := r.Context().Value(common.RequestIDKey).(string); ok {
-			t.Error("expected no request ID in context for skipped path")
-		}
-		w.WriteHeader(http.StatusOK)
-	})
-
-	handler := RequestMiddleware(config)(inner)
-
-	for _, path := range []string{metrics.MetricsPath, health.HealthPath} {
-		called = false
-		req := httptest.NewRequest(http.MethodGet, path, nil)
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-
-		if !called {
-			t.Errorf("expected handler to be called for path %s", path)
-		}
-	}
 }

--- a/internal/apiserver/middleware/security_headers_middleware.go
+++ b/internal/apiserver/middleware/security_headers_middleware.go
@@ -19,11 +19,14 @@ package middleware
 
 import (
 	"net/http"
+
+	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/common"
 )
 
-func SecurityHeadersMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+// SecurityHeaders returns a RouteMiddleware that sets security headers
+// and handles CORS preflight requests.
+func SecurityHeaders(_ common.Route, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		// Security headers
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
@@ -35,6 +38,6 @@ func SecurityHeadersMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		next.ServeHTTP(w, r)
-	})
+		next(w, r)
+	}
 }

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -89,19 +89,22 @@ func New(ctx context.Context, config *common.ServerConfig) (*Server, error) {
 		return nil, err
 	}
 
-	// API mux: business endpoints only
+	// API mux: business endpoints with per-route middleware.
+	// Request flow:
+	//   Matched:   Client → ServeMux → Recovery → RequestMiddleware (+ OTel) → SecurityHeaders → Handler
+	//   Unmatched: Client → ServeMux → Recovery → RequestMiddleware → SecurityHeaders → NotFoundHandler
 	apiMux := http.NewServeMux()
 	fileHandler := file.NewFileAPIHandler(config, clients)
 	batchHandler := batch.NewBatchAPIHandler(config, clients)
-	for _, h := range []common.ApiHandler{fileHandler, batchHandler} {
-		common.RegisterHandler(apiMux, h)
+	apiMiddlewares := []common.RouteMiddleware{
+		middleware.Recovery,                     // outermost: catches panics from all inner layers
+		middleware.NewRequestMiddleware(config), // request ID, tenant, logging, metrics, OTel tracing
+		middleware.SecurityHeaders,              // innermost: security response headers
 	}
-
-	// apply middlewares to the API handler
-	var apiHandler http.Handler = apiMux
-	apiHandler = middleware.SecurityHeadersMiddleware(apiHandler)
-	apiHandler = middleware.RequestMiddleware(config)(apiHandler)
-	apiHandler = middleware.RecoveryMiddleware(apiHandler)
+	for _, h := range []common.ApiHandler{fileHandler, batchHandler} {
+		common.RegisterHandler(apiMux, h, apiMiddlewares...)
+	}
+	common.RegisterNotFoundHandler(apiMux, apiMiddlewares...)
 
 	// Observability mux: health, readiness, metrics (always plain HTTP)
 	obsMux := http.NewServeMux()
@@ -116,7 +119,7 @@ func New(ctx context.Context, config *common.ServerConfig) (*Server, error) {
 		config:      config,
 		logger:      logger,
 		serverReady: serverReady,
-		apiHandler:  apiHandler,
+		apiHandler:  apiMux,
 		obsHandler:  obsMux,
 		clients:     clients,
 	}, nil


### PR DESCRIPTION
The PR will fully support metrics described in [metrics.md](https://github.com/llm-d-incubation/batch-gateway/blob/main/docs/guides/metrics.md)

```
$ curl http://127.0.0.1:8081/metrics

# HELP http_request_duration_seconds HTTP request duration in seconds for the api server
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.005"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.01"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.025"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.05"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.1"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.25"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="0.5"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="1"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="2.5"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="5"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="10"} 1
http_request_duration_seconds_bucket{method="DELETE",path="/v1/files/{file_id}",status="200",le="+Inf"} 1
http_request_duration_seconds_sum{method="DELETE",path="/v1/files/{file_id}",status="200"} 0.001167806
http_request_duration_seconds_count{method="DELETE",path="/v1/files/{file_id}",status="200"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.005"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.01"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.025"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.05"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.1"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.25"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="0.5"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="1"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="2.5"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="5"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="10"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches",status="200",le="+Inf"} 4
http_request_duration_seconds_sum{method="GET",path="/v1/batches",status="200"} 0.002266821
http_request_duration_seconds_count{method="GET",path="/v1/batches",status="200"} 4
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.005"} 25
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.01"} 25
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.025"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.05"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.1"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.25"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="0.5"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="1"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="2.5"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="5"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="10"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="200",le="+Inf"} 26
http_request_duration_seconds_sum{method="GET",path="/v1/batches/{batch_id}",status="200"} 0.032490578
http_request_duration_seconds_count{method="GET",path="/v1/batches/{batch_id}",status="200"} 26
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.005"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.01"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.025"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.05"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.1"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.25"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="0.5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="1"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="2.5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="10"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/batches/{batch_id}",status="404",le="+Inf"} 1
http_request_duration_seconds_sum{method="GET",path="/v1/batches/{batch_id}",status="404"} 0.000240545
http_request_duration_seconds_count{method="GET",path="/v1/batches/{batch_id}",status="404"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.005"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.01"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.025"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.05"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.1"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.25"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="0.5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="1"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="2.5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="10"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files",status="200",le="+Inf"} 6
http_request_duration_seconds_sum{method="GET",path="/v1/files",status="200"} 0.005457486
http_request_duration_seconds_count{method="GET",path="/v1/files",status="200"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.005"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.01"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.025"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.05"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.1"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.25"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="0.5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="1"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="2.5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="5"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="10"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="200",le="+Inf"} 1
http_request_duration_seconds_sum{method="GET",path="/v1/files/{file_id}",status="200"} 0.000913553
http_request_duration_seconds_count{method="GET",path="/v1/files/{file_id}",status="200"} 1
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.005"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.01"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.025"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.05"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.1"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.25"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="0.5"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="1"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="2.5"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="5"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="10"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}",status="404",le="+Inf"} 2
http_request_duration_seconds_sum{method="GET",path="/v1/files/{file_id}",status="404"} 0.0006223
http_request_duration_seconds_count{method="GET",path="/v1/files/{file_id}",status="404"} 2
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.005"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.01"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.025"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.05"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.1"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.25"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="0.5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="1"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="2.5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="5"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="10"} 6
http_request_duration_seconds_bucket{method="GET",path="/v1/files/{file_id}/content",status="200",le="+Inf"} 6
http_request_duration_seconds_sum{method="GET",path="/v1/files/{file_id}/content",status="200"} 0.004274221999999999
http_request_duration_seconds_count{method="GET",path="/v1/files/{file_id}/content",status="200"} 6
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.005"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.01"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.025"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.05"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.1"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.25"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="0.5"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="1"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="2.5"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="5"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="10"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="200",le="+Inf"} 17
http_request_duration_seconds_sum{method="POST",path="/v1/batches",status="200"} 0.026802758
http_request_duration_seconds_count{method="POST",path="/v1/batches",status="200"} 17
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.005"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.01"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.025"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.05"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.1"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.25"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="0.5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="1"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="2.5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="10"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches",status="400",le="+Inf"} 1
http_request_duration_seconds_sum{method="POST",path="/v1/batches",status="400"} 0.000286921
http_request_duration_seconds_count{method="POST",path="/v1/batches",status="400"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.005"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.01"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.025"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.05"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.1"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.25"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="0.5"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="1"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="2.5"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="5"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="10"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="200",le="+Inf"} 2
http_request_duration_seconds_sum{method="POST",path="/v1/batches/{batch_id}/cancel",status="200"} 0.0034222519999999998
http_request_duration_seconds_count{method="POST",path="/v1/batches/{batch_id}/cancel",status="200"} 2
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.005"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.01"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.025"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.05"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.1"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.25"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="0.5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="1"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="2.5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="5"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="10"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/batches/{batch_id}/cancel",status="404",le="+Inf"} 1
http_request_duration_seconds_sum{method="POST",path="/v1/batches/{batch_id}/cancel",status="404"} 0.000304712
http_request_duration_seconds_count{method="POST",path="/v1/batches/{batch_id}/cancel",status="404"} 1
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.005"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.01"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.025"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.05"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.1"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.25"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="0.5"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="1"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="2.5"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="5"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="10"} 19
http_request_duration_seconds_bucket{method="POST",path="/v1/files",status="200",le="+Inf"} 19
http_request_duration_seconds_sum{method="POST",path="/v1/files",status="200"} 0.021636147
http_request_duration_seconds_count{method="POST",path="/v1/files",status="200"} 19
# HELP http_requests_in_flight Current number of HTTP requests being processed by the api server
# TYPE http_requests_in_flight gauge
http_requests_in_flight{method="DELETE",path="/v1/files/{file_id}"} 0
http_requests_in_flight{method="GET",path="/v1/batches"} 0
http_requests_in_flight{method="GET",path="/v1/batches/{batch_id}"} 0
http_requests_in_flight{method="GET",path="/v1/files"} 0
http_requests_in_flight{method="GET",path="/v1/files/{file_id}"} 0
http_requests_in_flight{method="GET",path="/v1/files/{file_id}/content"} 0
http_requests_in_flight{method="POST",path="/v1/batches"} 0
http_requests_in_flight{method="POST",path="/v1/batches/{batch_id}/cancel"} 0
http_requests_in_flight{method="POST",path="/v1/files"} 0
# HELP http_requests_total Total number of HTTP requests to the api server
# TYPE http_requests_total counter
http_requests_total{method="DELETE",path="/v1/files/{file_id}",status="200"} 1
http_requests_total{method="GET",path="/v1/batches",status="200"} 4
http_requests_total{method="GET",path="/v1/batches/{batch_id}",status="200"} 26
http_requests_total{method="GET",path="/v1/batches/{batch_id}",status="404"} 1
http_requests_total{method="GET",path="/v1/files",status="200"} 6
http_requests_total{method="GET",path="/v1/files/{file_id}",status="200"} 1
http_requests_total{method="GET",path="/v1/files/{file_id}",status="404"} 2
http_requests_total{method="GET",path="/v1/files/{file_id}/content",status="200"} 6
http_requests_total{method="POST",path="/v1/batches",status="200"} 17
http_requests_total{method="POST",path="/v1/batches",status="400"} 1
http_requests_total{method="POST",path="/v1/batches/{batch_id}/cancel",status="200"} 2
http_requests_total{method="POST",path="/v1/batches/{batch_id}/cancel",status="404"} 1
http_requests_total{method="POST",path="/v1/files",status="200"} 19
```