### PR TITLE
feat: expose redis client config via helm values

### DIFF
--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -19,6 +19,17 @@ data:
     write_timeout_seconds: {{ .Values.apiserver.config.writeTimeoutSeconds }}
     idle_timeout_seconds: {{ .Values.apiserver.config.idleTimeoutSeconds }}
     database_type: {{ .Values.global.databaseType | quote }}
+    redis:
+      db_idx: {{ .Values.global.redis.dbIdx }}
+      enable_tls: {{ .Values.global.redis.enableTLS }}
+      insecure: {{ .Values.global.redis.insecure }}
+      timeout: {{ .Values.global.redis.timeout | quote }}
+      max_retries: {{ .Values.global.redis.maxRetries }}
+      min_retry_backoff: {{ .Values.global.redis.minRetryBackoff | quote }}
+      max_retry_backoff: {{ .Values.global.redis.maxRetryBackoff | quote }}
+      pool_timeout: {{ .Values.global.redis.poolTimeout | quote }}
+      conn_max_idle_time: {{ .Values.global.redis.connMaxIdleTime | quote }}
+      conn_max_lifetime: {{ .Values.global.redis.connMaxLifetime | quote }}
     file_client:
       type: {{ .Values.global.fileClient.type | quote }}
       fs:

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -21,6 +21,17 @@ data:
     work_dir: {{ .Values.processor.config.workDir | quote }}
 
     database_type: {{ .Values.global.databaseType | quote }}
+    redis:
+      db_idx: {{ .Values.global.redis.dbIdx }}
+      enable_tls: {{ .Values.global.redis.enableTLS }}
+      insecure: {{ .Values.global.redis.insecure }}
+      timeout: {{ .Values.global.redis.timeout | quote }}
+      max_retries: {{ .Values.global.redis.maxRetries }}
+      min_retry_backoff: {{ .Values.global.redis.minRetryBackoff | quote }}
+      max_retry_backoff: {{ .Values.global.redis.maxRetryBackoff | quote }}
+      pool_timeout: {{ .Values.global.redis.poolTimeout | quote }}
+      conn_max_idle_time: {{ .Values.global.redis.connMaxIdleTime | quote }}
+      conn_max_lifetime: {{ .Values.global.redis.connMaxLifetime | quote }}
 
     model_gateways:
       {{- range $model, $cfg := .Values.processor.config.modelGateways }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -15,6 +15,21 @@ global:
   # Database backend type: "redis", or "postgresql"
   databaseType: "postgresql"
 
+  # Redis client settings (shared by apiserver and processor).
+  # The connection URL is read from the app secret (redis-url key), not from here.
+  # 0 (or "0s") means go-redis library default.
+  redis:
+    dbIdx: 0
+    enableTLS: false
+    insecure: false
+    timeout: "0s"
+    maxRetries: 0
+    minRetryBackoff: "0s"
+    maxRetryBackoff: "0s"
+    poolTimeout: "0s"
+    connMaxIdleTime: "0s"
+    connMaxLifetime: "0s"
+
   # OpenTelemetry configuration
   otel:
     # OTLP gRPC endpoint (e.g. "http://jaeger.default.svc.cluster.local:4317")

--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/util/interrupt"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
 	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
-	uredis "github.com/llm-d-incubation/batch-gateway/internal/util/redis"
 )
 
 func main() {
@@ -263,10 +262,8 @@ func waitObservabilityFatalError(ctx context.Context, obsFatalCh <-chan error, w
 func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*clientset.Clientset, error) {
 	logger := klog.FromContext(ctx)
 
-	redisCfg := &uredis.RedisClientConfig{
-		ServiceName:   "batch-processor",
-		EnableTracing: cfg.OTel.RedisTracing,
-	}
+	cfg.RedisCfg.ServiceName = "batch-processor"
+	cfg.RedisCfg.EnableTracing = cfg.OTel.RedisTracing
 
 	modelGatewaysConfigs, err := config.ResolveModelGateways(cfg.ModelGateways)
 	if err != nil {
@@ -278,7 +275,7 @@ func buildProcessorClients(ctx context.Context, cfg *config.ProcessorConfig) (*c
 		ctx,
 		cfg.DatabaseType,
 		&cfg.PostgreSQLCfg,
-		redisCfg,
+		&cfg.RedisCfg,
 		cfg.FileClientCfg.Type,
 		&cfg.FileClientCfg.FSConfig,
 		&cfg.FileClientCfg.S3Config,

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/database/postgresql"
 	fsclient "github.com/llm-d-incubation/batch-gateway/internal/files_store/fs"
 	s3client "github.com/llm-d-incubation/batch-gateway/internal/files_store/s3"
+	uredis "github.com/llm-d-incubation/batch-gateway/internal/util/redis"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
@@ -130,6 +131,10 @@ type ServerConfig struct {
 
 	// PostgreSQLCfg holds PostgreSQL connection settings (used when DatabaseType is "postgresql").
 	PostgreSQLCfg postgresql.PostgreSQLConfig `yaml:"postgresql"`
+
+	// RedisCfg holds Redis client settings (timeouts, retries, pool, TLS).
+	// URL, ServiceName, EnableTracing, and Certificates are set at runtime, not from YAML.
+	RedisCfg uredis.RedisClientConfig `yaml:"redis"`
 
 	// OTel holds OpenTelemetry-related settings.
 	OTel struct {

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -34,7 +34,6 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/middleware"
 	"github.com/llm-d-incubation/batch-gateway/internal/apiserver/readiness"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
-	uredis "github.com/llm-d-incubation/batch-gateway/internal/util/redis"
 	"k8s.io/klog/v2"
 )
 
@@ -50,18 +49,15 @@ type Server struct {
 func buildClients(ctx context.Context, config *common.ServerConfig) (*clientset.Clientset, error) {
 	logger := klog.FromContext(ctx)
 
-	redisCfg := &uredis.RedisClientConfig{
-		ServiceName:   "batch-apiserver",
-		EnableTracing: config.OTel.RedisTracing,
-	}
-
+	config.RedisCfg.ServiceName = "batch-apiserver"
+	config.RedisCfg.EnableTracing = config.OTel.RedisTracing
 	config.PostgreSQLCfg.EnableTracing = config.OTel.PostgresqlTracing
 
 	clients, err := clientset.NewClientset(
 		ctx,
 		config.DatabaseType,
 		&config.PostgreSQLCfg,
-		redisCfg,
+		&config.RedisCfg,
 		config.FileClientCfg.Type,
 		&config.FileClientCfg.FSConfig,
 		&config.FileClientCfg.S3Config,

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -27,6 +27,7 @@ import (
 	fsclient "github.com/llm-d-incubation/batch-gateway/internal/files_store/fs"
 	s3client "github.com/llm-d-incubation/batch-gateway/internal/files_store/s3"
 	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
+	uredis "github.com/llm-d-incubation/batch-gateway/internal/util/redis"
 	inference "github.com/llm-d-incubation/batch-gateway/pkg/clients/inference"
 	"gopkg.in/yaml.v3"
 )
@@ -88,6 +89,10 @@ type ProcessorConfig struct {
 
 	// ProgressTTLSeconds is the TTL for temporary progress updates in the status store (Redis).
 	ProgressTTLSeconds int `yaml:"progress_ttl_seconds"`
+
+	// RedisCfg holds Redis client settings (timeouts, retries, pool, TLS).
+	// URL, ServiceName, EnableTracing, and Certificates are set at runtime, not from YAML.
+	RedisCfg uredis.RedisClientConfig `yaml:"redis"`
 
 	// OTel holds OpenTelemetry-related settings.
 	OTel struct {

--- a/internal/util/redis/redis_client.go
+++ b/internal/util/redis/redis_client.go
@@ -39,20 +39,20 @@ const (
 )
 
 type RedisClientConfig struct {
-	Url             string
-	DbIdx           int
-	EnableTLS       bool
-	Insecure        bool
-	Certificates    *utls.Certificates
-	EnableTracing   bool
-	ServiceName     string
-	Timeout         time.Duration // Timeout for socket operations: dial, read, write.
-	MaxRetries      int           // Maximum number of retries before giving up. Default is 3 retries; -1 (not 0) disables retries.
-	MinRetryBackoff time.Duration // Minimum backoff between each retry. Default is 8 milliseconds; -1 disables backoff.
-	MaxRetryBackoff time.Duration // Maximum backoff between each retry. Default is 512 milliseconds; -1 disables backoff.
-	PoolTimeout     time.Duration // Amount of time client waits for connection if all connections are busy before returning an error. Default is ReadTimeout + 1 second.
-	ConnMaxIdleTime time.Duration // The maximum amount of time a connection may be idle. If <= 0, connections are not closed due to a connection's idle time. Default is 30 minutes. -1 disables idle timeout check.
-	ConnMaxLifetime time.Duration // The maximum amount of time a connection may be reused. If <= 0, connections are not closed due to a connection's age. Default is to not close idle connections.
+	Url             string             `yaml:"-"` // Resolved from K8s Secret at runtime
+	Certificates    *utls.Certificates `yaml:"-"` // Set programmatically for mTLS
+	EnableTracing   bool               `yaml:"-"` // Set from OTel config
+	ServiceName     string             `yaml:"-"` // Set per component (e.g. "batch-apiserver")
+	DbIdx           int                `yaml:"db_idx"`
+	EnableTLS       bool               `yaml:"enable_tls"`
+	Insecure        bool               `yaml:"insecure"`
+	Timeout         time.Duration      `yaml:"timeout"`            // Timeout for socket operations: dial, read, write.
+	MaxRetries      int                `yaml:"max_retries"`        // Maximum number of retries before giving up. Default is 3 retries; -1 (not 0) disables retries.
+	MinRetryBackoff time.Duration      `yaml:"min_retry_backoff"`  // Minimum backoff between each retry. Default is 8 milliseconds; -1 disables backoff.
+	MaxRetryBackoff time.Duration      `yaml:"max_retry_backoff"`  // Maximum backoff between each retry. Default is 512 milliseconds; -1 disables backoff.
+	PoolTimeout     time.Duration      `yaml:"pool_timeout"`       // Amount of time client waits for connection if all connections are busy before returning an error. Default is ReadTimeout + 1 second.
+	ConnMaxIdleTime time.Duration      `yaml:"conn_max_idle_time"` // The maximum amount of time a connection may be idle. If <= 0, connections are not closed due to a connection's idle time. Default is 30 minutes. -1 disables idle timeout check.
+	ConnMaxLifetime time.Duration      `yaml:"conn_max_lifetime"`  // The maximum amount of time a connection may be reused. If <= 0, connections are not closed due to a connection's age. Default is to not close idle connections.
 }
 
 func NewRedisClient(ctx context.Context, cnf *RedisClientConfig) (*gredis.Client, error) {


### PR DESCRIPTION
The PR will expose redis client config via helm values. so user can specify them during install. 

```
========== E2E Test Summary ==========
--- PASS: TestE2E (17.55s)
    --- PASS: TestE2E/Files (0.03s)
        --- PASS: TestE2E/Files/Lifecycle (0.02s)
        --- PASS: TestE2E/Files/List (0.01s)
            --- PASS: TestE2E/Files/List/Pagination (0.01s)
            --- PASS: TestE2E/Files/List/PurposeFilter (0.00s)
    --- PASS: TestE2E/Batches (10.33s)
        --- PASS: TestE2E/Batches/Lifecycle (2.02s)
        --- PASS: TestE2E/Batches/List (0.02s)
            --- PASS: TestE2E/Batches/List/Pagination (0.02s)
        --- PASS: TestE2E/Batches/Cancel (2.11s)
            --- PASS: TestE2E/Batches/Cancel/BeforeProcessing (0.01s)
            --- PASS: TestE2E/Batches/Cancel/InProgress (2.10s)
        --- PASS: TestE2E/Batches/MixedSuccessFailure (2.01s)
        --- PASS: TestE2E/Batches/SharedInputFile (2.04s)
        --- PASS: TestE2E/Batches/PassThroughHeaders (2.13s)
    --- PASS: TestE2E/Concurrent (2.03s)
        --- PASS: TestE2E/Concurrent/MultipleBatches (2.03s)
    --- PASS: TestE2E/MultiTenant (0.02s)
        --- PASS: TestE2E/MultiTenant/Isolation (0.02s)
    --- PASS: TestE2E/Observability (5.06s)
        --- PASS: TestE2E/Observability/APIServer (0.01s)
            --- PASS: TestE2E/Observability/APIServer/health (0.00s)
            --- PASS: TestE2E/Observability/APIServer/ready (0.00s)
            --- PASS: TestE2E/Observability/APIServer/metrics (0.01s)
        --- PASS: TestE2E/Observability/Processor (0.01s)
            --- PASS: TestE2E/Observability/Processor/health (0.00s)
            --- PASS: TestE2E/Observability/Processor/ready (0.00s)
            --- PASS: TestE2E/Observability/Processor/metrics (0.01s)
        --- PASS: TestE2E/Observability/OtelTraces (5.03s)

Passed: 30 | Failed: 0 | Skipped: 0

✅ All E2E tests passed!
```