### PR TITLE
fix: validate custom_id during batch ingestion

### DIFF
--- a/internal/processor/worker/planner.go
+++ b/internal/processor/worker/planner.go
@@ -31,7 +31,8 @@ import (
 const modelMapFileName = "model_map.json"
 
 type planRequestLine struct {
-	Body struct {
+	CustomID string `json:"custom_id"`
+	Body     struct {
 		Model    string `json:"model"`
 		Stream   *bool  `json:"stream,omitempty"`
 		Messages []struct {

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -92,6 +92,8 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	used := make(map[string]int)           // to prevent duplicate model IDs
 	modelToSafe := make(map[string]string) // to map the model ID to a safe file name
 
+	seenCustomIDs := make(map[string]struct{})
+
 	// streaming loop
 	var offset int64
 	var lineCount int64 // to count the number of lines in the input file for logging
@@ -129,15 +131,21 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 			return err
 		}
 
-		// extract model ID and prefix hash from the request line
-		modelID, prefixHash, err := extractModelAndPrefixHash(line)
+		requestMeta, err := extractAndValidateLine(line)
 		if err != nil {
-			logger.V(logging.ERROR).Error(err, "Failed to unmarshal request line", "lineCount", lineCount)
+			logger.V(logging.ERROR).Error(err, "Failed to validate request line", "lineCount", lineCount)
 			return err
 		}
 
+		if _, exists := seenCustomIDs[requestMeta.CustomID]; exists {
+			err := fmt.Errorf("line %d: duplicate custom_id %q", lineCount, requestMeta.CustomID)
+			logger.V(logging.ERROR).Error(err, "Duplicate custom_id in batch input")
+			return err
+		}
+		seenCustomIDs[requestMeta.CustomID] = struct{}{}
+
 		nextOffset := accumulatePlanEntry(
-			acc, modelID, modelToSafe, used, offset, uint32(len(line)), prefixHash,
+			acc, requestMeta.ModelID, modelToSafe, used, offset, uint32(len(line)), requestMeta.PrefixHash,
 		)
 		offset = nextOffset
 	}
@@ -197,20 +205,28 @@ func readNormalizedLine(r *bufio.Reader) ([]byte, bool, error) {
 	return line, false, nil
 }
 
-// extractModelAndPrefixHash parses a request line and returns the model ID
-// and a FNV-32a hash of the first system prompt's content (NoPrefixHash if absent).
-func extractModelAndPrefixHash(line []byte) (string, uint32, error) {
+type requestMeta struct {
+	CustomID   string
+	ModelID    string
+	PrefixHash uint32
+}
+
+// extractAndValidateLine parses and validates a request line and returns the
+// metadata needed during ingestion.
+func extractAndValidateLine(line []byte) (requestMeta, error) {
 	var req planRequestLine
 	trimmedLine := bytes.TrimSuffix(line, []byte{'\n'})
 	if err := json.Unmarshal(trimmedLine, &req); err != nil {
-		return "", NoPrefixHash, err
+		return requestMeta{}, err
 	}
-	modelID := req.Body.Model
-	if modelID == "" {
-		return "", NoPrefixHash, fmt.Errorf("model id is empty")
+	if req.CustomID == "" {
+		return requestMeta{}, fmt.Errorf("custom_id is required")
+	}
+	if req.Body.Model == "" {
+		return requestMeta{}, fmt.Errorf("model id is empty")
 	}
 	if req.Body.Stream != nil && *req.Body.Stream {
-		return "", NoPrefixHash, fmt.Errorf("streaming is not supported in batch requests (model: %s)", modelID)
+		return requestMeta{}, fmt.Errorf("streaming is not supported in batch requests (model: %s)", req.Body.Model)
 	}
 
 	prefixHash := NoPrefixHash
@@ -223,7 +239,11 @@ func extractModelAndPrefixHash(line []byte) (string, uint32, error) {
 		}
 	}
 
-	return modelID, prefixHash, nil
+	return requestMeta{
+		CustomID:   req.CustomID,
+		ModelID:    req.Body.Model,
+		PrefixHash: prefixHash,
+	}, nil
 }
 
 func writeModelMappings(jobRootDir string, modelToSafe map[string]string, lineCount int64) error {

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -790,9 +790,9 @@ func TestRunPollingLoop_NotRunnableJob_SkipsWithoutStatusUpdate(t *testing.T) {
 // stream: true rejection
 // ---------------------------------------------------------------------------
 
-func TestExtractModelAndPrefixHash_StreamTrue_ReturnsError(t *testing.T) {
-	line := []byte(`{"body":{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	_, _, err := extractModelAndPrefixHash(line)
+func TestExtractAndValidateLine_StreamTrue_ReturnsError(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","body":{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
+	_, err := extractAndValidateLine(line)
 	if err == nil {
 		t.Fatal("expected error for stream: true, got nil")
 	}
@@ -801,25 +801,50 @@ func TestExtractModelAndPrefixHash_StreamTrue_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestExtractModelAndPrefixHash_StreamFalse_OK(t *testing.T) {
-	line := []byte(`{"body":{"model":"gpt-4","stream":false,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	model, _, err := extractModelAndPrefixHash(line)
+func TestExtractAndValidateLine_StreamFalse_OK(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","body":{"model":"gpt-4","stream":false,"messages":[{"role":"user","content":"hi"}]}}` + "\n")
+	meta, err := extractAndValidateLine(line)
 	if err != nil {
 		t.Fatalf("unexpected error for stream: false: %v", err)
 	}
-	if model != "gpt-4" {
-		t.Fatalf("expected model gpt-4, got %s", model)
+	if meta.ModelID != "gpt-4" {
+		t.Fatalf("expected model gpt-4, got %s", meta.ModelID)
+	}
+	if meta.CustomID != "r1" {
+		t.Fatalf("expected custom_id r1, got %s", meta.CustomID)
 	}
 }
 
-func TestExtractModelAndPrefixHash_StreamOmitted_OK(t *testing.T) {
-	line := []byte(`{"body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
-	model, _, err := extractModelAndPrefixHash(line)
+func TestExtractAndValidateLine_StreamOmitted_OK(t *testing.T) {
+	line := []byte(`{"custom_id":"r1","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
+	meta, err := extractAndValidateLine(line)
 	if err != nil {
 		t.Fatalf("unexpected error when stream is omitted: %v", err)
 	}
-	if model != "gpt-4" {
-		t.Fatalf("expected model gpt-4, got %s", model)
+	if meta.ModelID != "gpt-4" {
+		t.Fatalf("expected model gpt-4, got %s", meta.ModelID)
+	}
+}
+
+func TestExtractAndValidateLine_EmptyCustomID_ReturnsError(t *testing.T) {
+	line := []byte(`{"custom_id":"","body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
+	_, err := extractAndValidateLine(line)
+	if err == nil {
+		t.Fatal("expected error for empty custom_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "custom_id is required") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestExtractAndValidateLine_MissingCustomID_ReturnsError(t *testing.T) {
+	line := []byte(`{"body":{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}}` + "\n")
+	_, err := extractAndValidateLine(line)
+	if err == nil {
+		t.Fatal("expected error for missing custom_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "custom_id is required") {
+		t.Fatalf("unexpected error message: %v", err)
 	}
 }
 
@@ -841,9 +866,9 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 	cleanMockFilesFolder(t, folder)
 
 	var remoteBuf bytes.Buffer
-	remoteBuf.WriteString(`{"body":{"model":"m1","messages":[{"role":"user","content":"ok"}]}}` + "\n")
-	remoteBuf.WriteString(`{"body":{"model":"m1","stream":true,"messages":[{"role":"user","content":"bad"}]}}` + "\n")
-	remoteBuf.WriteString(`{"body":{"model":"m1","messages":[{"role":"user","content":"ok2"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"r1","body":{"model":"m1","messages":[{"role":"user","content":"ok"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"r2","body":{"model":"m1","stream":true,"messages":[{"role":"user","content":"bad"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"r3","body":{"model":"m1","messages":[{"role":"user","content":"ok2"}]}}` + "\n")
 
 	filename := "input.jsonl"
 	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
@@ -889,5 +914,142 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "streaming is not supported") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
+	ctx := testLoggerCtx()
+
+	workDir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.WorkDir = workDir
+	dbClient := newMockBatchDBClient()
+	fileDBClient := newMockFileDBClient()
+	filesClient := mockfiles.NewMockBatchFilesClient()
+
+	tenantID := uniqueTestFolder(t, "tenantA/dup-custom-id")
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	cleanMockFilesFolder(t, folder)
+
+	var remoteBuf bytes.Buffer
+	remoteBuf.WriteString(`{"custom_id":"req-1","body":{"model":"m1","messages":[{"role":"user","content":"a"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"req-2","body":{"model":"m1","messages":[{"role":"user","content":"b"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"req-1","body":{"model":"m1","messages":[{"role":"user","content":"c"}]}}` + "\n")
+
+	filename := "input.jsonl"
+	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
+
+	inputFileID := "file-dup-custom-id"
+	fileSpec := &openai.FileObject{Filename: filename}
+	fileItem := &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: mustJSON(t, fileSpec)},
+	}
+	if err := fileDBClient.DBStore(ctx, fileItem); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  fileDBClient,
+		File:    filesClient,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	jobID := "job-dup-custom-id"
+	jobInfo := &batch_types.JobInfo{
+		JobID: jobID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{
+				Status: openai.BatchStatusInProgress,
+			},
+		},
+		TenantID: tenantID,
+	}
+
+	var cancelRequested atomic.Bool
+	err = p.preProcessJob(ctx, jobInfo, &cancelRequested)
+	if err == nil {
+		t.Fatal("expected preProcessJob to fail for duplicate custom_id")
+	}
+	if !strings.Contains(err.Error(), "duplicate custom_id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "req-1") {
+		t.Fatalf("error should mention the duplicated custom_id value: %v", err)
+	}
+}
+
+func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
+	ctx := testLoggerCtx()
+
+	workDir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.WorkDir = workDir
+	dbClient := newMockBatchDBClient()
+	fileDBClient := newMockFileDBClient()
+	filesClient := mockfiles.NewMockBatchFilesClient()
+
+	tenantID := uniqueTestFolder(t, "tenantA/unique-custom-id")
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	cleanMockFilesFolder(t, folder)
+
+	var remoteBuf bytes.Buffer
+	remoteBuf.WriteString(`{"custom_id":"req-1","body":{"model":"m1","messages":[{"role":"user","content":"a"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"req-2","body":{"model":"m1","messages":[{"role":"user","content":"b"}]}}` + "\n")
+	remoteBuf.WriteString(`{"custom_id":"req-3","body":{"model":"m1","messages":[{"role":"user","content":"c"}]}}` + "\n")
+
+	filename := "input.jsonl"
+	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
+
+	inputFileID := "file-unique-custom-id"
+	fileSpec := &openai.FileObject{Filename: filename}
+	fileItem := &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: mustJSON(t, fileSpec)},
+	}
+	if err := fileDBClient.DBStore(ctx, fileItem); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  fileDBClient,
+		File:    filesClient,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	jobID := "job-unique-custom-id"
+	jobInfo := &batch_types.JobInfo{
+		JobID: jobID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{
+				Status: openai.BatchStatusInProgress,
+			},
+		},
+		TenantID: tenantID,
+	}
+
+	var cancelRequested atomic.Bool
+	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+		t.Fatalf("expected preProcessJob to succeed with unique custom_ids, got: %v", err)
 	}
 }

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -496,10 +496,8 @@ func planEntriesFromLines(raw []byte) []planEntry {
 func makeInputLines(models []string) [][]byte {
 	lines := make([][]byte, 0, len(models))
 	for i, m := range models {
-		// preProcessJob expects:
-		// { "body": { "model": "..." ... }, ... }
-		// It only reads body.model.
 		req := map[string]any{
+			"custom_id": fmt.Sprintf("req-%d", i),
 			"body": map[string]any{
 				"model": m,
 			},
@@ -508,7 +506,6 @@ func makeInputLines(models []string) [][]byte {
 			},
 		}
 		b, _ := json.Marshal(req)
-		// Intentionally vary newline handling: add '\n' here; preProcess also appends if missing.
 		b = append(b, '\n')
 		lines = append(lines, b)
 	}
@@ -530,7 +527,11 @@ func makeInputLinesWithSystemPrompts(specs []inputLineSpec) [][]byte {
 				{"role": "user", "content": fmt.Sprintf("question %d", i)},
 			}
 		}
-		req := map[string]any{"body": body, "meta": map[string]any{"i": i}}
+		req := map[string]any{
+			"custom_id": fmt.Sprintf("req-%d", i),
+			"body":      body,
+			"meta":      map[string]any{"i": i},
+		}
 		b, _ := json.Marshal(req)
 		lines = append(lines, append(b, '\n'))
 	}


### PR DESCRIPTION
Reject batch requests that omit custom_id or reuse the same custom_id within a single batch so ingestion matches OpenAI Batch API behavior and preserves reliable output correlation.

Closes #147