### PR TITLE
feat: support load API key from configurable file

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -45,6 +45,9 @@ data:
         {{- if $cfg.apiKeyName }}
         api_key_name: {{ $cfg.apiKeyName | quote }}
         {{- end }}
+        {{- if $cfg.apiKeyFile }}
+        api_key_file: {{ $cfg.apiKeyFile | quote }}
+        {{- end }}
         {{- if $cfg.tlsCaCertFile }}
         tls_ca_cert_file: {{ $cfg.tlsCaCertFile | quote }}
         {{- end }}

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -44,6 +44,7 @@ model_gateways:
     # tls_client_key_file: "/path/to/client-key.pem"
   # Per-model entries (optional). Each entry must be fully specified —
   # all HTTP fields are required and are NOT inherited from "default".
+  # api_key_name and api_key_file are mutually exclusive.
   # "llama-3":
   #   url: "http://gateway-a:8000"
   #   request_timeout: "5m"
@@ -52,11 +53,18 @@ model_gateways:
   #   max_backoff: "60s"
   # "mistral":
   #   url: "http://gateway-b:8000"
-  #   api_key_name: "gateway-b-api-key"
+  #   api_key_name: "gateway-b-api-key"  # reads from /etc/.secrets/gateway-b-api-key
   #   request_timeout: "2m"
   #   max_retries: 1
   #   initial_backoff: "1s"
   #   max_backoff: "30s"
+  # "granite":
+  #   url: "http://gateway-c:8000"
+  #   api_key_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"  # reads from arbitrary file path
+  #   request_timeout: "5m"
+  #   max_retries: 3
+  #   initial_backoff: "1s"
+  #   max_backoff: "60s"
 
 # Default TTL for output/error files in seconds (0 = no expiration).
 # Used as fallback when the user does not provide output_expires_after in POST /v1/batches.

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -21,6 +21,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/database/postgresql"
@@ -121,8 +122,12 @@ const DefaultModelGatewayKey = "default"
 // ModelGatewayConfig describes the full gateway and HTTP/TLS settings for one
 // model (or the default fallback). Every entry in model_gateways must be
 // self-contained — there is no inheritance from the "default" entry.
-// api_key_name is the key name under /etc/.secrets/; empty means use the
-// default inference-api-key secret.
+//
+// API key resolution (mutually exclusive, first match wins):
+//   - api_key_file: read the token/key from an arbitrary file path
+//     (e.g. /var/run/secrets/kubernetes.io/serviceaccount/token).
+//   - api_key_name: key name under /etc/.secrets/ (mounted Kubernetes secret).
+//   - (neither set on "default"): falls back to the mounted inference-api-key secret.
 //
 // TODO: If per-model partial overrides (inherit unset fields from "default")
 // are needed in the future, introduce a separate ModelOverrideConfig type with
@@ -130,6 +135,7 @@ const DefaultModelGatewayKey = "default"
 type ModelGatewayConfig struct {
 	URL        string `yaml:"url"`
 	APIKeyName string `yaml:"api_key_name"`
+	APIKeyFile string `yaml:"api_key_file"`
 
 	RequestTimeout time.Duration `yaml:"request_timeout"`
 	MaxRetries     int           `yaml:"max_retries"`
@@ -276,6 +282,14 @@ func (c *ProcessorConfig) Validate() error {
 		if gw.MaxBackoff < gw.InitialBackoff {
 			return fmt.Errorf("model_gateways[%s].max_backoff must be >= initial_backoff", model)
 		}
+		if gw.APIKeyName != "" && gw.APIKeyFile != "" {
+			return fmt.Errorf("model_gateways[%s]: api_key_name and api_key_file are mutually exclusive", model)
+		}
+		if gw.APIKeyFile != "" {
+			if _, err := os.Stat(gw.APIKeyFile); err != nil {
+				return fmt.Errorf("model_gateways[%s].api_key_file: %w", model, err)
+			}
+		}
 		if (gw.TLSClientCertFile == "") != (gw.TLSClientKeyFile == "") {
 			return fmt.Errorf("model_gateways[%s]: tls_client_cert_file and tls_client_key_file must both be set or both be empty", model)
 		}
@@ -323,7 +337,14 @@ func ResolveModelGateways(gateways map[string]ModelGatewayConfig) (map[string]in
 	resolved := make(map[string]inference.GatewayClientConfig, len(gateways))
 	for model, gw := range gateways {
 		apiKey := ""
-		if gw.APIKeyName != "" {
+		switch {
+		case gw.APIKeyFile != "":
+			data, err := os.ReadFile(gw.APIKeyFile)
+			if err != nil {
+				return nil, fmt.Errorf("read API key file for model %q: %w", model, err)
+			}
+			apiKey = strings.TrimSpace(string(data))
+		case gw.APIKeyName != "":
 			key, err := ucom.ReadSecretFile(gw.APIKeyName)
 			if err != nil {
 				return nil, fmt.Errorf("read API key for model %q: %w", model, err)

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -123,6 +123,74 @@ func TestProcessorConfig_Validate_MissingDefaultGateway(t *testing.T) {
 	}
 }
 
+func TestProcessorConfig_Validate_APIKeyFile(t *testing.T) {
+	t.Run("name_and_file_mutually_exclusive", func(t *testing.T) {
+		c := NewConfig()
+		gw := c.ModelGateways[DefaultModelGatewayKey]
+		gw.APIKeyName = "my-key"
+		gw.APIKeyFile = "/some/file"
+		c.ModelGateways[DefaultModelGatewayKey] = gw
+		if err := c.Validate(); err == nil {
+			t.Fatal("Validate() expected error when both api_key_name and api_key_file are set, got nil")
+		}
+	})
+
+	t.Run("file_not_found", func(t *testing.T) {
+		c := NewConfig()
+		gw := c.ModelGateways[DefaultModelGatewayKey]
+		gw.APIKeyFile = "/nonexistent/path/to/key"
+		c.ModelGateways[DefaultModelGatewayKey] = gw
+		if err := c.Validate(); err == nil {
+			t.Fatal("Validate() expected error when api_key_file does not exist, got nil")
+		}
+	})
+
+	t.Run("valid_file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFile := filepath.Join(dir, "token")
+		if err := os.WriteFile(keyFile, []byte("my-secret-token"), 0o600); err != nil {
+			t.Fatalf("failed to write key file: %v", err)
+		}
+
+		c := NewConfig()
+		gw := c.ModelGateways[DefaultModelGatewayKey]
+		gw.APIKeyFile = keyFile
+		c.ModelGateways[DefaultModelGatewayKey] = gw
+		if err := c.Validate(); err != nil {
+			t.Fatalf("Validate() unexpected error with valid api_key_file: %v", err)
+		}
+	})
+
+	t.Run("resolve_reads_and_trims_file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyFile := filepath.Join(dir, "token")
+		if err := os.WriteFile(keyFile, []byte("  file-based-token  \n"), 0o600); err != nil {
+			t.Fatalf("failed to write key file: %v", err)
+		}
+
+		gateways := map[string]ModelGatewayConfig{
+			DefaultModelGatewayKey: {
+				URL:            "http://gateway:8000",
+				APIKeyFile:     keyFile,
+				RequestTimeout: 5 * time.Minute,
+				MaxRetries:     3,
+				InitialBackoff: 1 * time.Second,
+				MaxBackoff:     60 * time.Second,
+			},
+		}
+
+		resolved, err := ResolveModelGateways(gateways)
+		if err != nil {
+			t.Fatalf("ResolveModelGateways() error: %v", err)
+		}
+
+		got := resolved[DefaultModelGatewayKey].APIKey
+		if got != "file-based-token" {
+			t.Fatalf("APIKey = %q, want %q", got, "file-based-token")
+		}
+	})
+}
+
 func TestProcessorConfig_Validate_GatewayTLSPartialConfigRejected(t *testing.T) {
 	c := NewConfig()
 	gw := c.ModelGateways[DefaultModelGatewayKey]


### PR DESCRIPTION
## Why is this PR needed?
Currently, the processor retrieves the API key from a specific key (inference-api-key) within a mounted secret. The PR introduce an additional option that allows the processor to read the API key (or token) from a local file path.

## What does this PR do?

Add `api_key_file` option to `ModelGatewayConfig`, allowing the processor to read API keys from specified file paths (e.g.  service account tokens). Mutually exclusive with the existing `api_key_name` option.

## How was this tested?
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues
https://github.com/llm-d-incubation/batch-gateway/issues/90
