### PR TITLE
fix: reduce list files default limit from 10000 to 20

### DIFF
--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	defaultListFilesLimit = 10000
+	defaultListFilesLimit = 20
 	maxListFilesLimit     = 10000
 )
 
@@ -381,7 +381,7 @@ func (c *FileAPIHandler) ListFiles(w http.ResponseWriter, r *http.Request) {
 		start = parsedStart
 	}
 
-	// Validate and parse limit (default: 10000, range: 1-10000)
+	// Validate and parse limit (default: 20, range: 1-10000)
 	limit := defaultListFilesLimit
 	if limitStr != "" {
 		parsedLimit, err := strconv.Atoi(limitStr)


### PR DESCRIPTION
## Why is this PR needed?
`GET /v1/files` defaults to `limit=10000`, which can return an excessively large response and cause performance issues. OpenAI's list endpoints typically default to 20 items per page.
## What does this PR do?
Changes `defaultListFilesLimit` from 10,000 to 20 in the list files handler, aligning with the OpenAI convention and the batch list endpoint default. The max limit (10,000) remains unchanged.
## How was this tested?
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed
## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)
## Related Issues
Fixes #151