### PR TITLE
fix: clean up empty directories after GC deletes expired files (#173)

### DIFF
--- a/internal/files_store/fs/client.go
+++ b/internal/files_store/fs/client.go
@@ -85,15 +85,26 @@ func New(basePath string) (*Client, error) {
 }
 
 // resolvePath returns the relative path within the root.
-func (c *Client) resolvePath(folderName, fileName string) string {
-	return filepath.Join(folderName, fileName)
+// Both folderName and fileName must be non-empty to prevent operations
+// directly on the root directory.
+func (c *Client) resolvePath(folderName, fileName string) (string, error) {
+	if folderName == "" {
+		return "", fmt.Errorf("folderName must not be empty")
+	}
+	if fileName == "" {
+		return "", fmt.Errorf("fileName must not be empty")
+	}
+	return filepath.Join(folderName, fileName), nil
 }
 
 // Store stores a file in the filesystem.
 func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSizeLimit, lineNumLimit int64, reader io.Reader) (
 	*api.BatchFileMetadata, error,
 ) {
-	relPath := c.resolvePath(folderName, fileName)
+	relPath, err := c.resolvePath(folderName, fileName)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err := c.root.Stat(relPath); err == nil {
 		return nil, fmt.Errorf("%w: %s", api.ErrFileExists, relPath)
@@ -164,7 +175,10 @@ func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSiz
 // Retrieve retrieves a file from the filesystem.
 // The returned io.Reader is also an io.ReadCloser; callers should close it when done.
 func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.ReadCloser, *api.BatchFileMetadata, error) {
-	relPath := c.resolvePath(folderName, fileName)
+	relPath, err := c.resolvePath(folderName, fileName)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	file, err := c.root.Open(relPath)
 	if err != nil {
@@ -193,7 +207,10 @@ func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.
 // After removing the file, it attempts to remove the parent directory if empty.
 // The directory cleanup is best-effort and does not fail the operation. (e.g. if the directory is not empty, it will not be removed)
 func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {
-	relPath := c.resolvePath(folderName, fileName)
+	relPath, err := c.resolvePath(folderName, fileName)
+	if err != nil {
+		return err
+	}
 
 	if err := c.root.Remove(relPath); err != nil {
 		return err
@@ -202,10 +219,8 @@ func (c *Client) Delete(ctx context.Context, fileName, folderName string) error 
 	logger := klog.FromContext(ctx).V(logging.INFO)
 	logger.Info("File deleted successfully", "path", relPath)
 
-	if folderName != "" {
-		if err := c.root.Remove(folderName); err == nil {
-			logger.Info("Empty directory removed", "dir", folderName)
-		}
+	if err := c.root.Remove(folderName); err == nil {
+		logger.Info("Empty directory removed", "dir", folderName)
 	}
 
 	return nil

--- a/internal/files_store/fs/client_test.go
+++ b/internal/files_store/fs/client_test.go
@@ -224,6 +224,15 @@ func TestDelete(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects empty fileName and folderName", func(t *testing.T) {
+		client := newTestClient(t)
+
+		err := client.Delete(ctx, "", "")
+		if err == nil {
+			t.Fatal("expected error when both fileName and folderName are empty")
+		}
+	})
+
 	t.Run("returns error for non-existent file", func(t *testing.T) {
 		client := newTestClient(t)
 
@@ -256,21 +265,12 @@ func TestDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("empty folder name does not attempt root removal", func(t *testing.T) {
+	t.Run("rejects empty folderName", func(t *testing.T) {
 		client := newTestClient(t)
 
-		_, err := client.Store(ctx, "root-file.txt", "", 1024, 0, bytes.NewReader([]byte("data")))
-		if err != nil {
-			t.Fatalf("failed to store: %v", err)
-		}
-
-		if err := client.Delete(ctx, "root-file.txt", ""); err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		rootPath := client.root.Name()
-		if _, err := os.Stat(rootPath); os.IsNotExist(err) {
-			t.Fatal("root directory must not be removed")
+		err := client.Delete(ctx, "some-file.txt", "")
+		if err == nil {
+			t.Fatal("expected error when folderName is empty")
 		}
 	})
 


### PR DESCRIPTION
## Why is this PR needed?

When using filesystem storage (`fileClient.type: fs`), the garbage collector deletes expired files but does not clean up empty parent directories. Over time this accumulates many empty tenant directories on disk.

Fixes #173

## What does this PR do?

- After deleting a file in `fs.Client.Delete()`, attempt to remove the parent directory (tenant folder). The cleanup is best-effort: `os.Root.Remove` fails on non-empty directories, and the error is silently ignored.
- Only the immediate parent directory is cleaned up, not ancestors. This is sufficient because `folderName` is always a single-level tenant hash directory (e.g. `t-37a8eec1...`) produced by `GetFolderNameByTenantID` — nested folder paths are never used in practice.
- S3 storage is not affected (no real directory concept).

## How was this tested?

- [x] Unit tests added/updated/verified
  - `removes_empty_parent_directory_after_last_file_deleted`: verifies directory
    is removed when the last file is deleted.
  - `keeps_parent_directory_when_other_files_remain`: verifies directory is
    preserved when other files still exist.
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #173