### PR TITLE
ci: add build status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Go Version](https://img.shields.io/badge/Go-1.25-blue.svg)](https://golang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![apiserver](https://ghcr-badge.egpl.dev/llm-d-incubation/batch-gateway-apiserver/latest_tag?trim=major&label=apiserver)](https://github.com/llm-d-incubation/batch-gateway/pkgs/container/batch-gateway-apiserver)
+[![processor](https://ghcr-badge.egpl.dev/llm-d-incubation/batch-gateway-processor/latest_tag?trim=major&label=processor)](https://github.com/llm-d-incubation/batch-gateway/pkgs/container/batch-gateway-processor)
+[![gc](https://ghcr-badge.egpl.dev/llm-d-incubation/batch-gateway-gc/latest_tag?trim=major&label=gc)](https://github.com/llm-d-incubation/batch-gateway/pkgs/container/batch-gateway-gc)
 
 ## Overview
 


### PR DESCRIPTION
## Why is this PR needed?
Need to know the current latest image tag

## What does this PR do?

Add build status badges to README

You can easily find latest tag for each image `62acc08`
<img width="736" height="204" alt="image" src="https://github.com/user-attachments/assets/70abc5bb-e98b-4e76-b77e-d98a694c8972" />

Then pull image by:
- ghcr.io/llm-d-incubation/batch-gateway-apiserver:<tag>
- ghcr.io/llm-d-incubation/batch-gateway-processor:<tag>
- ghcr.io/llm-d-incubation/batch-gateway-gc:<tag>

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Pre-commit checks pass (`make pre-commit`)
- [ ] Unit tests pass (`make test`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
