### PR TITLE
chore: Remove creation of deployments

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,22 +4,16 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-    # Require approval for external contributors
-    environment:
-      name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || '' }}
     permissions:
       contents: read
 
     steps:
       - uses: actions/checkout@v6.0.2
-        with:
-          # For pull_request_target, check out the PR head commit
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Why is this PR needed?

Currently any commit in a PR from a fork creates a deployment and record in the main repo - just for running the pre-commit check inside the main repo - no need for this.

## What does this PR do?

Updated pre-commit.yml to use `pull_request` instead of `pull_request_target`.

What happens now:
- Internal PRs (same repo): Workflow runs normally.
- External PRs (forks): Workflow runs in fork's context.
- No manual approval needed - Safe by default since workflow only reads/lints code.

Benefits:
✅ More secure - External PRs run in fork context without access to secrets
✅ No more deployment records - Your deployments page will stay clean
✅ Simpler workflow - Removed conditional logic and environment complexity
✅ Consistent with other llm-d repos

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
