### PR TITLE
fix: use fileID as file names to prevent collisions

### DIFF
--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -290,10 +290,13 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	trace.SpanFromContext(ctx).SetAttributes(attribute.String(uotel.AttrInputFileID, fileID))
 
 	// Sanitize filename
-	fileName := filepath.Base(fileHeader.Filename)
-	if fileName == "" || fileName == "." || fileName == ".." {
-		fileName = fileID + ".jsonl"
+	origName := filepath.Base(fileHeader.Filename)
+	if origName == "" || origName == "." || origName == ".." || origName == "/" {
+		origName = fileID + ".jsonl"
 	}
+
+	// Use fileID-based name for storage to guarantee uniqueness
+	storageName := ucom.FileStorageName(fileID, origName)
 
 	// Get tenant ID from context to use as folder name
 	tenantID := common.GetTenantIDFromContext(ctx)
@@ -303,7 +306,7 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		common.WriteInternalServerError(w, r)
 		return
 	}
-	fileMeta, err := c.clients.File.Store(ctx, fileName, folderName, c.config.FileAPI.GetMaxSizeBytes(), c.config.FileAPI.GetMaxLineCount(), fileReader)
+	fileMeta, err := c.clients.File.Store(ctx, storageName, folderName, c.config.FileAPI.GetMaxSizeBytes(), c.config.FileAPI.GetMaxLineCount(), fileReader)
 	if err != nil {
 		switch {
 		case errors.Is(err, fsapi.ErrFileTooLarge):
@@ -327,6 +330,16 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 			)
 			common.WriteAPIError(w, r, apiErr)
 			return
+		case errors.Is(err, fsapi.ErrFileExists):
+			logger.V(logging.DEBUG).Info("file already exists in storage", "storageName", storageName)
+			apiErr := openai.NewAPIError(
+				http.StatusConflict,
+				"",
+				"A file with this name already exists",
+				nil,
+			)
+			common.WriteAPIError(w, r, apiErr)
+			return
 		default:
 			logger.Error(err, "failed to store file content")
 			common.WriteInternalServerError(w, r)
@@ -339,8 +352,8 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	var success bool
 	defer func() {
 		if !success {
-			if err := c.clients.File.Delete(ctx, fileName, folderName); err != nil {
-				logger.Error(err, "failed to cleanup file", "fileName", fileName, "folderName", folderName)
+			if err := c.clients.File.Delete(ctx, storageName, folderName); err != nil {
+				logger.Error(err, "failed to cleanup file", "storageName", storageName, "folderName", folderName)
 			}
 		}
 	}()
@@ -351,7 +364,7 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 		Bytes:     fileMeta.Size,
 		CreatedAt: createdAt,
 		ExpiresAt: expiresAt,
-		Filename:  fileName,
+		Filename:  origName,
 		Object:    "file",
 		Purpose:   purpose,
 		Status:    openai.FileObjectStatusUploaded,
@@ -571,9 +584,10 @@ func (c *FileAPIHandler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Retrieve file content from storage
-	fileReader, fileMeta, err := c.clients.File.Retrieve(ctx, fileObj.Filename, folderName)
+	storageName := ucom.FileStorageName(fileObj.ID, fileObj.Filename)
+	fileReader, fileMeta, err := c.clients.File.Retrieve(ctx, storageName, folderName)
 	if err != nil {
-		logger.Error(err, "failed to retrieve file content", "fileName", fileObj.Filename, "folderName", folderName)
+		logger.Error(err, "failed to retrieve file content", "storageName", storageName, "folderName", folderName)
 		common.WriteInternalServerError(w, r)
 		return
 	}
@@ -620,9 +634,10 @@ func (c *FileAPIHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Delete physical file from storage
-	err = c.clients.File.Delete(ctx, fileObj.Filename, folderName)
+	storageName := ucom.FileStorageName(fileObj.ID, fileObj.Filename)
+	err = c.clients.File.Delete(ctx, storageName, folderName)
 	if err != nil {
-		logger.Error(err, "failed to delete physical file", "fileName", fileObj.Filename, "folderName", folderName)
+		logger.Error(err, "failed to delete physical file", "storageName", storageName, "folderName", folderName)
 		// Continue to delete metadata even if physical file deletion fails
 	}
 

--- a/internal/apiserver/file/file_handler_test.go
+++ b/internal/apiserver/file/file_handler_test.go
@@ -201,17 +201,26 @@ func doTestCreateFileStoreValidationErrors(t *testing.T) {
 	cases := []struct {
 		name        string
 		storeErr    error
+		wantStatus  int
 		wantMessage string
 	}{
 		{
 			name:        "file too large",
 			storeErr:    fsapi.ErrFileTooLarge,
+			wantStatus:  http.StatusBadRequest,
 			wantMessage: fmt.Sprintf("File size exceeds the maximum allowed size of %d bytes", common.DefaultMaxFileSizeBytes),
 		},
 		{
 			name:        "too many lines",
 			storeErr:    fsapi.ErrTooManyLines,
+			wantStatus:  http.StatusBadRequest,
 			wantMessage: "File exceeds the maximum allowed line count of 10",
+		},
+		{
+			name:        "file already exists",
+			storeErr:    fsapi.ErrFileExists,
+			wantStatus:  http.StatusConflict,
+			wantMessage: "A file with this name already exists",
 		},
 	}
 
@@ -230,15 +239,15 @@ func doTestCreateFileStoreValidationErrors(t *testing.T) {
 			w := httptest.NewRecorder()
 			handler.CreateFile(w, req)
 
-			if w.Code != http.StatusBadRequest {
-				t.Fatalf("expected status %d, got %d, body: %s", http.StatusBadRequest, w.Code, w.Body.String())
+			if w.Code != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d, body: %s", tc.wantStatus, w.Code, w.Body.String())
 			}
 			var errResp openai.ErrorResponse
 			if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
 				t.Fatalf("failed to parse error response: %v", err)
 			}
-			if errResp.Error.Code != http.StatusBadRequest {
-				t.Errorf("expected error code %d, got %d", http.StatusBadRequest, errResp.Error.Code)
+			if errResp.Error.Code != tc.wantStatus {
+				t.Errorf("expected error code %d, got %d", tc.wantStatus, errResp.Error.Code)
 			}
 			if errResp.Error.Message != tc.wantMessage {
 				t.Errorf("expected message %q, got %q", tc.wantMessage, errResp.Error.Message)
@@ -308,12 +317,12 @@ func doTestCreateFileSuccess(t *testing.T) {
 	}
 
 	// Verify file was actually uploaded to storage
-	fileName := fileObj.Filename
+	storageName := ucom.FileStorageName(fileObj.ID, fileObj.Filename)
 	folderName, err := ucom.GetFolderNameByTenantID(common.DefaultTenantID)
 	if err != nil {
 		t.Fatalf("failed to get folder name from tenant ID: %v", err)
 	}
-	fileReader, fileMeta, err := handler.clients.File.Retrieve(ctx, fileName, folderName)
+	fileReader, fileMeta, err := handler.clients.File.Retrieve(ctx, storageName, folderName)
 	if err != nil {
 		t.Fatalf("failed to retrieve file from storage: %v", err)
 	}
@@ -949,11 +958,12 @@ func doTestDeleteFile(t *testing.T) {
 		}
 
 		// Verify physical file is deleted from storage
+		storageName := ucom.FileStorageName(createdFile.ID, createdFile.Filename)
 		folderName, err := ucom.GetFolderNameByTenantID(common.DefaultTenantID)
 		if err != nil {
 			t.Fatalf("failed to get folder name from tenant ID: %v", err)
 		}
-		_, _, err = handler.clients.File.Retrieve(ctx, createdFile.Filename, folderName)
+		_, _, err = handler.clients.File.Retrieve(ctx, storageName, folderName)
 		if err == nil {
 			t.Errorf("expected physical file to be deleted, but still exists")
 		}

--- a/internal/gc/collector/collector.go
+++ b/internal/gc/collector/collector.go
@@ -237,10 +237,9 @@ func (c *GarbageCollector) processFile(ctx context.Context, file *db.FileItem) (
 		return false, fmt.Errorf("failed to get folder name for tenant %q: %w", file.TenantID, err)
 	}
 
-	// Delete the physical file first, then the DB metadata. If the file is already
-	// gone (e.g. from a previous partial GC cycle), proceed to delete the metadata.
-	if err := c.filesClient.Delete(ctx, fileObject.Filename, folderName); err != nil && !errors.Is(err, os.ErrNotExist) {
-		logger.Error(err, "Failed to delete physical file", "fileID", file.ID, "fileName", fileObject.Filename, "folderName", folderName)
+	storageName := ucom.FileStorageName(fileObject.ID, fileObject.Filename)
+	if err := c.filesClient.Delete(ctx, storageName, folderName); err != nil && !errors.Is(err, os.ErrNotExist) {
+		logger.Error(err, "Failed to delete physical file", "fileID", file.ID, "storageName", storageName, "folderName", folderName)
 		return false, fmt.Errorf("failed to delete physical file with ID %v : %w", file.ID, err)
 	}
 

--- a/internal/processor/worker/fileio.go
+++ b/internal/processor/worker/fileio.go
@@ -149,7 +149,8 @@ func (p *Processor) openInputFileStream(ctx context.Context, inputFileID string)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get folder name by tenant id: %w", err)
 	}
-	reader, metadata, err := p.files.storage.Retrieve(ctx, fileObj.Filename, folderName)
+	storageName := ucom.FileStorageName(fileItem.ID, fileObj.Filename)
+	reader, metadata, err := p.files.storage.Retrieve(ctx, storageName, folderName)
 	if err != nil {
 		return nil, metadata, fmt.Errorf("failed to open input file stream: %w", err)
 	}

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -53,13 +53,17 @@ func (p *Processor) uploadFileAndStoreFileRecord(
 	var err error
 	var attrKey string
 
+	fileID := ucom.NewFileID()
+
 	if fileType == metrics.FileTypeOutput {
 		fileName = jobOutputStorageName(jobInfo.JobID)
-		fileSize, err = p.uploadOutputFile(ctx, jobInfo, fileName)
+		storageName := ucom.FileStorageName(fileID, fileName)
+		fileSize, err = p.uploadOutputFile(ctx, jobInfo, storageName)
 		attrKey = uotel.AttrOutputFileID
 	} else {
 		fileName = jobErrorStorageName(jobInfo.JobID)
-		fileSize, err = p.uploadErrorFile(ctx, jobInfo, fileName)
+		storageName := ucom.FileStorageName(fileID, fileName)
+		fileSize, err = p.uploadErrorFile(ctx, jobInfo, storageName)
 		attrKey = uotel.AttrErrorFileID
 	}
 	if err != nil {
@@ -69,7 +73,6 @@ func (p *Processor) uploadFileAndStoreFileRecord(
 		return "", nil
 	}
 
-	fileID := ucom.NewFileID()
 	uotel.SetAttr(ctx, attribute.String(attrKey, fileID))
 	if err := p.storeFileRecord(ctx, fileID, fileName, jobInfo.TenantID, fileSize, dbJob.Tags); err != nil {
 		return "", err

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -11,6 +11,8 @@ import (
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d-incubation/batch-gateway/internal/database/mock"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/config"
+	"github.com/llm-d-incubation/batch-gateway/internal/processor/metrics"
+	"github.com/llm-d-incubation/batch-gateway/internal/shared/converter"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
@@ -133,6 +135,64 @@ func TestExecutionProgress_RecordAndCounts(t *testing.T) {
 	}
 }
 
+// --- uploadFileAndStoreFileRecord ---
+
+func TestUploadFileAndStoreFileRecord_StorageKeyAndDBFilename(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.DefaultOutputExpirationSeconds = 86400
+	cfg.UploadRetry = config.RetryConfig{
+		MaxRetries:     0,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	mock := &failNTimesFilesClient{failCount: 0}
+	fileDB := newMockFileDBClient()
+	batchDB := newMockBatchDBClient()
+
+	clients := &clientset.Clientset{
+		File:    mock,
+		FileDB:  fileDB,
+		BatchDB: batchDB,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	jobID := "job-storage-key"
+	tenantID := "tenant-1"
+	jobInfo := setupJobWithOutputFile(t, cfg, jobID, tenantID)
+	ctx := testLoggerCtx()
+	dbJob := seedDBJob(t, batchDB, jobID)
+
+	fileID, err := p.uploadFileAndStoreFileRecord(ctx, jobInfo, dbJob, metrics.FileTypeOutput)
+	if err != nil {
+		t.Fatalf("uploadFileAndStoreFileRecord returned error: %v", err)
+	}
+	if fileID == "" {
+		t.Fatal("expected non-empty fileID")
+	}
+
+	// Verify storage key uses FileStorageName format: <fileID>.jsonl
+	wantStorageKey := fileID + ".jsonl"
+	if mock.lastFileName != wantStorageKey {
+		t.Errorf("storage key = %q, want %q", mock.lastFileName, wantStorageKey)
+	}
+
+	// Verify DB filename preserves the batch output format
+	items, _, _, err := fileDB.DBGet(ctx, &db.FileQuery{BaseQuery: db.BaseQuery{IDs: []string{fileID}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	fileObj, err := converter.DBItemToFile(items[0])
+	if err != nil {
+		t.Fatalf("DBItemToFile: %v", err)
+	}
+	wantDBFilename := "batch_output_" + jobID + ".jsonl"
+	if fileObj.Filename != wantDBFilename {
+		t.Errorf("DB filename = %q, want %q", fileObj.Filename, wantDBFilename)
+	}
+}
+
 // --- storeFileRecord ---
 
 func TestStoreOutputFileRecord_Success(t *testing.T) {
@@ -161,6 +221,34 @@ func TestStoreOutputFileRecord_Success(t *testing.T) {
 	}
 	if items[0].Purpose != string(openai.FileObjectPurposeBatchOutput) {
 		t.Fatalf("stored purpose = %q, want %q", items[0].Purpose, openai.FileObjectPurposeBatchOutput)
+	}
+}
+
+// --- uploadOutputFile retry ---
+
+// --- storage key format ---
+
+func TestUploadOutputFile_UsesFileStorageName(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+	cfg.UploadRetry = config.RetryConfig{
+		MaxRetries:     0,
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	mock := &failNTimesFilesClient{failCount: 0}
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{File: mock})
+
+	jobInfo := setupJobWithOutputFile(t, cfg, "job-key-fmt", "tenant-1")
+	ctx := testLoggerCtx()
+
+	_, err := p.uploadOutputFile(ctx, jobInfo, "file_abc.jsonl")
+	if err != nil {
+		t.Fatalf("uploadOutputFile returned error: %v", err)
+	}
+	if mock.lastFileName != "file_abc.jsonl" {
+		t.Errorf("storage key = %q, want %q", mock.lastFileName, "file_abc.jsonl")
 	}
 }
 

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -62,12 +62,12 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		remoteBuf.Write(ln)
 	}
 
-	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
-		t.Fatalf("files.Store: %v", err)
-	}
-
 	// Create DB item for "input file metadata"
 	inputFileID := "file-123"
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, filename), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
 	fileSpec := &openai.FileObject{Filename: filename}
 	fileItem := &db.FileItem{
 		BaseIndexes: db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
@@ -217,11 +217,11 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 	}
 
 	filename := "input.jsonl"
-	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+	inputFileID := "file-sys-prompt"
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, filename), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
 		t.Fatalf("files.Store: %v", err)
 	}
-
-	inputFileID := "file-sys-prompt"
 	fileSpec := &openai.FileObject{Filename: filename}
 	fileItem := &db.FileItem{
 		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
@@ -463,7 +463,7 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 		remoteBuf.Write(ln)
 	}
 
-	if _, err := filesClient.Store(ctx, "input.jsonl", folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, "input.jsonl"), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
 		t.Fatalf("files.Store: %v", err)
 	}
 	fileSpec := &openai.FileObject{Filename: "input.jsonl"}
@@ -808,11 +808,11 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 	remoteBuf.WriteString(`{"custom_id":"r3","body":{"model":"m1","messages":[{"role":"user","content":"ok2"}]}}` + "\n")
 
 	filename := "input.jsonl"
-	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+	inputFileID := "file-stream-reject"
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, filename), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
 		t.Fatalf("files.Store: %v", err)
 	}
-
-	inputFileID := "file-stream-reject"
 	fileSpec := &openai.FileObject{Filename: filename}
 	fileItem := &db.FileItem{
 		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
@@ -877,11 +877,11 @@ func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
 	remoteBuf.WriteString(`{"custom_id":"req-1","body":{"model":"m1","messages":[{"role":"user","content":"c"}]}}` + "\n")
 
 	filename := "input.jsonl"
-	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+	inputFileID := "file-dup-custom-id"
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, filename), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
 		t.Fatalf("files.Store: %v", err)
 	}
-
-	inputFileID := "file-dup-custom-id"
 	fileSpec := &openai.FileObject{Filename: filename}
 	fileItem := &db.FileItem{
 		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
@@ -949,11 +949,11 @@ func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
 	remoteBuf.WriteString(`{"custom_id":"req-3","body":{"model":"m1","messages":[{"role":"user","content":"c"}]}}` + "\n")
 
 	filename := "input.jsonl"
-	if _, err := filesClient.Store(ctx, filename, folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+	inputFileID := "file-unique-custom-id"
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, filename), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
 		t.Fatalf("files.Store: %v", err)
 	}
-
-	inputFileID := "file-unique-custom-id"
 	fileSpec := &openai.FileObject{Filename: filename}
 	fileItem := &db.FileItem{
 		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -103,16 +103,18 @@ func (m *mockInferenceClient) Generate(ctx context.Context, req *inference.Gener
 // ---------------------------------------------------------------------------
 
 type failNTimesFilesClient struct {
-	failCount int
-	calls     int
-	lastMeta  *filesapi.BatchFileMetadata
+	failCount    int
+	calls        int
+	lastMeta     *filesapi.BatchFileMetadata
+	lastFileName string // records the fileName passed to the most recent successful Store call
 }
 
-func (f *failNTimesFilesClient) Store(_ context.Context, _, _ string, _, _ int64, _ io.Reader) (*filesapi.BatchFileMetadata, error) {
+func (f *failNTimesFilesClient) Store(_ context.Context, fileName, _ string, _, _ int64, _ io.Reader) (*filesapi.BatchFileMetadata, error) {
 	f.calls++
 	if f.calls <= f.failCount {
 		return nil, errors.New("transient upload error")
 	}
+	f.lastFileName = fileName
 	f.lastMeta = &filesapi.BatchFileMetadata{Size: 42}
 	return f.lastMeta, nil
 }

--- a/internal/util/com/common.go
+++ b/internal/util/com/common.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"path/filepath"
 
 	"github.com/google/uuid"
 )
@@ -49,6 +50,14 @@ func RandString(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func FileStorageName(fileID, origFilename string) string {
+	ext := filepath.Ext(origFilename)
+	if ext == "" {
+		ext = ".jsonl"
+	}
+	return fileID + ext
 }
 
 // GetFolderNameByTenantID converts a tenant ID into a filesystem and S3-safe folder name.

--- a/internal/util/com/common_test.go
+++ b/internal/util/com/common_test.go
@@ -119,6 +119,30 @@ func TestGetFolderNameByTenantID(t *testing.T) {
 	}
 }
 
+func TestFileStorageName(t *testing.T) {
+	tests := []struct {
+		name         string
+		fileID       string
+		origFilename string
+		want         string
+	}{
+		{"jsonl extension", "file_abc", "input.jsonl", "file_abc.jsonl"},
+		{"csv extension", "file_abc", "data.csv", "file_abc.csv"},
+		{"no extension defaults to jsonl", "file_abc", "noext", "file_abc.jsonl"},
+		{"batch output format", "file_xyz", "batch_output_batch_123.jsonl", "file_xyz.jsonl"},
+		{"batch error format", "file_xyz", "batch_error_batch_123.jsonl", "file_xyz.jsonl"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FileStorageName(tt.fileID, tt.origFilename)
+			if got != tt.want {
+				t.Errorf("FileStorageName(%q, %q) = %q, want %q", tt.fileID, tt.origFilename, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSameMembersInStrSlice(t *testing.T) {
 	tests := []struct {
 		name string

--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -268,6 +268,15 @@ func doTestBatchLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("download output file failed: %v", err)
 	}
+
+	// Verify output file download filename matches expected format
+	wantOutputFilename := fmt.Sprintf("batch_output_%s.jsonl", batchID)
+	cd := resp.Header.Get("Content-Disposition")
+	wantCD := fmt.Sprintf(`attachment; filename=%q`, wantOutputFilename)
+	if cd != wantCD {
+		t.Errorf("output file Content-Disposition mismatch\ngot:  %s\nwant: %s", cd, wantCD)
+	}
+
 	outputBody, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	validateAndLogJSONL(t, "output file", string(outputBody))
@@ -279,6 +288,15 @@ func doTestBatchLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("download error file failed: %v", err)
 		}
+
+		// Verify error file download filename matches expected format
+		wantErrorFilename := fmt.Sprintf("batch_error_%s.jsonl", batchID)
+		cd := resp.Header.Get("Content-Disposition")
+		wantCD := fmt.Sprintf(`attachment; filename=%q`, wantErrorFilename)
+		if cd != wantCD {
+			t.Errorf("error file Content-Disposition mismatch\ngot:  %s\nwant: %s", cd, wantCD)
+		}
+
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		validateAndLogJSONL(t, "error file", string(body))

--- a/test/e2e/files_test.go
+++ b/test/e2e/files_test.go
@@ -29,10 +29,52 @@ import (
 
 func testFiles(t *testing.T) {
 	t.Run("Lifecycle", doTestFileLifecycle)
+	t.Run("Create", func(t *testing.T) {
+		t.Run("DuplicateFilename", doTestDuplicateFileUpload)
+	})
 	t.Run("List", func(t *testing.T) {
 		t.Run("Pagination", doTestFilePagination)
 		t.Run("PurposeFilter", doTestFilePurposeFilter)
 	})
+}
+
+// doTestDuplicateFileUpload verifies that uploading two files with the same
+// filename under the same tenant succeeds. Each upload should get a unique
+// fileID and storage path. Reproduces https://github.com/llm-d-incubation/batch-gateway/issues/214
+func doTestDuplicateFileUpload(t *testing.T) {
+	t.Helper()
+
+	client := newClient()
+	filename := fmt.Sprintf("duplicate-%s.jsonl", testRunID)
+
+	// First upload — should succeed
+	fileID1 := mustCreateFileWithClient(t, client, filename, testJSONL)
+	t.Logf("first upload: fileID=%s, filename=%s", fileID1, filename)
+
+	// Second upload with the same filename — should also succeed with a different fileID
+	fileID2 := mustCreateFileWithClient(t, client, filename, testJSONL)
+	t.Logf("second upload: fileID=%s, filename=%s", fileID2, filename)
+
+	if fileID1 == fileID2 {
+		t.Errorf("expected different file IDs, both got %s", fileID1)
+	}
+
+	// Both files should be retrievable and preserve the original filename
+	got1, err := client.Files.Get(context.Background(), fileID1)
+	if err != nil {
+		t.Fatalf("retrieve first file failed: %v", err)
+	}
+	if got1.Filename != filename {
+		t.Errorf("first file: expected filename %q, got %q", filename, got1.Filename)
+	}
+
+	got2, err := client.Files.Get(context.Background(), fileID2)
+	if err != nil {
+		t.Fatalf("retrieve second file failed: %v", err)
+	}
+	if got2.Filename != filename {
+		t.Errorf("second file: expected filename %q, got %q", filename, got2.Filename)
+	}
 }
 
 // doTestFileLifecycle uploads a file, verifies list, retrieve, download, then deletes it.
@@ -78,6 +120,13 @@ func doTestFileLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("download file failed: %v", err)
 	}
+	// Verify download filename matches the original upload filename
+	cd := resp.Header.Get("Content-Disposition")
+	wantCD := fmt.Sprintf(`attachment; filename=%q`, filename)
+	if cd != wantCD {
+		t.Errorf("Content-Disposition mismatch\ngot:  %s\nwant: %s", cd, wantCD)
+	}
+
 	content, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/llm-d-incubation/batch-gateway/issues/214
Uploading a file with a name that already exists returns HTTP 500

## What does this PR do?
- Unify physical file name of all file types (input, output, error) to  `<fileID>.jsonl`
- Save user-meaningful display names in DB
    - Input: `original-uploaded-filename`
    - Output: `batch_output_<batchID>.jsonl`
    - Error: `batch_error_<batchID>.jsonl`
- Uses display filename from DB as `Content-Disposition` when downloading, so users get meaningful file names 
- Add test cases to cover above

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
