### PR TITLE
feat: add OpenTelemetry tracing for storage operations

### DIFF
--- a/cmd/batch-gc/main.go
+++ b/cmd/batch-gc/main.go
@@ -30,6 +30,7 @@ import (
 
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	fsapi "github.com/llm-d-incubation/batch-gateway/internal/files_store/api"
+	fstracing "github.com/llm-d-incubation/batch-gateway/internal/files_store/tracing"
 	"github.com/llm-d-incubation/batch-gateway/internal/gc/collector"
 	gcconfig "github.com/llm-d-incubation/batch-gateway/internal/gc/config"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
@@ -78,6 +79,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize files storage client: %w", err)
 	}
+	filesClient = fstracing.Wrap(filesClient, cfg.FileClientCfg.Type)
 	defer func() { _ = filesClient.Close() }()
 
 	var batchDB db.BatchDBClient

--- a/internal/files_store/tracing/tracing.go
+++ b/internal/files_store/tracing/tracing.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tracing provides an OpenTelemetry tracing wrapper for BatchFilesClient.
+package tracing
+
+import (
+	"context"
+	"io"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/llm-d-incubation/batch-gateway/internal/files_store/api"
+	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
+)
+
+// Client wraps a BatchFilesClient and adds OpenTelemetry tracing spans
+// to all storage operations.
+type Client struct {
+	inner   api.BatchFilesClient
+	backend attribute.KeyValue
+}
+
+// Wrap returns a new BatchFilesClient that adds tracing spans around
+// every call to the underlying client. The backend parameter (e.g. "fs",
+// "s3") is recorded as a storage.backend attribute on every span.
+func Wrap(inner api.BatchFilesClient, backend string) api.BatchFilesClient {
+	return &Client{
+		inner:   inner,
+		backend: attribute.String("storage.backend", backend),
+	}
+}
+
+func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSizeLimit, lineNumLimit int64, reader io.Reader) (*api.BatchFileMetadata, error) {
+	ctx, span := uotel.StartSpan(ctx, "storage.Store")
+	defer span.End()
+	span.SetAttributes(
+		c.backend,
+		attribute.String("storage.file_name", fileName),
+		attribute.String("storage.folder", folderName),
+	)
+
+	md, err := c.inner.Store(ctx, fileName, folderName, fileSizeLimit, lineNumLimit, reader)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "store failed")
+		return md, err
+	}
+	span.SetAttributes(attribute.Int64("storage.file_size", md.Size))
+	return md, nil
+}
+
+func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.ReadCloser, *api.BatchFileMetadata, error) {
+	_, span := uotel.StartSpan(ctx, "storage.Retrieve")
+	span.SetAttributes(
+		c.backend,
+		attribute.String("storage.file_name", fileName),
+		attribute.String("storage.folder", folderName),
+	)
+
+	reader, md, err := c.inner.Retrieve(ctx, fileName, folderName)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "retrieve failed")
+		span.End()
+		return nil, nil, err
+	}
+	if md != nil {
+		span.SetAttributes(attribute.Int64("storage.file_size", md.Size))
+	}
+	// The span is kept open and ended when the caller closes the reader,
+	// so that streaming download time (especially from S3) is captured.
+	return &tracedReadCloser{ReadCloser: reader, span: span}, md, nil
+}
+
+// tracedReadCloser wraps an io.ReadCloser and ends the associated span
+// when Close is called, capturing the full streaming duration.
+type tracedReadCloser struct {
+	io.ReadCloser
+	span trace.Span
+}
+
+func (r *tracedReadCloser) Close() error {
+	defer r.span.End()
+	err := r.ReadCloser.Close()
+	if err != nil {
+		r.span.RecordError(err)
+		r.span.SetStatus(codes.Error, "close failed")
+	}
+	return err
+}
+
+func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {
+	ctx, span := uotel.StartSpan(ctx, "storage.Delete")
+	defer span.End()
+	span.SetAttributes(
+		c.backend,
+		attribute.String("storage.file_name", fileName),
+		attribute.String("storage.folder", folderName),
+	)
+
+	err := c.inner.Delete(ctx, fileName, folderName)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "delete failed")
+	}
+	return err
+}
+
+func (c *Client) Close() error {
+	return c.inner.Close()
+}

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -98,10 +98,11 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 		logger.V(logging.ERROR).Error(err, "Failed to get event watcher")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "event watcher failed")
-		// Re-enqueue best-effort. Use context.Background() because ctx may already be
+		// Re-enqueue best-effort. Use a detached context because ctx may already be
 		// cancelled (e.g. pod shutdown) and we don't want the enqueue call to be short-circuited.
 		if params.task != nil {
-			bgCtx := klog.NewContext(context.Background(), klog.FromContext(ctx))
+			bgCtx, bgSpan := uotel.DetachedContext(ctx, "re-enqueue")
+			defer bgSpan.End()
 			if enqErr := p.poller.enqueueOne(bgCtx, params.task); enqErr != nil {
 				logger.V(logging.ERROR).Error(enqErr, "Failed to re-enqueue the job to the queue")
 				if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, nil); failErr != nil {
@@ -215,9 +216,10 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 		// Parent context was cancelled or deadline exceeded (e.g. pod shutdown).
 		// Re-enqueue so another worker can pick it up.
 		// Note: SLO expiry returns ErrExpired, which is handled before this function is called.
-		// Use context.Background() because ctx is already cancelled.
+		// Use a detached context because ctx is already cancelled.
 		if params.task != nil {
-			bgCtx := klog.NewContext(context.Background(), klog.FromContext(ctx))
+			bgCtx, bgSpan := uotel.DetachedContext(ctx, "re-enqueue")
+			defer bgSpan.End()
 			if enqErr := p.poller.enqueueOne(bgCtx, params.task); enqErr != nil {
 				logger.V(logging.ERROR).Error(enqErr, "Failed to re-enqueue the job to the queue")
 				if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, nil); failErr != nil {

--- a/internal/util/clientset/clientset.go
+++ b/internal/util/clientset/clientset.go
@@ -30,6 +30,7 @@ import (
 	fsapi "github.com/llm-d-incubation/batch-gateway/internal/files_store/api"
 	fsclient "github.com/llm-d-incubation/batch-gateway/internal/files_store/fs"
 	s3client "github.com/llm-d-incubation/batch-gateway/internal/files_store/s3"
+	fstracing "github.com/llm-d-incubation/batch-gateway/internal/files_store/tracing"
 	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
 	uredis "github.com/llm-d-incubation/batch-gateway/internal/util/redis"
 	"github.com/llm-d-incubation/batch-gateway/pkg/clients/inference"
@@ -186,13 +187,13 @@ func NewClientset(
 		if err != nil {
 			return nil, err
 		}
-		cs.File = c
+		cs.File = fstracing.Wrap(c, "fs")
 	case "s3":
 		c, err := NewS3FileClient(ctx, s3Cfg)
 		if err != nil {
 			return nil, err
 		}
-		cs.File = c
+		cs.File = fstracing.Wrap(c, "s3")
 	default:
 		return nil, fmt.Errorf("unsupported file_client.type: %s (supported values: fs, s3)", fileClientType)
 	}

--- a/internal/util/otel/otel.go
+++ b/internal/util/otel/otel.go
@@ -58,6 +58,20 @@ func SetAttr(ctx context.Context, attrs ...attribute.KeyValue) {
 	trace.SpanFromContext(ctx).SetAttributes(attrs...)
 }
 
+// DetachedContext returns a new background context that carries a span linked to
+// the span in the original context. Use this when the original context is cancelled
+// (e.g. pod shutdown) but you still need to perform traced operations (e.g. re-enqueue).
+// The linked span appears in Jaeger as a separate trace with a link back to the original,
+// avoiding orphan spans with no connection to the parent trace.
+func DetachedContext(ctx context.Context, name string) (context.Context, trace.Span) {
+	var links []trace.Link
+	if sc := trace.SpanFromContext(ctx).SpanContext(); sc.IsValid() {
+		links = append(links, trace.Link{SpanContext: sc})
+	}
+	bgCtx := klog.NewContext(context.Background(), klog.FromContext(ctx))
+	return StartSpan(bgCtx, name, trace.WithLinks(links...))
+}
+
 // InitTracer sets up an OpenTelemetry TracerProvider with an OTLP gRPC exporter.
 // It reads the endpoint from the OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
 // If the endpoint is not set, tracing is disabled (no-op) and a nil shutdown function is returned.


### PR DESCRIPTION
## Why is this PR needed?

Currently, we generate child span for redis and postresql operations. but there is no span for file store operations

## What does this PR do?

The PR will add span to Store / Retrieve / Delete for file store 

<img width="1918" height="582" alt="image" src="https://github.com/user-attachments/assets/74505b14-54a7-4401-b300-02d785d788b8" />

<img width="1916" height="585" alt="image" src="https://github.com/user-attachments/assets/380299c4-bc6f-4e5f-b5d0-7b650d236a3b" />

<img width="1915" height="610" alt="image" src="https://github.com/user-attachments/assets/0dfa4b0d-8269-4f2f-8e8b-b7e61f49fbee" />

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
