### PR TITLE
fix: mark malformed dequeued batches as failed instead of stranding them

### DIFF
--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -664,6 +664,67 @@ func TestRunPollingLoop_DBTransient_ReEnqueuesTask(t *testing.T) {
 	}
 }
 
+func TestRunPollingLoop_MalformedJobItem_MarksFailed(t *testing.T) {
+	ctx := testLoggerCtx()
+
+	cfg := config.NewConfig()
+	cfg.PollInterval = 5 * time.Millisecond
+	cfg.NumWorkers = 1
+
+	pq := &spyPQ{inner: mockdb.NewMockBatchPriorityQueueClient()}
+	dbClient := newSpyBatchDB(newMockBatchDBClient())
+	statusClient := mockdb.NewMockBatchStatusClient()
+	jobID := "job-malformed-1"
+
+	jobItem := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{
+			ID:       jobID,
+			TenantID: "tenantA",
+			Tags: db.Tags{
+				"tenant": "tenantA",
+			},
+		},
+		BaseContents: db.BaseContents{
+			// Invalid JSON in Spec forces DBItemToBatch -> FromDBItemToJobInfoObject to fail,
+			// while keeping Status valid so handleFailed can still write a terminal status.
+			Spec: []byte(`{"input_file_id":`),
+			Status: mustJSON(t, openai.BatchStatusInfo{
+				Status: openai.BatchStatusValidating,
+			}),
+		},
+	}
+	if err := dbClient.DBStore(ctx, jobItem); err != nil {
+		t.Fatalf("DBStore job item: %v", err)
+	}
+	if err := pq.PQEnqueue(ctx, &db.BatchJobPriority{
+		ID:  jobID,
+		SLO: time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("PQEnqueue task: %v", err)
+	}
+	initialEnqueueCalls := pq.EnqueueCalls()
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		Queue:   pq,
+		Status:  statusClient,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	runCtx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	if err := p.runPollingLoop(runCtx); err != nil {
+		t.Fatalf("runPollingLoop: %v", err)
+	}
+
+	if dbClient.StatusCalls(openai.BatchStatusFailed) < 1 {
+		t.Fatalf("expected malformed dequeued job to be marked failed")
+	}
+	if pq.EnqueueCalls() != initialEnqueueCalls {
+		t.Fatalf("expected malformed dequeued job not to be re-enqueued")
+	}
+}
+
 func TestRunPollingLoop_NotRunnableJob_SkipsWithoutStatusUpdate(t *testing.T) {
 	ctx := testLoggerCtx()
 

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -193,7 +193,9 @@ func (p *Processor) runPollingLoop(ctx context.Context) error {
 		if err != nil {
 			jlogger.Error(err, "Failed to convert job object in DB to job info object")
 			p.releaseForNextPoll()
-			metrics.RecordJobProcessed(metrics.ResultFailed, metrics.ReasonSystemError)
+			if failErr := p.handleFailed(jobCtx, p.updater, jobItem, nil); failErr != nil {
+				jlogger.Error(failErr, "Failed to mark malformed job as failed")
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Why is this PR needed?

When a batch is dequeued from Redis and the DB item is fetched successfully, but `FromDBItemToJobInfoObject()` fails (e.g. malformed Spec JSON), the current code logs the error and continues polling. Since the queue item was already removed by `BZMPop()`, the batch can be left stranded — out of the queue, but still non-terminal in the DB.

This is not a transient infrastructure error, so re-enqueueing would just create a retry loop.

## What does this PR do?

- Calls `handleFailed()` on the malformed batch to transition it to terminal `failed` status, preventing it from being stranded between queue and DB state.
- Adds a regression test (`TestRunPollingLoop_MalformedJobItem_MarksFailed`) that verifies:
  - a dequeued batch with valid status but malformed spec is marked `failed`
  - it is not re-enqueued

The metric recording (`ResultFailed`, `ReasonSystemError`) is preserved. `handleFailed()` calls `RecordJobProcessed` internally with the same labels.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [X] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #234