### PR TITLE
refactor: clean up cancel state management and rename inferCtx to abortCtx (Issue #200)

### DIFF
--- a/cmd/batch-processor/main.go
+++ b/cmd/batch-processor/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The entry point for the worker process.
+// The entry point for the batch processor.
 
 package main
 

--- a/docs/design/batch_processor_architecture.md
+++ b/docs/design/batch_processor_architecture.md
@@ -20,7 +20,7 @@ The current design focuses on:
     backend layout)
 -   Maintaining OpenAI-compatible request/response schema parity
 
-This document describes the proposed 3-phase processing architecture and scheduling model.
+This document describes the ingestion → execution → finalization processing architecture and scheduling model.
 
 -------------------------------------------------------------------
 
@@ -214,7 +214,7 @@ Terminal states:
 -   expired
 -   cancelled
 
-Transient states such as `cancelling` and `finalizing` indicate that the job has already been claimed and is being handled by an active worker. They are not eligible for reassignment. If encountered in the priority queue, workers skip them; queue clean up is handled by the owning worker or system policy.
+Transient states such as `cancelling` and `finalizing` indicate that the job has already been claimed and is being handled by an active worker. They are not eligible for reassignment. If a worker dequeues a job and finds it in `cancelling` state (e.g. the API server wrote `cancelling` between dequeue and the runnable check), the worker transitions it directly to `cancelled` so it cannot stick indefinitely. Other non-runnable transient states (e.g. `finalizing`) are skipped; queue cleanup is handled by the owning worker or system policy.
 
 Terminal states are removed from the priority queue.
 
@@ -228,9 +228,9 @@ The processor uses a layered context tree to propagate cancellation signals. Eac
 ctx (Run parameter — signal-aware, cancelled by SIGTERM/SIGINT)
   └── jobCtx (per-job — klog.NewContext with job/tenant logger)
         ├── sloCtx (context.WithDeadline — SLO expiry)
-        │     └── inferCtx (context.WithCancel — user cancel event)
+        │     └── abortCtx (context.WithCancel — user cancel event)
         │           └── execCtx (context.WithCancel — first model error cancels sibling models)
-        └── watchCancel goroutine (listens for Redis cancel events, sets cancelRequested flag)
+        └── watchCancel goroutine (listens for Redis cancel events, sets cancelRequested flag and calls abortInferFn)
 ```
 
 | Context | Created in | Cancelled by | Effect |
@@ -238,12 +238,12 @@ ctx (Run parameter — signal-aware, cancelled by SIGTERM/SIGINT)
 | `ctx` | `main.go` via `interrupt.ContextWithSignal` | SIGTERM / SIGINT | Entire processor shuts down; polling loop exits, in-flight jobs see `ctx.Done()` and re-enqueue |
 | `jobCtx` | `runPollingLoop` via `klog.NewContext(ctx, jlogger)` | Parent `ctx` cancellation | Single job's lifecycle; passed to `runJob` |
 | `sloCtx` | `runJob` via `context.WithDeadline(ctx, slo)` | SLO deadline fires | Stops new request dispatch; in-flight requests finish; undispatched entries drained as `batch_expired` |
-| `inferCtx` | `runJob` via `context.WithCancel(sloCtx)` | `watchCancel` calls `inferCancelFn` on user cancel event | Aborts in-flight HTTP inference requests immediately |
-| `execCtx` | `executeJob` via `context.WithCancel(inferCtx)` | First model goroutine error calls `execCancel()` | Stops dispatch in all model goroutines; already-dispatched requests run to completion |
+| `abortCtx` | `runJob` via `context.WithCancel(sloCtx)` | `watchCancel` calls `abortInferFn` on user cancel event | Aborts in-flight HTTP inference requests immediately |
+| `execCtx` | `executeJob` via `context.WithCancel(abortCtx)` | First model goroutine error calls `execCancel()` | Stops dispatch in all model goroutines; already-dispatched requests run to completion |
 
 **Design notes:**
--   `inferCtx` is derived from `sloCtx` so the SLO deadline propagates to inference requests automatically.
--   `execCtx` is derived from `inferCtx` so both user cancel and SLO expiry stop dispatch.
+-   `abortCtx` is derived from `sloCtx` so the SLO deadline propagates to inference requests automatically.
+-   `execCtx` is derived from `abortCtx` so both user cancel and SLO expiry stop dispatch.
 -   The `cancelRequested` flag is **not** used to stop dispatch (context cancellation handles that). It is only consulted in the error-handling path to distinguish the cancellation reason (user cancel vs SLO vs pod shutdown) and to drain undispatched entries with the correct error code.
 -   `watchCancel` runs in a separate goroutine and does not update DB status to `cancelling` — the API server already did that before sending the cancel event.
 

--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -18,8 +18,6 @@ package worker
 
 import (
 	"context"
-	"sync"
-	"sync/atomic"
 
 	"k8s.io/klog/v2"
 
@@ -30,12 +28,6 @@ import (
 
 func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams) {
 	logger := klog.FromContext(ctx)
-	if params.cancelRequested == nil {
-		params.cancelRequested = &atomic.Bool{}
-	}
-	if params.cancellingOnce == nil {
-		params.cancellingOnce = &sync.Once{}
-	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -51,15 +43,11 @@ func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams)
 			if event.Type == db.BatchEventCancel {
 				logger.V(logging.INFO).Info("watchCancel: cancel event received")
 
-				// signal
 				params.cancelRequested.Store(true)
+				params.abortInferFn()
 
-				// cancel the inference context to abort in-flight HTTP requests immediately,
-				// freeing downstream resources.
-				params.inferCancelFn()
-
-				// Note: We don't update the DB status to 'cancelling' here because
-				// the API server already wrote 'cancelling' to the DB before sending this event.
+				// We don't update the DB status to 'cancelling' here because
+				// the API server already wrote 'cancelling' before sending this event.
 			}
 		}
 	}
@@ -74,7 +62,6 @@ func (p *Processor) handleCancelled(ctx context.Context, params *jobExecutionPar
 
 	var outputFileID, errorFileID string
 	if params.requestCounts != nil && params.jobInfo != nil {
-		// upload partial results
 		logger.V(logging.INFO).Info("Job cancelled mid-execution, uploading partial results")
 		outputFileID, errorFileID = p.uploadPartialResults(ctx, params.jobInfo, params.jobItem)
 	}
@@ -88,7 +75,6 @@ func (p *Processor) handleCancelled(ctx context.Context, params *jobExecutionPar
 
 	setRequestCountAttrs(ctx, params.requestCounts)
 
-	// record processed metrics as success because we successfully finished user-initiated cancellation
 	metrics.RecordJobProcessed(metrics.ResultSuccess, metrics.ReasonNone)
 	logger.V(logging.INFO).Info("Job cancelled handled", "outputFileID", outputFileID, "errorFileID", errorFileID)
 	return nil

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -122,19 +122,15 @@ func (ep *executionProgress) counts() *openai.BatchRequestCounts {
 //   - System error:   (counts, firstErr)      — drain as batch_failed
 //   - Pod shutdown:   (nil, ctx.Err())        — no flush, caller re-enqueues
 
-// inferCtx is cancelled when the user requests batch cancellation. Cancelling it aborts all
+// abortCtx is cancelled when the user requests batch cancellation. Cancelling it aborts all
 // in-flight inference HTTP requests immediately, freeing downstream resources (GPU slots, EPP
-// capacity). inferCtx is derived from sloCtx in the caller so the SLO deadline is also respected.
+// capacity). abortCtx is derived from sloCtx in the caller so the SLO deadline is also respected.
 //
 // Dispatch abort relies solely on context cancellation (checkAbortCondition checks ctx.Err()).
 // The cancelRequested flag is NOT polled to stop dispatch; it is only consulted in the
 // error-handling path to distinguish the cancellation reason (user cancel vs SLO vs pod shutdown)
 // and to drain undispatched entries with the correct error code.
-func (p *Processor) executeJob(ctx, sloCtx, inferCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
-	if params.cancelRequested == nil {
-		params.cancelRequested = &atomic.Bool{}
-	}
-
+func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(logging.INFO).Info("Starting execution: executing job")
 
@@ -199,9 +195,9 @@ func (p *Processor) executeJob(ctx, sloCtx, inferCtx context.Context, params *jo
 
 	// one goroutine per model; concurrency within each model is bounded
 	// by globalSem (processor-wide concurrency limit) and perModelMaxConcurrency (per-model concurrency limit).
-	// execCtx is derived from inferCtx (which itself is derived from sloCtx) so both the SLO
+	// execCtx is derived from abortCtx (which itself is derived from sloCtx) so both the SLO
 	// deadline and user-initiated cancellation propagate to all dispatch loops and inference calls.
-	execCtx, execCancel := context.WithCancel(inferCtx)
+	execCtx, execCancel := context.WithCancel(abortCtx)
 	defer execCancel()
 
 	progress := &executionProgress{
@@ -313,9 +309,10 @@ func (p *Processor) executeJob(ctx, sloCtx, inferCtx context.Context, params *jo
 // This prevents starving other models — blocking on global only wastes a local slot.
 //
 // Error strategy in this function: when a goroutine encounters a fatal error, modelErr is captured
-// via errOnce but the context is NOT cancelled within this function. Already-dispatched
-// goroutines run to completion. Context cancellation is propagated at the executeJob level
-// (execCancel), which stops dispatch across all models.
+// via errOnce but the context is NOT cancelled within this function. Context cancellation is
+// propagated at the executeJob level (execCancel), which stops dispatch across all models.
+// Already-dispatched goroutines may finish with errors or cancellation rather than successful
+// completion, depending on when execCancel fires.
 func (p *Processor) processModel(
 	ctx context.Context,
 	sloCtx context.Context,
@@ -384,7 +381,7 @@ dispatch:
 			// If cancel was requested while this request was in-flight,
 			// overwrite the result as batch_cancelled and write to the error file
 			// so that output lines + error lines == total requests.
-			// Note: inferCtx is already cancelled at this point, so the HTTP
+			// Note: abortCtx is already cancelled at this point, so the HTTP
 			// request was aborted and this goroutine returns almost immediately.
 			if cancelRequested.Load() {
 				result.Response = nil

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -312,7 +312,7 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	errWriter := bufio.NewWriter(&errBuf)
 	writers := &outputWriters{output: writer, errors: errWriter}
 
-	// Cancel context to simulate the real flow: watchCancel cancels inferCtx (which
+	// Cancel context to simulate the real flow: watchCancel cancels abortCtx (which
 	// propagates to execCtx passed to processModel) AND sets cancelRequested.
 	ctx, cancel := context.WithCancel(testLoggerCtx())
 	cancel()
@@ -638,7 +638,7 @@ func TestExecuteJob_ContextCancelled(t *testing.T) {
 	}
 }
 
-// TestExecuteJob_UserCancelFlag verifies that when inferCtx is cancelled and cancelRequested
+// TestExecuteJob_UserCancelFlag verifies that when abortCtx is cancelled and cancelRequested
 // is set (matching the real watchCancel flow), executeJob returns ErrCancelled. Context
 // cancellation stops dispatch; cancelRequested is used in the error-handling path to
 // return the correct sentinel error.
@@ -655,10 +655,10 @@ func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	cancelReq.Store(true)
 
 	ctx := testLoggerCtx()
-	inferCtx, inferCancel := context.WithCancel(ctx)
-	inferCancel()
+	abortCtx, abortFn := context.WithCancel(ctx)
+	abortFn()
 
-	_, err := env.p.executeJob(ctx, ctx, inferCtx, &jobExecutionParams{
+	_, err := env.p.executeJob(ctx, ctx, abortCtx, &jobExecutionParams{
 		updater:         env.updater,
 		jobInfo:         jobInfo,
 		cancelRequested: cancelReq,
@@ -703,10 +703,10 @@ func TestExecuteJob_CancelFlagSetAfterAllRequestsComplete(t *testing.T) {
 	}
 }
 
-// TestExecuteJob_InferCtxCancel_AbortsInflightRequests verifies that cancelling inferCtx
+// TestExecuteJob_AbortCtxCancel_AbortsInflightRequests verifies that cancelling abortCtx
 // aborts in-flight inference requests. The mock blocks until it sees context cancellation,
 // simulating a long-running inference call that should be interrupted.
-func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
+func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -731,7 +731,7 @@ func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
 
 	cancelReq := &atomic.Bool{}
 	ctx := testLoggerCtx()
-	inferCtx, inferCancelFn := context.WithCancel(ctx)
+	abortCtx, abortInferFn := context.WithCancel(ctx)
 
 	type result struct {
 		counts *openai.BatchRequestCounts
@@ -739,7 +739,7 @@ func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, ctx, inferCtx, &jobExecutionParams{
+		counts, err := env.p.executeJob(ctx, ctx, abortCtx, &jobExecutionParams{
 			updater:         env.updater,
 			jobInfo:         jobInfo,
 			cancelRequested: cancelReq,
@@ -749,7 +749,7 @@ func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
 
 	<-inferStarted
 	cancelReq.Store(true)
-	inferCancelFn()
+	abortInferFn()
 
 	select {
 	case res := <-resCh:
@@ -769,7 +769,7 @@ func TestExecuteJob_InferCtxCancel_AbortsInflightRequests(t *testing.T) {
 			t.Errorf("Failed = %d, want 1 (aborted request counted as failed)", res.counts.Failed)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("executeJob did not return within 5s after inferCtx cancellation")
+		t.Fatal("executeJob did not return within 5s after abortCtx cancellation")
 	}
 }
 
@@ -833,7 +833,7 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 //
 // This exercises the full context-cancellation chain for SLO expiry:
 //
-//	sloCtx (WithDeadline) → inferCtx (WithCancel) → execCtx (WithCancel)
+//	sloCtx (WithDeadline) → abortCtx (WithCancel) → execCtx (WithCancel)
 //	         DeadlineExceeded       Canceled                Canceled
 //
 // checkAbortCondition sees Canceled on execCtx to stop dispatch;

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -125,7 +125,7 @@ func (p *Processor) finalizeJob(
 			return fmt.Errorf("failed to update job status to cancelled: %w", err)
 		}
 		setRequestCountAttrs(ctx, requestCounts)
-		return nil
+		return ErrCancelled
 	}
 
 	// finalizing → completed

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -283,8 +284,8 @@ func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 	cancelRequested.Store(true)
 
 	err := p.finalizeJob(ctx, updater, staleJob, jobInfo, counts, &cancelRequested)
-	if err != nil {
-		t.Fatalf("finalizeJob error: %v", err)
+	if !errors.Is(err, ErrCancelled) {
+		t.Fatalf("expected ErrCancelled, got: %v", err)
 	}
 
 	// Verify that the final status written to the DB is cancelled, not completed.

--- a/internal/processor/worker/job_execution.go
+++ b/internal/processor/worker/job_execution.go
@@ -18,7 +18,6 @@ package worker
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
@@ -28,17 +27,19 @@ import (
 
 // jobExecutionParams holds the job-scoped state shared across processing stages.
 // Contexts are NOT stored here — they are passed explicitly per Go convention.
+//
+// cancelRequested must be a non-nil *atomic.Bool — it is shared across goroutines
+// (watchCancel, preProcessJob, executeJob, finalizeJob).
 type jobExecutionParams struct {
 	updater *StatusUpdater
 	jobItem *db.BatchItem
 	jobInfo *batch_types.JobInfo
 	task    *db.BatchJobPriority
 
-	eventWatcher  *db.BatchEventsChan
-	inferCancelFn context.CancelFunc
+	eventWatcher *db.BatchEventsChan
+	abortInferFn context.CancelFunc
 
 	cancelRequested *atomic.Bool
-	cancellingOnce  *sync.Once
 
 	requestCounts *openai.BatchRequestCounts
 }

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -61,13 +59,6 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	defer span.End()
 
 	logger := klog.FromContext(ctx)
-
-	if params.cancelRequested == nil {
-		params.cancelRequested = &atomic.Bool{}
-	}
-	if params.cancellingOnce == nil {
-		params.cancellingOnce = &sync.Once{}
-	}
 
 	defer p.wg.Done()
 	defer p.release()
@@ -130,12 +121,12 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	}
 	defer eventWatcher.CloseFn()
 
-	// inferCtx is cancelled when the user requests batch cancellation, propagating
+	// abortCtx is cancelled when the user requests batch cancellation, propagating
 	// the signal to all in-flight inference HTTP requests so they abort promptly.
 	// It is derived from sloCtx so the SLO deadline is also respected.
-	inferCtx, inferCancelFn := context.WithCancel(sloCtx)
-	params.inferCancelFn = inferCancelFn
-	defer inferCancelFn()
+	abortCtx, abortInferFn := context.WithCancel(sloCtx)
+	params.abortInferFn = abortInferFn
+	defer abortInferFn()
 
 	// watch for cancel event
 	params.eventWatcher = eventWatcher
@@ -163,7 +154,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	// execution: execute inference requests
 	var execErr error
-	requestCounts, execErr = p.executeJob(ctx, sloCtx, inferCtx, params)
+	requestCounts, execErr = p.executeJob(ctx, sloCtx, abortCtx, params)
 	params.requestCounts = requestCounts
 	if execErr != nil {
 		switch {
@@ -195,11 +186,18 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	// finalization: upload output, update status to completed
 	if err := p.finalizeJob(ctx, params.updater, params.jobItem, params.jobInfo, requestCounts, params.cancelRequested); err != nil {
+		if errors.Is(err, ErrCancelled) {
+			// Cancel arrived during finalization — DB already updated to cancelled.
+			// Treat as successful cancellation (same as handleCancelled).
+			p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
+			metrics.RecordJobProcessingDuration(time.Since(jobStart), params.jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
+			metrics.RecordJobProcessed(metrics.ResultSuccess, metrics.ReasonNone)
+			logger.V(logging.INFO).Info("Job cancelled during finalization")
+			return
+		}
 		logger.V(logging.ERROR).Error(err, "Failed to finalize job")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "finalize failed")
-		// Upload retries already exhausted inside finalizeJob — don't re-attempt upload.
-		// Pass requestCounts so they are recorded in the failed status.
 		if failErr := p.handleFailed(ctx, params.updater, params.jobItem, requestCounts); failErr != nil {
 			logger.V(logging.ERROR).Error(failErr, "Failed to handle failed event")
 		}
@@ -258,11 +256,12 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 
 	switch {
 	case errors.Is(err, ErrCancelled):
-		// Ingestion cancel: no output files exist yet
-		cancelParams := *params
-		cancelParams.jobInfo = nil
-		cancelParams.requestCounts = nil
-		if cancelErr := p.handleCancelled(ctx, &cancelParams); cancelErr != nil {
+		// Ingestion cancel: no output files exist yet, so clear these fields
+		// to tell handleCancelled to skip partial-output upload.
+		// Safe to mutate params — callers return immediately after handleJobError.
+		params.jobInfo = nil
+		params.requestCounts = nil
+		if cancelErr := p.handleCancelled(ctx, params); cancelErr != nil {
 			logger.V(logging.ERROR).Error(cancelErr, "Failed to handle cancelled event")
 		}
 
@@ -322,11 +321,12 @@ func (p *Processor) uploadPartialResults(
 	return outputFileID, errorFileID
 }
 
-// handleExpired finalizes a job whose SLO deadline fired during execution.
-// Partial results are preserved: completed requests remain in the output file,
-// and unexecuted requests were already written to the error file as "batch_expired"
-// by drainUnprocessedRequests. This function uploads both files and transitions
-// the job directly to expired status (in_progress → expired).
+// handleExpired finalizes a job whose SLO deadline fired.
+// Two cases reach here:
+// (1) deadline expired before dispatch began — no output/error files exist, uploadPartialResults is a no-op;
+// 2) deadline expired during execution — completed requests remain in the output file and undispatched entries were drained
+// as "batch_expired" by drainUnprocessedRequests.
+// In both cases, this function uploads whatever files exist and transitions the job to expired status.
 func (p *Processor) handleExpired(
 	ctx context.Context,
 	updater *StatusUpdater,
@@ -335,7 +335,7 @@ func (p *Processor) handleExpired(
 	requestCounts *openai.BatchRequestCounts,
 ) error {
 	logger := klog.FromContext(ctx)
-	logger.V(logging.INFO).Info("Job SLO expired mid-execution, uploading partial results")
+	logger.V(logging.INFO).Info("Job SLO expired, finalizing as expired")
 
 	outputFileID, errorFileID := p.uploadPartialResults(ctx, jobInfo, dbJob)
 

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d-incubation/batch-gateway/internal/database/mock"
+	mockfiles "github.com/llm-d-incubation/batch-gateway/internal/files_store/mock"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/config"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
@@ -166,6 +168,84 @@ func TestRunJob_PreProcessError_HandlesFailedStatus(t *testing.T) {
 	}
 	if updated.Status != openai.BatchStatusFailed {
 		t.Fatalf("expected failed status, got %s", updated.Status)
+	}
+}
+
+// TestRunJob_WithCancelRequested_ReachesPreProcess verifies that runJob with a properly
+// initialized cancelRequested field proceeds past the event watcher setup and into
+// preProcessJob without panicking.
+func TestRunJob_WithCancelRequested_ReachesPreProcess(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.NumWorkers = 1
+	cfg.WorkDir = t.TempDir()
+
+	dbClient := newMockBatchDBClient()
+	statusClient := mockdb.NewMockBatchStatusClient()
+	eventClient := mockdb.NewMockBatchEventChannelClient()
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  newMockFileDBClient(),
+		Status:  statusClient,
+		Event:   eventClient,
+		File:    mockfiles.NewMockBatchFilesClient(),
+	})
+
+	ctx := testLoggerCtx()
+
+	jobItem := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{ID: "job-contract", TenantID: "tenantA"},
+		BaseContents: db.BaseContents{
+			Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress}),
+		},
+	}
+	if err := dbClient.DBStore(ctx, jobItem); err != nil {
+		t.Fatalf("DBStore: %v", err)
+	}
+
+	// InputFileID is set so preProcessJob proceeds past the empty-check and reaches
+	// the cancelRequested.Load() call. Without cancelRequested initialized, this panics.
+	jobInfo := &batch_types.JobInfo{
+		JobID: "job-contract",
+		BatchJob: &openai.Batch{
+			ID: "job-contract",
+			BatchSpec: openai.BatchSpec{
+				InputFileID: "file-123",
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{Status: openai.BatchStatusInProgress},
+		},
+		TenantID: "tenantA",
+	}
+
+	if !p.acquire(context.Background()) {
+		t.Fatalf("expected token acquire before runJob")
+	}
+	p.wg.Add(1)
+
+	var cancelRequested atomic.Bool
+	p.runJob(ctx, &jobExecutionParams{
+		updater:         NewStatusUpdater(dbClient, statusClient, 86400),
+		jobItem:         jobItem,
+		jobInfo:         jobInfo,
+		cancelRequested: &cancelRequested,
+		task: &db.BatchJobPriority{
+			ID:  "job-contract",
+			SLO: time.Now().Add(1 * time.Hour),
+		},
+	})
+
+	// preProcessJob will fail (file doesn't exist on disk) and handleJobError marks it failed.
+	// The key assertion: we reached handleFailed (not a silent panic recovery).
+	items, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-contract"}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+
+	var updated openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &updated); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if updated.Status != openai.BatchStatusFailed {
+		t.Fatalf("expected failed status (preprocess error handled), got %s", updated.Status)
 	}
 }
 

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -100,7 +100,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	inputFileReader := bufio.NewReaderSize(reader, 1024*1024)
 
 	for {
-		// Ingestion uses the parent ctx (not inferCtx), so user-cancel signals do not
+		// Ingestion uses the parent ctx (not abortCtx), so user-cancel signals do not
 		// propagate through the context tree. Check cancelRequested explicitly.
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -376,17 +375,15 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 	defer evCh.CloseFn()
 
 	var cancelRequested atomic.Bool
-	var cancellingOnce sync.Once
-	inferCtx, inferCancelFn := context.WithCancel(ctx)
+	abortCtx, abortInferFn := context.WithCancel(ctx)
 
 	// Start watching cancel in background
 	params := &jobExecutionParams{
 		eventWatcher:    evCh,
 		updater:         updater,
 		jobItem:         jobItem,
-		inferCancelFn:   inferCancelFn,
+		abortInferFn:    abortInferFn,
 		cancelRequested: &cancelRequested,
-		cancellingOnce:  &cancellingOnce,
 	}
 	go p.watchCancel(ctx, params)
 
@@ -404,12 +401,12 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 		t.Fatalf("cancelRequested was not set")
 	}
 
-	// Verify inference context was cancelled
+	// Verify abort context was cancelled
 	select {
-	case <-inferCtx.Done():
-		// success — inferCancelFn was called
+	case <-abortCtx.Done():
+		// success — abortInferFn was called
 	case <-time.After(2 * time.Second):
-		t.Fatal("inferCtx was not cancelled within 2s after cancel event")
+		t.Fatal("abortCtx was not cancelled within 2s after cancel event")
 	}
 
 	// Verify that watchCancel does NOT update status to cancelling

--- a/internal/processor/worker/recovery.go
+++ b/internal/processor/worker/recovery.go
@@ -192,8 +192,8 @@ func (p *Processor) recoverCancelling(ctx context.Context, dbItem *db.BatchItem,
 }
 
 // recoverInProgress handles a job that crashed during inference execution.
-// If output data exists on disk (bufio auto-flushed >= 1MB), the inference cost is
-// significant — upload partial results and mark as failed.
+// If the output file exists and has non-zero size, inference made meaningful progress
+// — upload partial results and mark as failed.
 // If output is empty or absent, inference barely started — re-enqueue for retry.
 func (p *Processor) recoverInProgress(ctx context.Context, dbItem *db.BatchItem, jobInfo *batch_types.JobInfo) error {
 	logger := klog.FromContext(ctx)

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -248,10 +249,11 @@ func (p *Processor) runPollingLoop(ctx context.Context) error {
 		// process job
 		p.wg.Add(1)
 		go p.runJob(jobCtx, &jobExecutionParams{
-			updater: p.updater,
-			jobItem: jobItem,
-			jobInfo: jobInfo,
-			task:    task,
+			updater:         p.updater,
+			jobItem:         jobItem,
+			jobInfo:         jobInfo,
+			task:            task,
+			cancelRequested: &atomic.Bool{},
 		})
 	}
 }

--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -95,7 +95,7 @@ func doTestBatchCancel(t *testing.T) {
 		finalBatch.ErrorFileID)
 
 	// Verify that in-flight inference requests were actually aborted by the inference client
-	// (context cancellation propagated through inferCtx → execCtx → HTTP request).
+	// (context cancellation propagated through abortCtx → execCtx → HTTP request).
 	if testKubectlAvailable {
 		out, err := exec.Command("kubectl", "logs",
 			"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),


### PR DESCRIPTION
## Why is this PR needed?

Issue #200 identified two problems in the cancellation subsystem:
1. In-flight request results were silently dropped on cancel (already fixed in a prior PR)
2. `cancelRequested` and `cancellingOnce` were lazily initialized in three separate locations, relying on fragile call ordering

Additionally, `inferCtx`/`inferCancelFn` naming was misleading (they abort inference, not perform it), and the finalization-cancel path returned `nil` instead of signalling cancellation to the caller.

## What does this PR do?

**Mechanical renames (no behaviour change):**
- `inferCtx` → `abortCtx`, `inferCancelFn` → `abortInferFn` across all runtime, test, and doc files

**Structural cleanup (no behavior change):**
- Initialize `cancelRequested` at `jobExecutionParams` construction in `runPollingLoop`
- Remove all three lazy-init nil-check guards (`job_runner.go`, `cancel.go`, `executor.go`)
- Remove the unused `cancellingOnce` field and its `sync.Once` import

**New logic (~10 lines):**
- `finalizeJob` returns `ErrCancelled` when cancel is detected during finalization
- `runJob` handles `ErrCancelled` from `finalizeJob` explicitly: cleanup artifacts, record metrics as success (user-initiated cancellation), skip `handleFailed`
- `handleJobError` mutates `params` directly instead of creating a defensive copy (safe because callers return immediately after)

15 files touched, but most changes are mechanical renames and deletions.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

New test: `TestRunJob_WithCancelRequested_ReachesPreProcess` — verifies that `runJob` with eagerly initialized `cancelRequested` proceeds past event watcher setup without panicking.

Updated test: `TestFinalizeJob_CancelRequested_FinalizesCancelled` — now expects `ErrCancelled` instead of `nil`.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Ref #200