### PR TITLE
fix: remove tenantID label from processor metrics to prevent cardinality explosion (Issue #202)

### DIFF
--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -135,6 +135,69 @@ tests:
           any: true
         template: templates/prometheus-rule.yaml
 
+  # --- PrometheusRule expr metric name guards ---
+
+  - it: should use job_queue_wait_duration_seconds_bucket in HighQueueWait expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: job_queue_wait_duration_seconds_bucket
+        template: templates/prometheus-rule.yaml
+
+  - it: should use jobs_processed_total in HighJobFailureRate expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[1].expr
+          pattern: jobs_processed_total
+        template: templates/prometheus-rule.yaml
+
+  - it: should use jobs_processed_total in ExpiredJobsDetected expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[2].expr
+          pattern: jobs_processed_total
+        template: templates/prometheus-rule.yaml
+
+  - it: should use active_workers and total_workers in WorkersSaturated expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[3].expr
+          pattern: active_workers
+        template: templates/prometheus-rule.yaml
+      - matchRegex:
+          path: spec.groups[0].rules[3].expr
+          pattern: total_workers
+        template: templates/prometheus-rule.yaml
+
+  - it: should not reference tenantID in any PrometheusRule expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.groups[0].rules[0].expr
+          pattern: tenantID
+        template: templates/prometheus-rule.yaml
+      - notMatchRegex:
+          path: spec.groups[0].rules[1].expr
+          pattern: tenantID
+        template: templates/prometheus-rule.yaml
+      - notMatchRegex:
+          path: spec.groups[0].rules[2].expr
+          pattern: tenantID
+        template: templates/prometheus-rule.yaml
+      - notMatchRegex:
+          path: spec.groups[0].rules[3].expr
+          pattern: tenantID
+        template: templates/prometheus-rule.yaml
+
   # --- Grafana Dashboards ConfigMap ---
 
   - it: should not render Grafana ConfigMap when disabled (default)
@@ -153,4 +216,57 @@ tests:
       - equal:
           path: metadata.labels["grafana_dashboard"]
           value: "1"
+        template: templates/grafana-dashboards-configmap.yaml
+
+  # --- Dashboard JSON metric name guards ---
+
+  - it: should reference expected processor metric names in dashboard JSON
+    set:
+      grafana.dashboards.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: job_processing_duration_seconds_bucket
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: job_queue_wait_duration_seconds_bucket
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: plan_build_duration_seconds_bucket
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: jobs_processed_total
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: active_workers
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["processor.json"]
+          pattern: processor_inflight_requests
+        template: templates/grafana-dashboards-configmap.yaml
+
+  - it: should not reference tenantID in processor dashboard JSON
+    set:
+      grafana.dashboards.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["processor.json"]
+          pattern: tenantID
+        template: templates/grafana-dashboards-configmap.yaml
+
+  - it: should reference expected apiserver metric names in dashboard JSON
+    set:
+      grafana.dashboards.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["apiserver.json"]
+          pattern: http_requests_total
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["apiserver.json"]
+          pattern: http_request_duration_seconds_bucket
         template: templates/grafana-dashboards-configmap.yaml

--- a/docs/design/batch_processor_architecture.md
+++ b/docs/design/batch_processor_architecture.md
@@ -659,10 +659,10 @@ Tracing is disabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (no-op provide
   - `expired_execution` — SLO deadline fired during execution; partial results preserved
   - `none` — no additional reason beyond the result (e.g. success, cancelled)
 
-- `job_processing_duration_seconds{tenantID,size_bucket}` (histogram)
+- `job_processing_duration_seconds{size_bucket}` (histogram)
   Measures total job processing duration (end-to-end, including ingestion and execution).
 
-- `job_queue_wait_duration_seconds{tenantID}` (histogram)
+- `job_queue_wait_duration_seconds` (histogram)
   Measures how long a job waited in the priority queue before being picked up.
 
 **Worker Utilization Metrics**
@@ -685,7 +685,7 @@ Tracing is disabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (no-op provide
 
 **Duration Metrics**
 
-- `plan_build_duration_seconds{tenantID,size_bucket}` (histogram)
+- `plan_build_duration_seconds{size_bucket}` (histogram)
   Measures ingestion and plan build duration.
 
 - `model_request_execution_duration_seconds{model}` (histogram)
@@ -706,6 +706,6 @@ Tracing is disabled when `OTEL_EXPORTER_OTLP_ENDPOINT` is not set (no-op provide
 
 - `batch_startup_recovery_total{status,action}` (counter)
   Counts jobs recovered during processor startup after a container restart.
-  - `status`: the DB status of the recovered job (`in_progress`, `finalizing`, `cancelling`, `validating`)
-  - `action`: the recovery action taken (`re_enqueued`, `failed`, `finalized`, `cancelled`, `cleaned`)
-  Non-zero values indicate container-level crashes (OOM, panic) occurred.
+  - `status`: the recovered job status at the time recovery ran. Common values include `in_progress`, `finalizing`, `cancelling`, `validating`, and `unknown` when the DB lookup failed or no DB record existed.
+  - `action`: the recovery action taken. Values include `re_enqueued`, `failed`, `finalized`, `cancelled`, `expired`, `cleaned_up`, and `error`.
+  Non-zero values indicate container-level crashes (OOM, panic) or stale on-disk artifacts from a prior processor instance.

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -1,7 +1,7 @@
 # Metrics
 
-**Revision:** 1.1
-**Last Modified:** 2026-03-26
+**Revision:** 1.2
+**Last Modified:** 2026-03-27
 
 Metric names below match `internal/*/metrics/metrics.go` (and related packages). Deployments may add a namespace/subsystem prefix when registering; check `/metrics` on the running binary for the exact series name.
 
@@ -19,6 +19,8 @@ The API server exposes the following Prometheus metrics (`internal/apiserver/met
 
 The processor exposes the following Prometheus metrics (`internal/processor/metrics/metrics.go`):
 
+Processor metrics intentionally omit unbounded identifiers such as tenant IDs. Per-tenant breakdown belongs in logs or traces, not Prometheus labels, to avoid cardinality growth.
+
 **Job-Level Metrics:**
 
 - `jobs_processed_total{result,reason}` (Counter) - Total jobs processed by result and reason.
@@ -27,11 +29,11 @@ The processor exposes the following Prometheus metrics (`internal/processor/metr
 
   **reason** values (see `internal/processor/metrics/metrics.go`): `system_error`, `guard_shutdown`, `db_transient`, `db_inconsistency`, `not_runnable_state`, `expired_dequeue`, `expired_execution`, `none`.
 
-- `job_processing_duration_seconds{tenantID,size_bucket}` (Histogram) - End-to-end job processing duration. `size_bucket` is derived from input line count (`100`, `1000`, `10000`, `30000`, `large`).
+- `job_processing_duration_seconds{size_bucket}` (Histogram) - End-to-end job processing duration. `size_bucket` is derived from input line count (`100`, `1000`, `10000`, `30000`, `large`).
 
-- `job_queue_wait_duration_seconds{tenantID}` (Histogram) - Time spent in the priority queue before being picked up.
+- `job_queue_wait_duration_seconds` (Histogram) - Time spent in the priority queue before being picked up.
 
-- `plan_build_duration_seconds{tenantID,size_bucket}` (Histogram) - Duration of ingestion and plan build in seconds.
+- `plan_build_duration_seconds{size_bucket}` (Histogram) - Duration of ingestion and plan build in seconds.
 
 **Worker Metrics:**
 
@@ -55,10 +57,22 @@ The processor exposes the following Prometheus metrics (`internal/processor/metr
 
 **Startup Recovery:**
 
-- `batch_startup_recovery_total{status,action}` (Counter) - Jobs recovered during processor startup after a container restart. Non-zero values indicate prior container-level crashes (OOM, panic). Label values are defined in code paths that call `RecordStartupRecovery`.
+- `batch_startup_recovery_total{status,action}` (Counter) - Jobs recovered during processor startup after a container restart. `status` is the recovered job status (common values: `in_progress`, `finalizing`, `cancelling`, `validating`, `unknown`). `action` is the recovery action taken (common values: `re_enqueued`, `failed`, `finalized`, `cancelled`, `expired`, `cleaned_up`, `error`). Non-zero values indicate prior container-level crashes (OOM, panic) or stale on-disk artifacts from a prior processor instance.
 
 ## Shared (file storage retry client)
 
 Used by components that wrap file storage with retries (`internal/files_store/retryclient/metrics.go`):
 
 - `file_storage_operations_total{operation,component,status}` (Counter) - File storage operations by outcome. `operation` is `store` / `retrieve` / `delete`; `component` is `processor` / `apiserver` / `garbage-collector`; `status` is `success`, `retry`, or `exhausted`.
+
+## Dashboard PromQL: aggregated quantile caveat
+
+The default Grafana dashboards (`charts/batch-gateway/dashboards/`) compute histogram quantiles by summing buckets across all pods first, then applying `histogram_quantile`:
+
+```promql
+histogram_quantile(0.95, sum(rate(..._bucket{namespace="$namespace"}[5m])) by (le))
+```
+
+This yields a **fleet-wide approximate percentile**, not a mathematically exact one. The approximation is acceptable for this system because each job is processed by exactly one pod, and the priority queue distributes work roughly evenly. However, if pod-level distributions diverge significantly (e.g., one pod consistently receives larger jobs), the aggregated quantile can mask per-pod outliers.
+
+For per-pod breakdown, add `by (le, pod)` inside `histogram_quantile` and use a Grafana variable to select individual pods. The default dashboards intentionally omit this to keep the fleet-level SLO view simple.

--- a/internal/processor/metrics/metrics.go
+++ b/internal/processor/metrics/metrics.go
@@ -167,7 +167,7 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 				cfg.ProcessTimeBucket.BucketFactor,
 				cfg.ProcessTimeBucket.BucketCount,
 			),
-		}, []string{"tenantID", "size_bucket"},
+		}, []string{"size_bucket"},
 	)
 
 	// per-model in-flight requests during execution
@@ -202,7 +202,7 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 				cfg.ProcessTimeBucket.BucketFactor,
 				cfg.ProcessTimeBucket.BucketCount,
 			),
-		}, []string{"tenantID", "size_bucket"},
+		}, []string{"size_bucket"},
 	)
 
 	// duration of queue wait time
@@ -215,7 +215,7 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 				cfg.QueueTimeBucket.BucketFactor,
 				cfg.QueueTimeBucket.BucketCount,
 			),
-		}, []string{"tenantID"},
+		}, nil,
 	)
 
 	// Startup recovery: counts jobs discovered in workdir after a container restart.
@@ -267,8 +267,8 @@ func InitMetrics(cfg config.ProcessorConfig) error {
 // Recorder funcs
 
 // RecordQueueWait observes the queue time
-func RecordQueueWaitDuration(duration time.Duration, tenantID string) {
-	jobQueueWaitDuration.WithLabelValues(tenantID).Observe(duration.Seconds())
+func RecordQueueWaitDuration(duration time.Duration) {
+	jobQueueWaitDuration.WithLabelValues().Observe(duration.Seconds())
 }
 
 // RecordJobProcessed increments the total processed jobs count.
@@ -277,8 +277,8 @@ func RecordJobProcessed(result string, reason string) {
 }
 
 // RecordJobProcessingDuration observes the time taken to process a job.
-func RecordJobProcessingDuration(duration time.Duration, tenantID string, sizeBucket string) {
-	jobProcessingDuration.WithLabelValues(tenantID, sizeBucket).Observe(duration.Seconds())
+func RecordJobProcessingDuration(duration time.Duration, sizeBucket string) {
+	jobProcessingDuration.WithLabelValues(sizeBucket).Observe(duration.Seconds())
 }
 
 // IncActiveWorkers increments the gauge for active workers.
@@ -307,8 +307,8 @@ func DecProcessorInflightRequests() {
 }
 
 // RecordPlanBuildDuration observes ingestion plan build duration.
-func RecordPlanBuildDuration(duration time.Duration, tenantID string, sizeBucket string) {
-	planBuildDuration.WithLabelValues(tenantID, sizeBucket).Observe(duration.Seconds())
+func RecordPlanBuildDuration(duration time.Duration, sizeBucket string) {
+	planBuildDuration.WithLabelValues(sizeBucket).Observe(duration.Seconds())
 }
 
 // IncModelInflightRequests increments the in-flight request gauge for a model.

--- a/internal/processor/metrics/metrics_test.go
+++ b/internal/processor/metrics/metrics_test.go
@@ -24,23 +24,101 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-// replace with a new registry for every test
 func withIsolatedPromRegistry(t *testing.T, fn func(reg *prometheus.Registry)) {
 	t.Helper()
-
-	oldReg := prometheus.DefaultRegisterer
-	oldGather := prometheus.DefaultGatherer
-
+	oldReg, oldGather := prometheus.DefaultRegisterer, prometheus.DefaultGatherer
 	reg := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = reg
 	prometheus.DefaultGatherer = reg
-
 	t.Cleanup(func() {
 		prometheus.DefaultRegisterer = oldReg
 		prometheus.DefaultGatherer = oldGather
 	})
-
 	fn(reg)
+}
+
+func collectFamilies(t *testing.T, reg *prometheus.Registry) map[string]*dto.MetricFamily {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	out := make(map[string]*dto.MetricFamily, len(mfs))
+	for _, mf := range mfs {
+		out[mf.GetName()] = mf
+	}
+	return out
+}
+
+func labelNamesOf(m *dto.Metric) []string {
+	if m == nil || len(m.Label) == 0 {
+		return nil
+	}
+	names := make([]string, len(m.Label))
+	for i, lp := range m.Label {
+		names[i] = lp.GetName()
+	}
+	return names
+}
+
+func assertLabelNames(t *testing.T, mf *dto.MetricFamily, want []string) {
+	t.Helper()
+	if mf == nil || len(mf.Metric) == 0 {
+		t.Fatal("empty metric family")
+	}
+	got := labelNamesOf(mf.Metric[0])
+	if len(got) != len(want) {
+		t.Fatalf("labels=%v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("labels=%v, want %v", got, want)
+		}
+	}
+}
+
+func gaugeValue(mf *dto.MetricFamily) float64 {
+	if mf == nil || len(mf.Metric) != 1 {
+		return -1
+	}
+	return mf.Metric[0].GetGauge().GetValue()
+}
+
+func counterWithLabels(mf *dto.MetricFamily, want map[string]string) float64 {
+	if mf == nil {
+		return -1
+	}
+outer:
+	for _, m := range mf.Metric {
+		for k, v := range want {
+			var got string
+			for _, lp := range m.Label {
+				if lp.GetName() == k {
+					got = lp.GetValue()
+					break
+				}
+			}
+			if got != v {
+				continue outer
+			}
+		}
+		return m.GetCounter().GetValue()
+	}
+	return -1
+}
+
+func gaugeWithLabel(mf *dto.MetricFamily, label, value string) float64 {
+	if mf == nil {
+		return -1
+	}
+	for _, m := range mf.Metric {
+		for _, lp := range m.Label {
+			if lp.GetName() == label && lp.GetValue() == value {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return -1
 }
 
 func TestGetSizeBucket(t *testing.T) {
@@ -59,10 +137,8 @@ func TestGetSizeBucket(t *testing.T) {
 		{30000, BucketLarge},
 		{999999, BucketLarge},
 	}
-
 	for _, tc := range cases {
-		got := GetSizeBucket(tc.lines)
-		if got != tc.want {
+		if got := GetSizeBucket(tc.lines); got != tc.want {
 			t.Fatalf("GetSizeBucket(%d)=%q, want %q", tc.lines, got, tc.want)
 		}
 	}
@@ -74,217 +150,85 @@ func TestInitMetrics_AndRecorders(t *testing.T) {
 		cfg.NumWorkers = 7
 
 		if err := InitMetrics(cfg); err != nil {
-			t.Fatalf("InitMetrics() error: %v", err)
+			t.Fatalf("InitMetrics: %v", err)
 		}
 
-		// recorder calls
 		RecordJobProcessed(ResultSuccess, ReasonNone)
 		RecordJobProcessed(ResultFailed, ReasonSystemError)
-
-		RecordQueueWaitDuration(250*time.Millisecond, "tenantA")
-		RecordJobProcessingDuration(1500*time.Millisecond, "tenantA", Bucket1000)
-
+		RecordQueueWaitDuration(250 * time.Millisecond)
+		RecordJobProcessingDuration(1500*time.Millisecond, Bucket1000)
 		IncActiveWorkers()
 		IncActiveWorkers()
 		DecActiveWorkers()
-
 		RecordRequestError("test")
 		RecordRequestError("test")
 		IncProcessorInflightRequests()
 		IncProcessorInflightRequests()
 		DecProcessorInflightRequests()
-		RecordPlanBuildDuration(2*time.Second, "tenantA", Bucket1000)
+		RecordPlanBuildDuration(2*time.Second, Bucket1000)
 		IncModelInflightRequests("modelA")
 		IncModelInflightRequests("modelA")
 		DecModelInflightRequests("modelA")
 		RecordModelRequestExecutionDuration(300*time.Millisecond, "modelA")
-		// gather + value check
-		mfs, err := reg.Gather()
-		if err != nil {
-			t.Fatalf("Gather() error: %v", err)
+
+		f := collectFamilies(t, reg)
+
+		if v := gaugeValue(f["total_workers"]); v != float64(cfg.NumWorkers) {
+			t.Fatalf("total_workers=%v, want %v", v, cfg.NumWorkers)
+		}
+		if v := gaugeValue(f["active_workers"]); v != 1 {
+			t.Fatalf("active_workers=%v, want 1", v)
+		}
+		if v := gaugeValue(f["processor_inflight_requests"]); v != 1 {
+			t.Fatalf("processor_inflight_requests=%v, want 1", v)
+		}
+		if v := gaugeValue(f["processor_max_inflight_concurrency"]); v != float64(cfg.GlobalConcurrency) {
+			t.Fatalf("processor_max_inflight_concurrency=%v, want %v", v, cfg.GlobalConcurrency)
 		}
 
-		// helpers
-		find := func(name string) *dto.MetricFamily {
-			for _, mf := range mfs {
-				if mf.GetName() == name {
-					return mf
-				}
-			}
-			return nil
+		if v := counterWithLabels(f["jobs_processed_total"], map[string]string{"result": ResultSuccess, "reason": ReasonNone}); v != 1 {
+			t.Fatalf("jobs_processed success/none=%v, want 1", v)
+		}
+		if v := counterWithLabels(f["jobs_processed_total"], map[string]string{"result": ResultFailed, "reason": ReasonSystemError}); v != 1 {
+			t.Fatalf("jobs_processed failed/system_error=%v, want 1", v)
+		}
+		if v := counterWithLabels(f["request_errors_by_model_total"], map[string]string{"model": "test"}); v != 2 {
+			t.Fatalf("request_errors_by_model_total=%v, want 2", v)
+		}
+		if v := gaugeWithLabel(f["model_inflight_requests"], "model", "modelA"); v != 1 {
+			t.Fatalf("model_inflight_requests{modelA}=%v, want 1", v)
 		}
 
-		// total_workers gauge == cfg.NumWorkers
-		{
-			mf := find("total_workers")
-			if mf == nil || len(mf.Metric) != 1 {
-				t.Fatalf("total_workers metric not found or invalid")
-			}
-			got := mf.Metric[0].GetGauge().GetValue()
-			if got != float64(cfg.NumWorkers) {
-				t.Fatalf("total_workers=%v, want %v", got, float64(cfg.NumWorkers))
-			}
-		}
+		// No high-cardinality tenant label on these histograms (regression guard).
+		assertLabelNames(t, f["job_queue_wait_duration_seconds"], nil)
+		assertLabelNames(t, f["job_processing_duration_seconds"], []string{"size_bucket"})
+		assertLabelNames(t, f["plan_build_duration_seconds"], []string{"size_bucket"})
 
-		// active_workers gauge == 1 (2 inc, 1 dec)
-		{
-			mf := find("active_workers")
-			if mf == nil || len(mf.Metric) != 1 {
-				t.Fatalf("active_workers metric not found or invalid")
-			}
-			got := mf.Metric[0].GetGauge().GetValue()
-			if got != 1 {
-				t.Fatalf("active_workers=%v, want %v", got, 1)
-			}
-		}
-
-		// jobs_processed_total counter: (success/none)=1, (failed/system_error)=1
-		{
-			mf := find("jobs_processed_total")
-			if mf == nil {
-				t.Fatalf("jobs_processed_total not found")
-			}
-			// label match > count check
-			var successNone, failedSys float64
-			for _, m := range mf.Metric {
-				var result, reason string
-				for _, lp := range m.Label {
-					if lp.GetName() == "result" {
-						result = lp.GetValue()
-					}
-					if lp.GetName() == "reason" {
-						reason = lp.GetValue()
-					}
-				}
-				val := m.GetCounter().GetValue()
-				if result == ResultSuccess && reason == ReasonNone {
-					successNone = val
-				}
-				if result == ResultFailed && reason == ReasonSystemError {
-					failedSys = val
-				}
-			}
-			if successNone != 1 {
-				t.Fatalf("jobs_processed_total{result=%q,reason=%q}=%v, want 1", ResultSuccess, ReasonNone, successNone)
-			}
-			if failedSys != 1 {
-				t.Fatalf("jobs_processed_total{result=%q,reason=%q}=%v, want 1", ResultFailed, ReasonSystemError, failedSys)
-			}
-		}
-
-		{
-			mf := find("request_errors_by_model_total")
-			if mf == nil {
-				t.Fatalf("request_errors_by_model_total not found")
-			}
-			var got float64
-			for _, m := range mf.Metric {
-				var model string
-				for _, lp := range m.Label {
-					if lp.GetName() == "model" {
-						model = lp.GetValue()
-					}
-				}
-				if model == "test" {
-					got = m.GetCounter().GetValue()
-				}
-			}
-			if got != 2 {
-				t.Fatalf("request_errors_by_model_total{model=%q}=%v, want 2", "test", got)
-			}
-		}
-
-		// histogram minimal observation check
-		{
-			mf := find("job_queue_wait_duration_seconds")
+		for _, name := range []string{
+			"job_queue_wait_duration_seconds",
+			"job_processing_duration_seconds",
+			"plan_build_duration_seconds",
+			"model_request_execution_duration_seconds",
+		} {
+			mf := f[name]
 			if mf == nil || len(mf.Metric) == 0 {
-				t.Fatalf("job_queue_wait_duration_seconds not found")
+				t.Fatalf("%s: missing or empty", name)
 			}
 			if mf.Metric[0].GetHistogram().GetSampleCount() < 1 {
-				t.Fatalf("expected at least 1 observation")
-			}
-		}
-		{
-			mf := find("job_processing_duration_seconds")
-			if mf == nil {
-				t.Fatalf("job_processing_duration_seconds not found")
-			}
-			if len(mf.Metric) == 0 {
-				t.Fatalf("job_processing_duration_seconds has no metrics")
-			}
-		}
-		{
-			mf := find("processor_inflight_requests")
-			if mf == nil || len(mf.Metric) != 1 {
-				t.Fatalf("processor_inflight_requests metric not found or invalid")
-			}
-			got := mf.Metric[0].GetGauge().GetValue()
-			if got != 1 {
-				t.Fatalf("processor_inflight_requests=%v, want %v", got, 1)
-			}
-		}
-		{
-			mf := find("plan_build_duration_seconds")
-			if mf == nil || len(mf.Metric) == 0 {
-				t.Fatalf("plan_build_duration_seconds not found")
-			}
-			if mf.Metric[0].GetHistogram().GetSampleCount() < 1 {
-				t.Fatalf("expected at least 1 observation for plan_build_duration_seconds")
-			}
-		}
-		{
-			mf := find("model_inflight_requests")
-			if mf == nil || len(mf.Metric) == 0 {
-				t.Fatalf("model_inflight_requests not found")
-			}
-			var got float64
-			for _, m := range mf.Metric {
-				var model string
-				for _, lp := range m.Label {
-					if lp.GetName() == "model" {
-						model = lp.GetValue()
-					}
-				}
-				if model == "modelA" {
-					got = m.GetGauge().GetValue()
-				}
-			}
-			if got != 1 {
-				t.Fatalf("model_inflight_requests{model=%q}=%v, want 1", "modelA", got)
-			}
-		}
-		{
-			mf := find("model_request_execution_duration_seconds")
-			if mf == nil || len(mf.Metric) == 0 {
-				t.Fatalf("model_request_execution_duration_seconds not found")
-			}
-			if mf.Metric[0].GetHistogram().GetSampleCount() < 1 {
-				t.Fatalf("expected at least 1 observation for model_request_execution_duration_seconds")
-			}
-		}
-		{
-			mf := find("processor_max_inflight_concurrency")
-			if mf == nil || len(mf.Metric) != 1 {
-				t.Fatalf("processor_max_inflight_concurrency metric not found or invalid")
-			}
-			got := mf.Metric[0].GetGauge().GetValue()
-			if got != float64(cfg.GlobalConcurrency) {
-				t.Fatalf("processor_max_inflight_concurrency=%v, want %v", got, float64(cfg.GlobalConcurrency))
+				t.Fatalf("%s: expected ≥1 observation", name)
 			}
 		}
 	})
 }
 
 func TestInitMetrics_Twice_DoesNotError(t *testing.T) {
-	withIsolatedPromRegistry(t, func(reg *prometheus.Registry) {
+	withIsolatedPromRegistry(t, func(*prometheus.Registry) {
 		cfg := *config.NewConfig()
-
 		if err := InitMetrics(cfg); err != nil {
-			t.Fatalf("InitMetrics first error: %v", err)
+			t.Fatalf("first InitMetrics: %v", err)
 		}
-		// AlreadyRegisteredError is passed with continue. expect no error.
 		if err := InitMetrics(cfg); err != nil {
-			t.Fatalf("InitMetrics second error: %v", err)
+			t.Fatalf("second InitMetrics: %v", err)
 		}
 	})
 }

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -164,7 +164,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 				span.RecordError(expiredErr)
 				span.SetStatus(codes.Error, "expired finalization failed")
 			}
-			metrics.RecordJobProcessingDuration(time.Since(jobStart), params.jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
+			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 
 		case errors.Is(execErr, ErrCancelled):
 			if cancelErr := p.handleCancelled(ctx, params); cancelErr != nil {
@@ -173,7 +173,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 				span.SetStatus(codes.Error, "cancelled finalization failed")
 			}
 			if requestCounts != nil {
-				metrics.RecordJobProcessingDuration(time.Since(jobStart), params.jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
+				metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 			}
 
 		default:
@@ -190,7 +190,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 			// Cancel arrived during finalization — DB already updated to cancelled.
 			// Treat as successful cancellation (same as handleCancelled).
 			p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
-			metrics.RecordJobProcessingDuration(time.Since(jobStart), params.jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
+			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 			metrics.RecordJobProcessed(metrics.ResultSuccess, metrics.ReasonNone)
 			logger.V(logging.INFO).Info("Job cancelled during finalization")
 			return
@@ -206,7 +206,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	// cleanup local artifacts (best-effort)
 	p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
-	metrics.RecordJobProcessingDuration(time.Since(jobStart), params.jobItem.TenantID, metrics.GetSizeBucket(int(requestCounts.Total)))
+	metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 	metrics.RecordJobProcessed(metrics.ResultSuccess, metrics.ReasonNone)
 	logger.V(logging.INFO).Info("Job completed successfully")
 }

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -167,7 +167,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		return err
 	}
 
-	metrics.RecordPlanBuildDuration(time.Since(planBuildStart), jobInfo.TenantID, metrics.GetSizeBucket(int(lineCount)))
+	metrics.RecordPlanBuildDuration(time.Since(planBuildStart), metrics.GetSizeBucket(int(lineCount)))
 	modelCounts := make(map[string]int, len(modelToSafe))
 	for model, safe := range modelToSafe {
 		modelCounts[model] = len(acc.entries[safe])

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -212,7 +212,7 @@ func (p *Processor) runPollingLoop(pollingCtx, jobBaseCtx context.Context) error
 		// queue wait metrics recording
 		if jobPriorityData, err := batch_utils.GetJobPriorityDataFromQueueItem(task); err == nil {
 			queueWait := time.Since(time.Unix(jobPriorityData.CreatedAt, 0))
-			metrics.RecordQueueWaitDuration(queueWait, jobItem.TenantID)
+			metrics.RecordQueueWaitDuration(queueWait)
 			pollLogger.V(logging.TRACE).Info("Queue wait duration recorded", "duration", queueWait)
 		} else {
 			pollLogger.Error(err, "Failed to get job priority data from queue item")


### PR DESCRIPTION
## Why is this PR needed?

Three processor histogram metrics — `job_processing_duration_seconds`, `job_queue_wait_duration_seconds`, and `plan_build_duration_seconds` — use `tenantID` as a Prometheus label. In a multi-tenant environment each unique
tenant creates a new time series per metric, leading to unbounded cardinality growth, high Prometheus memory usage, slow queries, and potential OOM.

Per-tenant observability belongs in logs and traces (span attributes), not metric labels.

## What does this PR do?

**Metric label removal:**
- Remove `tenantID` from the label set of the three histograms in   `internal/processor/metrics/metrics.go`.
- Update recorder function signatures (`RecordQueueWaitDuration`,   `RecordJobProcessingDuration`, `RecordPlanBuildDuration`) to drop the `tenantID` parameter.
- Update all 6 call sites in `job_runner.go`, `preprocessor.go`, and `worker.go`.

**Regression guards:**
- Add `assertLabelNames` checks in `metrics_test.go` that verify the exact label set of each histogram. Re-introducing `tenantID` immediately fails the test.
- Add Helm observability tests in `observability_test.yaml`:
  - PrometheusRule expr metric name guards (all 4 alert rules).
  - `notMatchRegex` for `tenantID` across all PrometheusRule exprs.
  - Dashboard JSON metric name guards for both processor and apiserver
    dashboards.
  - `notMatchRegex` for `tenantID` in processor dashboard JSON.

**Documentation:**
- Update `docs/guides/metrics.md` and
  `docs/design/batch_processor_architecture.md` to reflect the new label schema.
- Add cardinality policy note explaining that processor metrics intentionally omit unbounded identifiers.
- Add "aggregated quantile caveat" section documenting the fleet-wide `sum by (le)` approximation used in dashboard PromQL.
- Improve `batch_startup_recovery_total` label descriptions with common values and broader scope.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Pre-commit checks pass (`pre-commit run -a` — 15 hooks PASS)
- [x] E2E tests pass (`make test-e2e`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #202