### PR TITLE
fix: preserve HTTP status code and response body in batch output

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -76,6 +76,18 @@ type outputError struct {
 	Message string `json:"message"`
 }
 
+// isSuccess returns true when the output line represents a fully successful request
+// (no non-HTTP error and a 200 HTTP status). HTTP error responses (4xx/5xx) are not
+// considered successful even though they populate the Response field.
+//
+// NOTE: because HTTP errors are written to the output file (not the error file),
+// request_counts.failed may be greater than the number of lines in the error file.
+// This diverges from OpenAI's documented behavior but aligns with the OpenAPI schema
+// (see executeOneRequest for rationale).
+func (o *outputLine) isSuccess() bool {
+	return o.Error == nil && o.Response != nil && o.Response.StatusCode == 200
+}
+
 // progressUpdateInterval is the minimum time between Redis progress updates.
 // Updates within this window are skipped — the next update after the interval
 // will include all accumulated progress. Declared as var so tests can override.
@@ -437,7 +449,7 @@ dispatch:
 				return
 			}
 
-			progress.record(ctx, result.Error == nil)
+			progress.record(ctx, result.isSuccess())
 
 			lineBytes, marshalErr := json.Marshal(result)
 			if marshalErr != nil {
@@ -447,7 +459,9 @@ dispatch:
 			}
 			lineBytes = append(lineBytes, '\n')
 
-			// Write to error file if the result has an error, otherwise to output file.
+			// Write to error file only for non-HTTP errors (error field populated).
+			// HTTP error responses (4xx/5xx) go to output file since they carry a valid
+			// response object with status_code and body per the OpenAI batch spec.
 			isError := result.Error != nil
 			if writeErr := writers.write(lineBytes, isError); writeErr != nil {
 				kind := "output"
@@ -630,13 +644,45 @@ func (p *Processor) executeOneRequest(
 		CustomID: req.CustomID,
 	}
 
-	// response handling by case
+	// Response handling by case.
+	//
+	// Design note: HTTP errors (4xx/5xx) are written to the output file with their
+	// status code and body, rather than the error file. The OpenAI Batch API guides
+	// describe output_file_id as containing "successfully executed requests", but
+	// the OpenAPI schema defines the error field as "for requests that failed with a
+	// non-HTTP error", implying HTTP errors belong in the response. We follow the
+	// schema interpretation here, as it preserves the HTTP status code and body for
+	// callers to inspect.
 	if inferErr != nil {
-		// error is returned by the inference client
 		logger.V(logging.DEBUG).Info("Inference request failed", "error", inferErr.Message)
-		result.Error = &outputError{
-			Code:    string(inferErr.Category),
-			Message: inferErr.Message,
+		if inferErr.StatusCode > 0 {
+			// HTTP error (4xx/5xx) — populate response with status code and original body
+			// per OpenAI spec, error field is only for non-HTTP errors
+			// Ensure body is always a non-nil object to satisfy the OpenAI schema (type: object).
+			body := make(map[string]interface{})
+			if len(inferErr.ResponseBody) > 0 {
+				if err := json.Unmarshal(inferErr.ResponseBody, &body); err != nil {
+					// Non-JSON response body cannot be placed directly into a JSON object field,
+					// so we wrap it in a synthetic error structure to preserve the content.
+					body = map[string]interface{}{
+						"error": map[string]interface{}{
+							"message": string(inferErr.ResponseBody),
+							"type":    inferErr.OpenAIErrorType(),
+						},
+					}
+				}
+			}
+			result.Response = &batch_types.ResponseData{
+				StatusCode: inferErr.StatusCode,
+				RequestID:  inferReq.RequestID,
+				Body:       body,
+			}
+		} else {
+			// Non-HTTP error (network, timeout, etc.)
+			result.Error = &outputError{
+				Code:    string(inferErr.Category),
+				Message: inferErr.Message,
+			}
 		}
 	} else if inferResp == nil {
 		// ok status without error but no response
@@ -669,7 +715,7 @@ func (p *Processor) executeOneRequest(
 		}
 	}
 
-	if result.Error != nil {
+	if !result.isSuccess() {
 		metrics.RecordRequestError(modelID)
 	}
 	return result, nil

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -77,7 +77,7 @@ func TestExecuteOneRequest_Success(t *testing.T) {
 	}
 }
 
-func TestExecuteOneRequest_InferenceError(t *testing.T) {
+func TestExecuteOneRequest_NonHTTPError(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -108,13 +108,166 @@ func TestExecuteOneRequest_InferenceError(t *testing.T) {
 		t.Fatalf("executeOneRequest should not return error for inference failure, got: %v", err)
 	}
 	if result.Error == nil {
-		t.Fatalf("expected error field in output line")
+		t.Fatalf("expected error field in output line for non-HTTP error")
 	}
 	if result.Error.Code != string(httpclient.ErrCategoryServer) {
 		t.Fatalf("error code = %q, want %q", result.Error.Code, httpclient.ErrCategoryServer)
 	}
 	if result.Response != nil {
-		t.Fatalf("expected nil response on inference error")
+		t.Fatalf("expected nil response on non-HTTP error")
+	}
+}
+
+func TestExecuteOneRequest_HTTPError(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	errorBody := []byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","code":"model_not_found"}}`)
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return nil, &inference.ClientError{
+				Category:     httpclient.ErrCategoryInvalidReq,
+				Message:      "HTTP 422: Invalid model",
+				StatusCode:   422,
+				ResponseBody: errorBody,
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-http-err", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("expected nil error for HTTP error response, got: %+v", result.Error)
+	}
+	if result.Response == nil {
+		t.Fatalf("expected response field for HTTP error")
+	}
+	if result.Response.StatusCode != 422 {
+		t.Fatalf("status_code = %d, want 422", result.Response.StatusCode)
+	}
+	if result.Response.Body == nil {
+		t.Fatalf("expected non-nil body")
+	}
+	// Verify the original error body is preserved
+	errObj, ok := result.Response.Body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected error object in body, got: %v", result.Response.Body)
+	}
+	if errObj["message"] != "Invalid model" {
+		t.Fatalf("expected error message 'Invalid model', got: %v", errObj["message"])
+	}
+	if errObj["code"] != "model_not_found" {
+		t.Fatalf("expected error code 'model_not_found', got: %v", errObj["code"])
+	}
+}
+
+func TestExecuteOneRequest_HTTPErrorEmptyBody(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return nil, &inference.ClientError{
+				Category:     httpclient.ErrCategoryServer,
+				Message:      "HTTP 502: ",
+				StatusCode:   502,
+				ResponseBody: nil,
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-empty", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Response == nil {
+		t.Fatalf("expected response field for HTTP error")
+	}
+	if result.Response.StatusCode != 502 {
+		t.Fatalf("status_code = %d, want 502", result.Response.StatusCode)
+	}
+	// Body should be empty object {}, not null
+	if result.Response.Body == nil {
+		t.Fatalf("expected non-nil body (empty object), got nil")
+	}
+	if len(result.Response.Body) != 0 {
+		t.Fatalf("expected empty body object, got: %v", result.Response.Body)
+	}
+}
+
+func TestExecuteOneRequest_HTTPErrorNonJSONBody(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return nil, &inference.ClientError{
+				Category:     httpclient.ErrCategoryServer,
+				Message:      "HTTP 500: Bad Gateway",
+				StatusCode:   500,
+				ResponseBody: []byte("<html>Bad Gateway</html>"),
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-html", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	result, err := env.p.executeOneRequest(ctx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Response == nil {
+		t.Fatalf("expected response field for HTTP error")
+	}
+	// Non-JSON body should be wrapped in synthetic error object
+	errObj, ok := result.Response.Body["error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected synthetic error object in body, got: %v", result.Response.Body)
+	}
+	if errObj["message"] != "<html>Bad Gateway</html>" {
+		t.Fatalf("expected original body as message, got: %v", errObj["message"])
+	}
+	if errObj["type"] != "server_error" {
+		t.Fatalf("expected type %q, got: %v", "server_error", errObj["type"])
 	}
 }
 
@@ -1068,6 +1221,126 @@ func TestExecuteJob_SeparatesSuccessAndErrors(t *testing.T) {
 	}
 	if errLine.Error == nil || errLine.Response != nil {
 		t.Fatalf("error line: want error set and response nil, got response=%v error=%v", errLine.Response, errLine.Error)
+	}
+}
+
+// TestExecuteJob_HTTPErrorGoesToOutputFile verifies that HTTP error responses (4xx/5xx)
+// are written to output.jsonl (not error.jsonl) with the response field populated,
+// while non-HTTP errors go to error.jsonl with the error field populated.
+// This matches the OpenAI batch spec: error file is for non-HTTP failures only.
+func TestExecuteJob_HTTPErrorGoesToOutputFile(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	var callCount atomic.Int32
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			n := callCount.Add(1)
+			switch n {
+			case 1:
+				// success
+				return &inference.GenerateResponse{RequestID: "srv-1", Response: []byte(`{"ok":true}`)}, nil
+			case 2:
+				// HTTP 422 error — should go to output file
+				return nil, &inference.ClientError{
+					Category:     httpclient.ErrCategoryInvalidReq,
+					Message:      "HTTP 422: Invalid model",
+					StatusCode:   422,
+					ResponseBody: []byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","code":"model_not_found"}}`),
+				}
+			default:
+				// non-HTTP error — should go to error file
+				return nil, &inference.ClientError{
+					Category: httpclient.ErrCategoryServer,
+					Message:  "connection refused",
+				}
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "r1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+		{CustomID: "r2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+		{CustomID: "r3", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+	cancelReq := &atomic.Bool{}
+
+	ctx := testLoggerCtx(t)
+	counts, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
+		updater:         env.updater,
+		jobInfo:         jobInfo,
+		cancelRequested: cancelReq,
+	})
+	if err != nil {
+		t.Fatalf("executeJob error: %v", err)
+	}
+	// Only the 200 response counts as completed; HTTP 422 and non-HTTP error are both failures.
+	if counts.Completed != 1 {
+		t.Fatalf("Completed = %d, want 1", counts.Completed)
+	}
+	if counts.Failed != 2 {
+		t.Fatalf("Failed = %d, want 2", counts.Failed)
+	}
+
+	// output.jsonl should contain 2 lines: the 200 success AND the HTTP 422 error.
+	outputPath, _ := env.p.jobOutputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	outputLines := readNonEmptyJSONLLines(t, outputPath)
+	if len(outputLines) != 2 {
+		t.Fatalf("output.jsonl lines = %d, want 2", len(outputLines))
+	}
+
+	// Verify both output lines: one success (200) and one HTTP error (422).
+	var found200, found422 bool
+	for _, line := range outputLines {
+		var entry outputLine
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal output line: %v", err)
+		}
+		if entry.Error != nil {
+			t.Fatalf("output line should not have error field, got: %+v", entry.Error)
+		}
+		if entry.Response == nil {
+			t.Fatalf("output line should have response field")
+		}
+		switch entry.Response.StatusCode {
+		case 200:
+			found200 = true
+		case 422:
+			found422 = true
+			errObj, ok := entry.Response.Body["error"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("HTTP error response body should contain error object, got: %v", entry.Response.Body)
+			}
+			if errObj["code"] != "model_not_found" {
+				t.Fatalf("expected error code 'model_not_found', got: %v", errObj["code"])
+			}
+		default:
+			t.Fatalf("unexpected status code %d in output file", entry.Response.StatusCode)
+		}
+	}
+	if !found200 || !found422 {
+		t.Fatalf("expected both 200 and 422 in output file, found200=%v found422=%v", found200, found422)
+	}
+
+	// error.jsonl should contain 1 line: the non-HTTP error only.
+	errorPath, _ := env.p.jobErrorFilePath(jobInfo.JobID, jobInfo.TenantID)
+	errorLines := readNonEmptyJSONLLines(t, errorPath)
+	if len(errorLines) != 1 {
+		t.Fatalf("error.jsonl lines = %d, want 1", len(errorLines))
+	}
+	var errEntry outputLine
+	if err := json.Unmarshal(errorLines[0], &errEntry); err != nil {
+		t.Fatalf("unmarshal error line: %v", err)
+	}
+	if errEntry.Error == nil {
+		t.Fatalf("error file line should have error field")
+	}
+	if errEntry.Response != nil {
+		t.Fatalf("error file line should not have response field")
+	}
+	if errEntry.Error.Code != string(httpclient.ErrCategoryServer) {
+		t.Fatalf("error code = %q, want %q", errEntry.Error.Code, httpclient.ErrCategoryServer)
 	}
 }
 

--- a/pkg/clients/http/http_client.go
+++ b/pkg/clients/http/http_client.go
@@ -204,7 +204,7 @@ func (c *HTTPClient) HandleErrorResponse(ctx context.Context, statusCode int, bo
 	// Try to parse OpenAI-style error response
 	var errorResp struct {
 		Error struct {
-			Code    int    `json:"code"`
+			Code    string `json:"code"`
 			Type    string `json:"type"`
 			Message string `json:"message"`
 			Param   string `json:"param"`
@@ -222,9 +222,11 @@ func (c *HTTPClient) HandleErrorResponse(ctx context.Context, statusCode int, bo
 	logger.V(logging.DEBUG).Info("HTTP request failed", "status", statusCode, "category", category, "message", message)
 
 	return &ClientError{
-		Category: category,
-		Message:  fmt.Sprintf("HTTP %d: %s", statusCode, message),
-		RawError: fmt.Errorf("status code: %d, body: %s", statusCode, string(body)),
+		Category:     category,
+		Message:      fmt.Sprintf("HTTP %d: %s", statusCode, message),
+		RawError:     fmt.Errorf("status code: %d, body: %s", statusCode, string(body)),
+		StatusCode:   statusCode,
+		ResponseBody: body,
 	}
 }
 

--- a/pkg/clients/http/http_client_errors.go
+++ b/pkg/clients/http/http_client_errors.go
@@ -30,13 +30,35 @@ const (
 
 // ClientError represents an HTTP client error with category and context
 type ClientError struct {
-	Category ErrorCategory
-	Message  string
-	RawError error // original error message
+	Category     ErrorCategory
+	Message      string
+	RawError     error  // original error message
+	StatusCode   int    // HTTP status code (0 for non-HTTP errors like network/timeout)
+	ResponseBody []byte // raw HTTP response body (nil for non-HTTP errors)
 }
 
 func (e *ClientError) Error() string {
 	return e.Message
+}
+
+// OpenAIErrorType returns a best-effort OpenAI-style error type string.
+// There is no global enum in the OpenAI spec for this field, so we map internal
+// categories to commonly used error type values.
+func (e *ClientError) OpenAIErrorType() string {
+	switch e.Category {
+	case ErrCategoryInvalidReq:
+		return "invalid_request_error"
+	case ErrCategoryAuth:
+		return "authentication_error"
+	case ErrCategoryRateLimit:
+		return "rate_limit_error"
+	case ErrCategoryServer:
+		return "server_error"
+	case ErrCategoryParse:
+		return "invalid_response"
+	default:
+		return "unknown_error"
+	}
 }
 
 // IsRetryable checks if the error is retryable

--- a/pkg/clients/http/http_client_test.go
+++ b/pkg/clients/http/http_client_test.go
@@ -447,7 +447,7 @@ func TestPost_NoRetryOn400(t *testing.T) {
 
 // TestHandleErrorResponse_OpenAIFormat tests parsing OpenAI-style error response
 func TestHandleErrorResponse_OpenAIFormat(t *testing.T) {
-	body := []byte(`{"error": {"message": "Invalid API key", "type": "invalid_request_error"}}`)
+	body := []byte(`{"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}}`)
 
 	client, _ := NewHTTPClient(Config{BaseURL: "http://localhost"}, testLogger(t))
 	clientErr := client.HandleErrorResponse(context.Background(), http.StatusUnauthorized, body)
@@ -462,6 +462,14 @@ func TestHandleErrorResponse_OpenAIFormat(t *testing.T) {
 
 	if clientErr.Message != "HTTP 401: Invalid API key" {
 		t.Errorf("Expected message 'HTTP 401: Invalid API key', got %s", clientErr.Message)
+	}
+
+	if clientErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("Expected StatusCode 401, got %d", clientErr.StatusCode)
+	}
+
+	if string(clientErr.ResponseBody) != string(body) {
+		t.Errorf("Expected ResponseBody to be preserved, got %s", clientErr.ResponseBody)
 	}
 }
 
@@ -529,6 +537,30 @@ func TestMapStatusCodeToCategory(t *testing.T) {
 			category := MapStatusCodeToCategory(tt.statusCode)
 			if category != tt.expected {
 				t.Errorf("For status %d, expected category %s, got %s", tt.statusCode, tt.expected, category)
+			}
+		})
+	}
+}
+
+func TestClientError_OpenAIErrorType(t *testing.T) {
+	tests := []struct {
+		name     string
+		category ErrorCategory
+		want     string
+	}{
+		{name: "invalid request", category: ErrCategoryInvalidReq, want: "invalid_request_error"},
+		{name: "auth", category: ErrCategoryAuth, want: "authentication_error"},
+		{name: "rate limit", category: ErrCategoryRateLimit, want: "rate_limit_error"},
+		{name: "server", category: ErrCategoryServer, want: "server_error"},
+		{name: "parse", category: ErrCategoryParse, want: "invalid_response"},
+		{name: "unknown", category: ErrCategoryUnknown, want: "unknown_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := (&ClientError{Category: tt.category}).OpenAIErrorType()
+			if got != tt.want {
+				t.Fatalf("OpenAIErrorType() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -842,6 +842,7 @@ install_batch_gateway() {
         --set "global.databaseType=postgresql"
         --set "apiserver.config.enablePprof=true"
         --set "processor.config.enablePprof=true"
+        --set "processor.resources.requests.memory=256Mi"
         --set "gc.enabled=true"
         --set "gc.image.pullPolicy=IfNotPresent"
         --set "gc.image.tag=${DEV_VERSION}"


### PR DESCRIPTION
## Why is this PR needed?

The batch processor currently treats all inference errors the same way — populating the `error` field and writing to `error.jsonl`. However, the [OpenAI batch spec](https://platform.openai.com/docs/api-reference/batch) distinguishes between HTTP error responses (4xx/5xx) and non-HTTP errors (network failures, timeouts). HTTP errors should carry the original status code and response body in the `response` field and be written to `output.jsonl`, not `error.jsonl`.

## What does this PR do?

- **Preserves HTTP status code and response body**: `ClientError` now carries `StatusCode` and `ResponseBody` fields, populated by `HandleErrorResponse`.
- **Routes HTTP errors to output file**: HTTP error responses (4xx/5xx) populate the `response` field with `status_code` and original `body`, and are written to `output.jsonl`. Non-HTTP errors (network, timeout) continue to use the `error` field and go to `error.jsonl`.
- **Adds `OpenAIErrorType()` helper**: Maps internal error categories to OpenAI-style error type strings (e.g., `invalid_request_error`, `server_error`).
- **Handles edge cases**: Empty response body produces an empty JSON object `{}`; non-JSON response body (e.g., HTML) is wrapped in a synthetic error structure.

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues
https://github.com/llm-d-incubation/batch-gateway/issues/205