### PR TITLE
refactor: replace tenantHeader with extensible inputHeaders map

### DIFF
--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -11,8 +11,11 @@ data:
     host: {{ .Values.apiserver.config.host | quote }}
     port: {{ .Values.apiserver.config.port | quote }}
     observability_port: {{ .Values.apiserver.config.observabilityPort | quote }}
-    {{- if .Values.apiserver.config.tenantHeader }}
-    tenant_header: {{ .Values.apiserver.config.tenantHeader | quote }}
+    {{- if .Values.apiserver.config.inputHeaders }}
+    input_headers:
+      {{- range $key, $value := .Values.apiserver.config.inputHeaders }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
     {{- end }}
     read_header_timeout_seconds: {{ .Values.apiserver.config.readHeaderTimeoutSeconds }}
     read_timeout_seconds: {{ .Values.apiserver.config.readTimeoutSeconds }}

--- a/charts/batch-gateway/tests/apiserver-configmap_test.yaml
+++ b/charts/batch-gateway/tests/apiserver-configmap_test.yaml
@@ -16,19 +16,22 @@ tests:
           path: data["config.yaml"]
           pattern: 'database_type: "postgresql"'
 
-  - it: should render tenantHeader when set
+  - it: should render inputHeaders when set
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: 'tenant_header: "X-MaaS-Username"'
+          pattern: 'input_headers:'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'tenant: "X-MaaS-Username"'
 
-  - it: should not render tenantHeader when empty
+  - it: should not render inputHeaders when null
     set:
-      apiserver.config.tenantHeader: ""
+      apiserver.config.inputHeaders: null
     asserts:
       - notMatchRegex:
           path: data["config.yaml"]
-          pattern: "tenant_header:"
+          pattern: "input_headers:"
 
   - it: should render TLS cert paths when TLS is enabled
     set:

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -169,7 +169,8 @@ apiserver:
     host: ""
     port: "8000"
     observabilityPort: "8081"
-    tenantHeader: "X-MaaS-Username"
+    inputHeaders:
+      tenant: "X-MaaS-Username"
     readHeaderTimeoutSeconds: 10
     readTimeoutSeconds: 900
     writeTimeoutSeconds: 120

--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -12,8 +12,9 @@ port: "8000"
 # ssl_cert_file: "path/to/cert.pem"
 # ssl_key_file: "path/to/key.pem"
 
-# HTTP header name for tenant ID (default: X-MaaS-User)
-tenant_header: "X-MaaS-User"
+# Input headers for special processing (key: logical name, value: HTTP header name)
+input_headers:
+  tenant: "X-MaaS-User"
 
 # HTTP server timeout configurations (in seconds)
 # These values should accommodate large file uploads and batch operations

--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -40,6 +40,8 @@ const (
 	DefaultBatchEventTTLSeconds = 30 * 24 * 60 * 60 // 2592000 seconds
 	// DefaultMaxFileLineCount is the default maximum number of lines per file
 	DefaultMaxFileLineCount = 50000
+	// InputHeaderKeyTenant is the key for the tenant header in InputHeaders
+	InputHeaderKeyTenant = "tenant"
 	// DefaultTenantHeader is the default HTTP header name for tenant ID
 	DefaultTenantHeader = "X-MaaS-Username"
 
@@ -103,12 +105,12 @@ func (f *FileAPIConfig) GetMaxLineCount() int64 {
 }
 
 type ServerConfig struct {
-	Host              string `yaml:"host"`
-	Port              string `yaml:"port"`
-	ObservabilityPort string `yaml:"observability_port"`
-	SSLCertFile       string `yaml:"ssl_cert_file"`
-	SSLKeyFile        string `yaml:"ssl_key_file"`
-	TenantHeader      string `yaml:"tenant_header"`
+	Host              string            `yaml:"host"`
+	Port              string            `yaml:"port"`
+	ObservabilityPort string            `yaml:"observability_port"`
+	SSLCertFile       string            `yaml:"ssl_cert_file"`
+	SSLKeyFile        string            `yaml:"ssl_key_file"`
+	InputHeaders      map[string]string `yaml:"input_headers"`
 
 	// HTTP server timeout configurations (in seconds)
 	ReadHeaderTimeoutSeconds int64 `yaml:"read_header_timeout_seconds"`
@@ -225,9 +227,6 @@ func (c *ServerConfig) applyDefaults() {
 	if c.DatabaseType == "" {
 		c.DatabaseType = "redis"
 	}
-	if c.TenantHeader == "" {
-		c.TenantHeader = DefaultTenantHeader
-	}
 	if c.ReadHeaderTimeoutSeconds <= 0 {
 		c.ReadHeaderTimeoutSeconds = DefaultReadHeaderTimeoutSeconds
 	}
@@ -264,6 +263,19 @@ func (c *ServerConfig) GetIdleTimeoutSeconds() int64 {
 	return c.IdleTimeoutSeconds
 }
 
+// GetInputHeader returns the HTTP header name mapped to the given logical key.
+// If the key is missing from InputHeaders or its value is an empty string, the
+// fallback is returned. This means setting a key to "" in YAML is equivalent to
+// leaving it unset — it does not disable header extraction.
+func (c *ServerConfig) GetInputHeader(key string, fallback string) string {
+	if c.InputHeaders != nil {
+		if v := c.InputHeaders[key]; v != "" {
+			return v
+		}
+	}
+	return fallback
+}
+
 func (c *ServerConfig) GetTenantHeader() string {
-	return c.TenantHeader
+	return c.GetInputHeader(InputHeaderKeyTenant, DefaultTenantHeader)
 }

--- a/internal/apiserver/common/config_test.go
+++ b/internal/apiserver/common/config_test.go
@@ -203,6 +203,89 @@ file_client:
 	})
 }
 
+func TestGetInputHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		key      string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "present key returns value",
+			headers:  map[string]string{"tenant": "X-Custom-Tenant"},
+			key:      "tenant",
+			fallback: "X-Default",
+			want:     "X-Custom-Tenant",
+		},
+		{
+			name:     "missing key returns fallback",
+			headers:  map[string]string{"other": "X-Other"},
+			key:      "tenant",
+			fallback: "X-Default",
+			want:     "X-Default",
+		},
+		{
+			name:     "empty string value returns fallback",
+			headers:  map[string]string{"tenant": ""},
+			key:      "tenant",
+			fallback: "X-Default",
+			want:     "X-Default",
+		},
+		{
+			name:     "nil map returns fallback",
+			headers:  nil,
+			key:      "tenant",
+			fallback: "X-Default",
+			want:     "X-Default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ServerConfig{InputHeaders: tt.headers}
+			got := cfg.GetInputHeader(tt.key, tt.fallback)
+			if got != tt.want {
+				t.Errorf("GetInputHeader(%q, %q) = %q, want %q", tt.key, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTenantHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{
+			name:    "custom tenant header",
+			headers: map[string]string{"tenant": "X-My-Tenant"},
+			want:    "X-My-Tenant",
+		},
+		{
+			name:    "nil map falls back to default",
+			headers: nil,
+			want:    DefaultTenantHeader,
+		},
+		{
+			name:    "empty tenant falls back to default",
+			headers: map[string]string{"tenant": ""},
+			want:    DefaultTenantHeader,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &ServerConfig{InputHeaders: tt.headers}
+			got := cfg.GetTenantHeader()
+			if got != tt.want {
+				t.Errorf("GetTenantHeader() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // Helper functions
 func setupTestSSLFiles(t *testing.T) {
 	// Create testdata directory

--- a/internal/apiserver/middleware/request_middleware_test.go
+++ b/internal/apiserver/middleware/request_middleware_test.go
@@ -29,8 +29,10 @@ import (
 // newTestConfig returns a minimal ServerConfig suitable for middleware tests.
 func newTestConfig(tenantHeader string) *common.ServerConfig {
 	return &common.ServerConfig{
-		Port:         "8080",
-		TenantHeader: tenantHeader,
+		Port: "8080",
+		InputHeaders: map[string]string{
+			common.InputHeaderKeyTenant: tenantHeader,
+		},
 	}
 }
 


### PR DESCRIPTION
## Why is this PR needed?
https://github.com/llm-d-incubation/batch-gateway/pull/37#discussion_r2784163262

The current configuration uses a single `tenantHeader` field to capture the tenant HTTP header. This is inflexible — as more headers need special processing (e.g., for authentication, routing, or tracing), each one would require adding a new dedicated field to `ServerConfig` and updating the Helm chart, config files, and defaults individually.

## What does this PR do?

Replaces the single `tenantHeader` string field with a generic `inputHeaders` map (`map[string]string`) where the key is a logical name (e.g., `tenant`) and the value is the actual HTTP header name (e.g., `X-MaaS-Username`). This makes it easy to add new input headers in the future without modifying the config struct.

Changes:
- **`ServerConfig`**: Replace `TenantHeader string` with `InputHeaders map[string]string`; add `GetInputHeader(key, fallback)` accessor
- **`GetTenantHeader()`**: Preserved for backward compatibility, now delegates to `GetInputHeader("tenant", DefaultTenantHeader)`
- **Helm chart**: `values.yaml` and configmap template updated to render the `inputHeaders` map
- **Tests**: Helm chart tests and middleware tests updated accordingly

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->