### PR TITLE
doc: update llm-d install scripts and doc

### DIFF
--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -783,13 +783,14 @@ EOF
 ### 4.1 Setup Test Accounts
 
 ```bash
-GW_URL="https://localhost:8080"
+# Get Gateway address (from status.addresses, populated by the controller)
+GW_ADDR=$(kubectl get gateway istio-gateway -n istio-ingress \
+    -o jsonpath='{.status.addresses[0].value}')
+GW_URL="https://${GW_ADDR}"
+
 MODEL_NAME=random
 LLM_NS=llm
 LLMD_POOL_NAME=gaie-llmd
-
-# Start port-forward to the Gateway
-kubectl port-forward svc/istio-gateway-istio ${GW_URL##*:}:443 -n istio-ingress &
 
 # Create authorized SA with RBAC to access the InferencePool
 kubectl create serviceaccount test-authorized-sa -n ${LLM_NS}

--- a/docs/guides/deploy-maas.md
+++ b/docs/guides/deploy-maas.md
@@ -43,7 +43,7 @@ USER_TOKEN=$(oc whoami -t)
 
 curl -sk -H "Authorization: Bearer ${USER_TOKEN}" \
     -H "Content-Type: application/json" \
-    -X POST -d '{"name":"my-key","expiration":"1h"}' \
+    -X POST -d '{"name":"my-key","expiresIn":"1h"}' \
     https://maas.<cluster-domain>/maas-api/v1/api-keys | jq -r '.key'
 ```
 
@@ -133,6 +133,12 @@ rules:
   resources: ["secrets"]
   resourceNames: ["maas-db-config"]
   verbs: ["get"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -262,7 +268,7 @@ spec:
       - name: ${MAAS_TEST_GROUP}
 EOF
 
-# MaaSSubscription — per-group token rate limit
+# MaaSSubscription — per-group token rate limit (authorized group)
 oc apply -f - <<EOF
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSSubscription
@@ -273,6 +279,25 @@ spec:
   owner:
     groups:
       - name: ${MAAS_TEST_GROUP}
+  modelRefs:
+    - name: facebook-opt-125m-simulated
+      namespace: ${LLM_NS}
+      tokenRateLimits:
+        - limit: 500
+          window: 1m
+EOF
+
+# MaaSSubscription — unauthorized group (has subscription but no model access)
+oc apply -f - <<EOF
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: batch-test-subscription-unauth
+  namespace: ${MAAS_POLICY_NAMESPACE}
+spec:
+  owner:
+    groups:
+      - name: tier-unauth-users
   modelRefs:
     - name: facebook-opt-125m-simulated
       namespace: ${LLM_NS}
@@ -601,12 +626,17 @@ spec:
 # Wait for OAuth restart
 sleep 30
 
-# Create group and add only the authorized user
+# Create authorized group and add authorized user
 oc adm groups new "${MAAS_TEST_GROUP}" 2>/dev/null || true
 oc adm groups add-users "${MAAS_TEST_GROUP}" "${MAAS_TEST_USER}"
+
+# Create unauthorized group (has subscription but NO model access via MaaSAuthPolicy)
+MAAS_UNAUTH_GROUP=tier-unauth-users
+oc adm groups new "${MAAS_UNAUTH_GROUP}" 2>/dev/null || true
+oc adm groups add-users "${MAAS_UNAUTH_GROUP}" "${MAAS_UNAUTH_USER}"
 ```
 
-> **Note**: The unauthorized user `testuser-unauth` is intentionally NOT added to the `tier-free-users` group. This allows testing that MaaSAuthPolicy correctly rejects users who lack group membership.
+> **Note**: The unauthorized user is in `tier-unauth-users` (not `tier-free-users`). This group has a MaaSSubscription (so the user can create API keys) but no MaaSAuthPolicy (so the user is denied model access).
 
 </details>
 
@@ -632,7 +662,7 @@ USER_TOKEN=$(KUBECONFIG="${TEMP_KUBECONFIG}" oc whoami -t)
 API_KEY=$(curl -sk \
     -H "Authorization: Bearer ${USER_TOKEN}" \
     -H "Content-Type: application/json" \
-    -X POST -d '{"name":"batch-e2e","expiration":"1h"}' \
+    -X POST -d '{"name":"batch-e2e","expiresIn":"1h"}' \
     "${GW_URL}/maas-api/v1/api-keys" | jq -r '.key')
 
 # Get MaaS API key for unauthorized user
@@ -643,7 +673,7 @@ UNAUTH_TOKEN=$(KUBECONFIG="${TEMP_KUBECONFIG}" oc whoami -t)
 UNAUTH_API_KEY=$(curl -sk \
     -H "Authorization: Bearer ${UNAUTH_TOKEN}" \
     -H "Content-Type: application/json" \
-    -X POST -d '{"name":"batch-e2e-unauth","expiration":"1h"}' \
+    -X POST -d '{"name":"batch-e2e-unauth","expiresIn":"1h"}' \
     "${GW_URL}/maas-api/v1/api-keys" | jq -r '.key')
 
 rm -f "${TEMP_KUBECONFIG}"

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -711,6 +711,8 @@ EOF
 
 ### 4.1 Setup Test Accounts
 ```bash
+# Get Gateway hostname (OpenShift router uses SNI-based routing, so the
+# spec hostname is required — the raw LB address won't work)
 GW_HOSTNAME=$(oc get gateway openshift-ai-inference -n openshift-ingress \
     -o jsonpath='{.spec.listeners[0].hostname}')
 GW_URL="https://${GW_HOSTNAME}"

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -206,6 +206,61 @@ EOF
     die "Failed to create ClusterIssuer after 5 attempts."
 }
 
+# ── Gateway URL ──────────────────────────────────────────────────────────────
+#
+# Resolves the external gateway URL. Priority:
+#
+#   1. spec.listeners[0].hostname — OpenShift router uses SNI (Server Name
+#      Indication) to route requests to the correct backend. The hostname
+#      (e.g. llm-inference.apps.xxx) must be present in the TLS ClientHello
+#      for the router to match it. Accessing via raw LB address fails because
+#      the router cannot determine which route to use without the hostname.
+#
+#   2. status.addresses[0].value — On vanilla K8s with Istio, the gateway
+#      terminates TLS directly and routes by path, not by hostname. Listeners
+#      typically have no hostname configured, so the LB address works fine.
+#
+#   3. port-forward — Fallback for clusters without a LoadBalancer (e.g.
+#      kind, minikube).
+
+set_gateway_url() {
+    # 1. Prefer spec hostname (required for SNI-based routing, e.g. OpenShift)
+    local gw_hostname
+    gw_hostname=$(kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" \
+        -o jsonpath='{.spec.listeners[0].hostname}' 2>/dev/null || echo "")
+    if [[ -n "${gw_hostname}" ]]; then
+        log "Gateway hostname: ${gw_hostname}"
+        export GATEWAY_URL="https://${gw_hostname}"
+        log "Gateway URL: ${GATEWAY_URL}"
+        return
+    fi
+
+    # 2. Fall back to status address (e.g. LoadBalancer IP/hostname on vanilla K8s)
+    local gw_addr
+    gw_addr=$(kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" \
+        -o jsonpath='{.status.addresses[0].value}' 2>/dev/null || echo "")
+    if [[ -n "${gw_addr}" ]]; then
+        log "Gateway address: ${gw_addr}"
+        export GATEWAY_URL="https://${gw_addr}"
+        log "Gateway URL: ${GATEWAY_URL}"
+        return
+    fi
+
+    # 3. Fall back to port-forward (no external address, e.g. kind/minikube)
+    log "No external address found, falling back to port-forward."
+    local gateway_svc
+    gateway_svc=$(kubectl get svc -n "${GATEWAY_NAMESPACE}" \
+        -l "gateway.networking.k8s.io/gateway-name=${GATEWAY_NAME}" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+    [ -z "${gateway_svc}" ] && die "No service found for gateway '${GATEWAY_NAME}'."
+    step "Starting port-forward: ${gateway_svc} ${GATEWAY_LOCAL_PORT}:443 -n ${GATEWAY_NAMESPACE}..."
+    kubectl port-forward "svc/${gateway_svc}" "${GATEWAY_LOCAL_PORT}:443" -n "${GATEWAY_NAMESPACE}" &
+    disown $!
+    log "Port-forward PID: $!"
+    export GATEWAY_URL="https://localhost:${GATEWAY_LOCAL_PORT}"
+    log "Gateway URL: ${GATEWAY_URL}"
+}
+
 # ── Shared Route & DestinationRule Functions ──────────────────────────────────
 
 create_batch_httproute() {

--- a/scripts/demo/deploy-k8s.sh
+++ b/scripts/demo/deploy-k8s.sh
@@ -258,28 +258,6 @@ EOF
     log "llm-route created."
 }
 
-start_gateway_port_forward() {
-    local gateway_svc
-    gateway_svc="${GATEWAY_NAME}-istio"
-
-    if ! kubectl get svc "${gateway_svc}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
-        gateway_svc="${GATEWAY_NAME}"
-        if ! kubectl get svc "${gateway_svc}" -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
-            warn "Gateway service not found. Skipping port-forward."
-            return
-        fi
-    fi
-
-    step "Starting port-forward: ${gateway_svc} ${GATEWAY_LOCAL_PORT}:443 -n ${GATEWAY_NAMESPACE}..."
-
-    kubectl port-forward "svc/${gateway_svc}" "${GATEWAY_LOCAL_PORT}:443" -n "${GATEWAY_NAMESPACE}" &
-    local pf_pid=$!
-    disown "${pf_pid}"
-
-    log "Port-forward PID: ${pf_pid}  (stop with: kill ${pf_pid})"
-    log "Gateway available at https://localhost:${GATEWAY_LOCAL_PORT}"
-}
-
 init_test() {
     local test_title="$1"
     banner "Testing: ${test_title}"
@@ -288,18 +266,13 @@ init_test() {
         die "Gateway '${GATEWAY_NAME}' not found in namespace '${GATEWAY_NAMESPACE}'. Run '$0 install' first."
     fi
 
-    if ! pgrep -f "kubectl port-forward.*${GATEWAY_NAME}" >/dev/null; then
-        start_gateway_port_forward
-        sleep 3
-    else
-        log "Port-forward already running."
-    fi
+    # Resolve gateway URL
+    set_gateway_url
 
     step "Waiting for gateway to be accessible..."
-    local base_url="https://localhost:${GATEWAY_LOCAL_PORT}"
     local retries=30
     for i in $(seq 1 "${retries}"); do
-        if curl -sk -o /dev/null -w "%{http_code}" "${base_url}/" &>/dev/null; then
+        if curl -sk -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/" &>/dev/null; then
             log "Gateway is accessible."
             break
         fi
@@ -566,8 +539,6 @@ cmd_install() {
     apply_batch_auth_policy
     apply_batch_request_rate_limit
 
-    start_gateway_port_forward
-
     log "Deployment complete! Run '$0 test' to verify."
 }
 
@@ -575,8 +546,6 @@ cmd_install() {
 
 cmd_test() {
     init_test "Batch Gateway (llm-d)"
-
-    local gw_url="https://localhost:${GATEWAY_LOCAL_PORT}"
 
     # Auth setup: create SA + RBAC + token
     local sa_name="test-authorized-sa"
@@ -625,10 +594,10 @@ EOF
         || die "Failed to create token for SA '${unauth_sa}'"
     [[ "${unauth_token}" == ey* ]] || die "Token for SA '${unauth_sa}' doesn't look like a valid JWT"
 
-    local llm_url="${gw_url}/${LLM_NAMESPACE}/${MODEL_NAME}/v1/chat/completions"
+    local llm_url="${GATEWAY_URL}/${LLM_NAMESPACE}/${MODEL_NAME}/v1/chat/completions"
     local inference_payload="{\"model\":\"${MODEL_NAME}\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}],\"max_tokens\":10}"
 
-    run_tests "${llm_url}" "${gw_url}" "${MODEL_NAME}" \
+    run_tests "${llm_url}" "${GATEWAY_URL}" "${MODEL_NAME}" \
         "Authorization: Bearer ${token}" \
         "Authorization: Bearer ${unauth_token}" \
         "${inference_payload}"
@@ -731,8 +700,8 @@ usage() {
     echo "  MODEL_NAME             Model name for routing (default: random)"
     echo "  LLMD_VERSION           llm-d git ref (default: main)"
     echo "  LLMD_RELEASE_POSTFIX   Release name postfix (default: llmd)"
-    echo "  GATEWAY_LOCAL_PORT     Port-forward port (default: 8080)"
     echo "  BATCH_HELM_RELEASE     Helm release name (default: batch-gateway)"
+    echo "  GATEWAY_LOCAL_PORT     Port-forward fallback port (default: 8080)"
     echo "  BATCH_DEV_VERSION      Image tag (default: latest)"
     echo ""
     echo "Examples:"

--- a/scripts/demo/deploy-maas.sh
+++ b/scripts/demo/deploy-maas.sh
@@ -37,9 +37,10 @@ MAAS_POLICY_NAMESPACE="${MAAS_POLICY_NAMESPACE:-models-as-a-service}"
 MAAS_TEST_USER="${MAAS_TEST_USER:-testuser}"
 MAAS_TEST_PASS="${MAAS_TEST_PASS:-testpass}"
 MAAS_TEST_GROUP="${MAAS_TEST_GROUP:-tier-free-users}"
-# Unauthorized user (valid OpenShift user, NOT in the authorized group)
+# Unauthorized user (valid OpenShift user, has subscription but NOT authorized to access the model)
 MAAS_UNAUTH_USER="${MAAS_UNAUTH_USER:-testuser-unauth}"
 MAAS_UNAUTH_PASS="${MAAS_UNAUTH_PASS:-testpass}"
+MAAS_UNAUTH_GROUP="${MAAS_UNAUTH_GROUP:-tier-unauth-users}"
 
 # Model served by MaaS simulator sample
 MAAS_MODEL_NAME="${MAAS_MODEL_NAME:-facebook/opt-125m}"
@@ -88,6 +89,14 @@ rules:
   resources: ["secrets"]
   resourceNames: ["maas-db-config"]
   verbs: ["get"]
+  # SAR-based admin authorization (replaces hardcoded admin list)
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+  # HTTPRoutes for model route resolution
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["httproutes"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -211,7 +220,7 @@ spec:
       - name: ${MAAS_TEST_GROUP}
 EOF
 
-    step "Creating MaaSSubscription (token rate limit: ${MAAS_TOKEN_RATE_LIMIT} tokens/${MAAS_TOKEN_RATE_WINDOW})..."
+    step "Creating MaaSSubscription for authorized group (token rate limit: ${MAAS_TOKEN_RATE_LIMIT} tokens/${MAAS_TOKEN_RATE_WINDOW})..."
     kubectl apply -f - <<EOF
 apiVersion: maas.opendatahub.io/v1alpha1
 kind: MaaSSubscription
@@ -222,6 +231,25 @@ spec:
   owner:
     groups:
       - name: ${MAAS_TEST_GROUP}
+  modelRefs:
+    - name: ${isvc_name}
+      namespace: ${LLM_NAMESPACE}
+      tokenRateLimits:
+        - limit: ${MAAS_TOKEN_RATE_LIMIT}
+          window: ${MAAS_TOKEN_RATE_WINDOW}
+EOF
+
+    step "Creating MaaSSubscription for unauthorized group (has subscription, no model access)..."
+    kubectl apply -f - <<EOF
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: batch-test-subscription-unauth
+  namespace: ${MAAS_POLICY_NAMESPACE}
+spec:
+  owner:
+    groups:
+      - name: ${MAAS_UNAUTH_GROUP}
   modelRefs:
     - name: ${isvc_name}
       namespace: ${LLM_NAMESPACE}
@@ -285,12 +313,13 @@ wait_for_auth_policies_enforced() {
     local deadline=$((SECONDS + timeout))
     while [ $SECONDS -lt $deadline ]; do
         local all_enforced=true total=0
-        while IFS= read -r status; do
+        while IFS=$'\t' read -r status message; do
             total=$((total + 1))
-            if [ "${status}" != "True" ]; then
+            # Enforced=True is ready; Enforced=False with "overridden" is also valid
+            if [ "${status}" != "True" ] && [[ "${message}" != *overridden* ]]; then
                 all_enforced=false
             fi
-        done < <(kubectl get authpolicy -A -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Enforced")].status}{"\n"}{end}' 2>/dev/null)
+        done < <(kubectl get authpolicy -A -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Enforced")].status}{"\t"}{.status.conditions[?(@.type=="Enforced")].message}{"\n"}{end}' 2>/dev/null)
 
         if ${all_enforced} && [ $total -gt 0 ]; then
             log "All AuthPolicies enforced (${total} policies)."
@@ -446,10 +475,16 @@ spec:
     if ! oc get group "${MAAS_TEST_GROUP}" &>/dev/null 2>&1; then
         oc adm groups new "${MAAS_TEST_GROUP}"
     fi
-    # Add only the authorized user to the group; unauth user is NOT in the group
+    # Authorized user -> authorized group (has model access via MaaSAuthPolicy)
     oc adm groups add-users "${MAAS_TEST_GROUP}" "${MAAS_TEST_USER}" 2>/dev/null || true
     log "User '${MAAS_TEST_USER}' added to group '${MAAS_TEST_GROUP}'."
-    log "User '${MAAS_UNAUTH_USER}' created (NOT in group '${MAAS_TEST_GROUP}')."
+
+    # Unauthorized user -> unauth group (has subscription but NO model access)
+    if ! oc get group "${MAAS_UNAUTH_GROUP}" &>/dev/null 2>&1; then
+        oc adm groups new "${MAAS_UNAUTH_GROUP}"
+    fi
+    oc adm groups add-users "${MAAS_UNAUTH_GROUP}" "${MAAS_UNAUTH_USER}" 2>/dev/null || true
+    log "User '${MAAS_UNAUTH_USER}' added to group '${MAAS_UNAUTH_GROUP}' (no model access)."
 }
 
 get_maas_gateway_host() {
@@ -481,7 +516,7 @@ get_maas_api_key() {
     key_response=$(curl -sSk \
         -H "Authorization: Bearer ${user_token}" \
         -H "Content-Type: application/json" \
-        -X POST -d '{"name":"batch-e2e","expiration":"1h"}' \
+        -X POST -d '{"name":"batch-e2e","expiresIn":"1h"}' \
         "${host}/maas-api/v1/api-keys")
     local api_key
     api_key=$(echo "${key_response}" | jq -r '.key // empty')
@@ -589,6 +624,7 @@ cmd_uninstall() {
     # Test user
     step "Removing test users..."
     oc delete group "${MAAS_TEST_GROUP}" 2>/dev/null || true
+    oc delete group "${MAAS_UNAUTH_GROUP}" 2>/dev/null || true
     oc delete user "${MAAS_TEST_USER}" 2>/dev/null || true
     oc delete identity "htpasswd:${MAAS_TEST_USER}" 2>/dev/null || true
     oc delete user "${MAAS_UNAUTH_USER}" 2>/dev/null || true

--- a/scripts/demo/deploy-rhoai.sh
+++ b/scripts/demo/deploy-rhoai.sh
@@ -683,19 +683,14 @@ cmd_install() {
 cmd_test() {
     banner "Testing: RHOAI + Batch Gateway"
 
-    # Get Gateway hostname
-    local gw_hostname
-    gw_hostname=$(kubectl get gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" \
-        -o jsonpath='{.spec.listeners[0].hostname}' 2>/dev/null || echo "")
-    [ -z "${gw_hostname}" ] && die "Gateway '${GATEWAY_NAME}' has no hostname. Is it ready?"
+    set_gateway_url
 
     local isvc_name
     isvc_name=$(echo "${MODEL_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 
-    local gw_url="https://${gw_hostname}"
-    log "Gateway:   ${gw_url}"
-    log "Inference: ${gw_url}/${LLM_NAMESPACE}/${isvc_name}"
-    log "Batch API: ${gw_url}"
+    log "Gateway:   ${GATEWAY_URL}"
+    log "Inference: ${GATEWAY_URL}/${LLM_NAMESPACE}/${isvc_name}"
+    log "Batch API: ${GATEWAY_URL}"
 
     # Auth setup: create SA + token + RBAC
     local sa_name="test-authorized-sa"
@@ -746,10 +741,10 @@ EOF
         || die "Failed to create token for SA '${unauth_sa}'"
     [[ "${unauth_token}" == ey* ]] || die "Token for SA '${unauth_sa}' doesn't look like a valid JWT"
 
-    local llm_url="${gw_url}/${LLM_NAMESPACE}/${isvc_name}/v1/chat/completions"
+    local llm_url="${GATEWAY_URL}/${LLM_NAMESPACE}/${isvc_name}/v1/chat/completions"
     local inference_payload="{\"model\":\"${MODEL_NAME}\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello\"}],\"max_tokens\":10}"
 
-    run_tests "${llm_url}" "${gw_url}" "${MODEL_NAME}" \
+    run_tests "${llm_url}" "${GATEWAY_URL}" "${MODEL_NAME}" \
         "Authorization: Bearer ${token}" \
         "Authorization: Bearer ${unauth_token}" \
         "${inference_payload}"


### PR DESCRIPTION
## Why is this PR needed?

Update demo scripts and documentation to improve gateway URL resolution, fix MaaS API compatibility, and add proper unauthorized user testing support.

## What does this PR do?

### Scripts (`scripts/demo/`)

- **`common.sh`**: Add shared `set_gateway_url()` function that resolves gateway URL with priority:
  1. `spec.listeners[0].hostname` — required for OpenShift SNI-based routing
  2. `status.addresses[0].value` — for vanilla K8s with LoadBalancer
  3. Port-forward fallback — for clusters without external address (kind/minikube)
- **`deploy-k8s.sh`**: Remove port-forward-only approach, use `set_gateway_url()` from common.sh
- **`deploy-rhoai.sh`**: Remove inline gateway URL logic, use `set_gateway_url()` from common.sh
- **`deploy-maas.sh`**:
  - Fix API key field name: `expiration` → `expiresIn` (aligns with latest MaaS API)
  - Add `tier-unauth-users` group + `batch-test-subscription-unauth` subscription so unauthorized user can create API keys (needed for authz testing)
  - Add `subjectaccessreviews` and `httproutes` RBAC permissions (needed by latest maas-api)
  - Handle `overridden` AuthPolicy status as valid (Kuadrant design: route-level policy overrides gateway-level)

### Documentation (`docs/guides/`)

- **`deploy-k8s.md`**: Update gateway URL to use `status.addresses[0].value`
- **`deploy-rhoai.md`**: Update gateway URL to use `spec.listeners[0].hostname` with SNI explanation
- **`deploy-maas.md`**: Fix `expiresIn` field, add unauth group/subscription, add new RBAC permissions

## How was this tested?

- [x] Full `uninstall → install → test` cycle on vanilla K8s (11/11 tests passed)
- [x] Full `uninstall → install → test` cycle on RHOAI/OpenShift (11/11 tests passed)
- [x] Full `uninstall → install → test` cycle on MaaS/OpenShift (11/11 tests passed)

## Checklist

- [x] Code follows project contributing guidelines
- [x] Manual testing performed