### PR TITLE
feat: add OTel sampler config and resource attributes

### DIFF
--- a/charts/batch-gateway/templates/apiserver-deployment.yaml
+++ b/charts/batch-gateway/templates/apiserver-deployment.yaml
@@ -46,10 +46,24 @@ spec:
         - --v={{ .Values.apiserver.logging.verbosity }}
         {{- if .Values.global.otel.endpoint }}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ .Values.global.otel.endpoint | quote }}
         - name: OTEL_EXPORTER_OTLP_INSECURE
           value: {{ .Values.global.otel.insecure | quote }}
+        - name: OTEL_TRACES_SAMPLER
+          value: {{ .Values.global.otel.sampler | quote }}
+        - name: OTEL_TRACES_SAMPLER_ARG
+          value: {{ .Values.global.otel.samplerArg | quote }}
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.namespace.name=$(NAMESPACE),k8s.pod.name=$(POD_NAME),service.version={{ .Chart.AppVersion }}"
         {{- end }}
         ports:
         - name: http

--- a/charts/batch-gateway/templates/processor-deployment.yaml
+++ b/charts/batch-gateway/templates/processor-deployment.yaml
@@ -46,10 +46,24 @@ spec:
         - --v={{ .Values.processor.logging.verbosity }}
         {{- if .Values.global.otel.endpoint }}
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: {{ .Values.global.otel.endpoint | quote }}
         - name: OTEL_EXPORTER_OTLP_INSECURE
           value: {{ .Values.global.otel.insecure | quote }}
+        - name: OTEL_TRACES_SAMPLER
+          value: {{ .Values.global.otel.sampler | quote }}
+        - name: OTEL_TRACES_SAMPLER_ARG
+          value: {{ .Values.global.otel.samplerArg | quote }}
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.namespace.name=$(NAMESPACE),k8s.pod.name=$(POD_NAME),service.version={{ .Chart.AppVersion }}"
         {{- end }}
         ports:
         - name: metrics

--- a/charts/batch-gateway/tests/deployment_test.yaml
+++ b/charts/batch-gateway/tests/deployment_test.yaml
@@ -130,6 +130,87 @@ tests:
           value: 65532
         template: templates/gc-deployment.yaml
 
+  # --- OTel env vars ---
+
+  - it: should not inject OTel env vars when endpoint is empty
+    templates:
+      - templates/apiserver-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+          any: true
+
+  - it: should inject all OTel env vars when endpoint is set
+    templates:
+      - templates/apiserver-deployment.yaml
+    set:
+      global.otel.endpoint: "http://jaeger:4317"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://jaeger:4317"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER
+            value: "parentbased_traceidratio"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER_ARG
+            value: "1.0"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+          any: true
+
+  - it: should not inject OTel env vars on processor when endpoint is empty
+    templates:
+      - templates/processor-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+          any: true
+
+  - it: should inject all OTel env vars on processor when endpoint is set
+    templates:
+      - templates/processor-deployment.yaml
+    set:
+      global.otel.endpoint: "http://jaeger:4317"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: "http://jaeger:4317"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OTEL_TRACES_SAMPLER
+            value: "parentbased_traceidratio"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+          any: true
+
   # --- Fail guards ---
 
   - it: should fail when fs pvcName is empty

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -45,11 +45,22 @@ global:
 
   # OpenTelemetry configuration
   otel:
-    # OTLP gRPC endpoint (e.g. "http://jaeger.default.svc.cluster.local:4317")
+    # OTLP gRPC endpoint for trace collection. Examples:
+    #   Dev (Jaeger all-in-one):     "http://jaeger.default.svc.cluster.local:4317"
+    #   OpenShift TempoStack:        "http://tempo-distributor.openshift-tempo-operator.svc:4317"
+    #   OpenShift OTEL Collector:    "http://otel-collector.openshift-distributed-tracing.svc:4317"
+    #   Grafana Alloy/Agent:         "http://alloy.monitoring.svc.cluster.local:4317"
     # Leave empty to disable tracing.
     endpoint: ""
     # Use insecure (plaintext) gRPC connection to the collector.
     insecure: true
+    # Sampling configuration (maps to standard OTel env vars).
+    # Options: "always_on", "always_off", "traceidratio", "parentbased_traceidratio"
+    # Default is "parentbased_traceidratio" (recommended for production).
+    sampler: "parentbased_traceidratio"
+    # Sampling ratio (0.0 to 1.0), used when sampler is "*traceidratio".
+    # 1.0 = 100% (dev), 0.1 = 10% (production).
+    samplerArg: "1.0"
     # Enable per-command Redis tracing spans. Can produce high span volume
     # for batch workloads — leave disabled unless actively debugging Redis.
     redisTracing: false


### PR DESCRIPTION
## Why is this PR needed?

The OTel tracing implementation uses `parentbased_traceidratio` with ratio `1.0` by default (100% sampling for root spans, respects parent decisions for child spans) and only sets `service.name` as a resource attribute. In production this generates excessive trace volume, and traces lack Kubernetes metadata (pod, namespace) needed to filter in Grafana/Jaeger. The Helm chart endpoint comment only mentions Jaeger.

Closes #180

## What does this PR do?

1. **Sampler configuration** — Exposes `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` via `values.yaml` (`global.otel.sampler` / `global.otel.samplerArg`), giving operators control over sampling rate without code changes. The Go OTel SDK reads these env vars automatically (no Go code changes needed).

2. **Kubernetes resource attributes** — Injects `POD_NAME` and `NAMESPACE` via Downward API, then sets `OTEL_RESOURCE_ATTRIBUTES` with `k8s.namespace.name`, `k8s.pod.name`, and `service.version` so traces can be filtered by pod/namespace in dashboards. `WithResource()` merges `resource.Environment()` internally, so these are picked up automatically.

3. **Endpoint documentation** — Expands `otel.endpoint` comment with examples for TempoStack, OpenShift OTEL Collector, and Grafana Alloy.

4. **Conditional env injection** — `POD_NAME` and `NAMESPACE` are only injected when OTel is enabled (`global.otel.endpoint` is set).

Rendered env block (when OTel is enabled):

```yaml
env:
- name: POD_NAME
  valueFrom:
    fieldRef:
      fieldPath: metadata.name
- name: NAMESPACE
  valueFrom:
    fieldRef:
      fieldPath: metadata.namespace
- name: OTEL_EXPORTER_OTLP_ENDPOINT
  value: "http://jaeger.default.svc.cluster.local:4317"
- name: OTEL_EXPORTER_OTLP_INSECURE
  value: "true"
- name: OTEL_TRACES_SAMPLER
  value: "parentbased_traceidratio"
- name: OTEL_TRACES_SAMPLER_ARG
  value: "1.0"
- name: OTEL_RESOURCE_ATTRIBUTES
  value: "k8s.namespace.name=$(NAMESPACE),k8s.pod.name=$(POD_NAME),service.version=0.0.1"
```

<img width="1433" height="468" alt="c47d60e1850978d46c4caf13d346f1d5" src="https://github.com/user-attachments/assets/af08b125-68b5-49ce-ac0a-ef09410313f6" />


## How was this tested?

- [x] `helm template` renders correctly with OTel enabled and disabled
- [x] `helm unittest` — added OTel env injection tests for both apiserver and processor
- [x] Manual testing on cluster — resource attributes resolve correctly in Jaeger

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #180