### PR TITLE
docs: fix deployment guides and Helm chart for OpenShift SCC compatibility

### DIFF
--- a/charts/batch-gateway/tests/deployment_test.yaml
+++ b/charts/batch-gateway/tests/deployment_test.yaml
@@ -88,25 +88,22 @@ tests:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
         template: templates/apiserver-deployment.yaml
-      - equal:
+      - isNull:
           path: spec.template.spec.securityContext.runAsUser
-          value: 65532
         template: templates/apiserver-deployment.yaml
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
         template: templates/processor-deployment.yaml
-      - equal:
+      - isNull:
           path: spec.template.spec.securityContext.runAsUser
-          value: 65532
         template: templates/processor-deployment.yaml
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
         template: templates/gc-deployment.yaml
-      - equal:
+      - isNull:
           path: spec.template.spec.securityContext.runAsUser
-          value: 65532
         template: templates/gc-deployment.yaml
 
   - it: should allow per-component podSecurityContext override
@@ -121,13 +118,11 @@ tests:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000
         template: templates/processor-deployment.yaml
-      - equal:
+      - isNull:
           path: spec.template.spec.securityContext.runAsUser
-          value: 65532
         template: templates/apiserver-deployment.yaml
-      - equal:
+      - isNull:
           path: spec.template.spec.securityContext.runAsUser
-          value: 65532
         template: templates/gc-deployment.yaml
 
   # --- OTel env vars ---

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -6,14 +6,13 @@ global:
   # All three components (apiserver, processor, gc) must run with the same UID/GID
   # when sharing files on a PVC. Per-component overrides are possible via
   # <component>.podSecurityContext, but use with caution to avoid permission issues.
-  # For OpenShift, set podSecurityContext: {} to use SCC-assigned UIDs.
+  #
+  # Only runAsNonRoot is set by default. The actual UID comes from the Dockerfile
+  # (USER 65532:65532) on vanilla Kubernetes, or from the namespace UID range on
+  # OpenShift (assigned by the restricted-v2 SCC). This avoids hardcoding UIDs that
+  # conflict with OpenShift's Security Context Constraints.
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 65532
-    runAsGroup: 65532
-    fsGroup: 65532
-    seccompProfile:
-      type: RuntimeDefault
 
   # Name of the Kubernetes Secret containing sensitive values (e.g. database URLs, API keys).
   # Shared by all components; mounted read-only at /etc/.secrets/ in each container.

--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -905,10 +905,16 @@ curl -sk -o /dev/null -w "%{http_code}" \
 # Unauthorized user creates a batch — batch is accepted (batch route has no authz),
 # but the processor forwards requests to the LLM route with the unauthorized token,
 # and the LLM route's AuthPolicy rejects with 403.
+
+# Create input file
+cat > /tmp/batch-input.jsonl <<EOF
+{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"${MODEL_NAME}","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}
+EOF
+
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${UNAUTH_TOKEN}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
@@ -917,7 +923,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll until completed/failed — expect failed requests with 403
+# Wait for processing, then check status — expect failed requests with 403
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${UNAUTH_TOKEN}" | jq '{status, request_counts}'
 ```
@@ -925,11 +932,11 @@ curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
 ### 4.7 Batch Lifecycle
 
 ```bash
-# Upload input file
+# Upload input file (reuse /tmp/batch-input.jsonl from 4.6, or create it)
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 # Create batch
@@ -939,7 +946,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll status until completed
+# Wait for processing, then check status
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${AUTH_TOKEN}" | jq '.status'
 

--- a/docs/guides/deploy-maas.md
+++ b/docs/guides/deploy-maas.md
@@ -404,14 +404,11 @@ helm install batch-gateway ./charts/batch-gateway \
     --set apiserver.tls.certManager.enabled=true \
     --set apiserver.tls.certManager.issuerName=selfsigned-issuer \
     --set apiserver.tls.certManager.issuerKind=ClusterIssuer \
-    --set "apiserver.tls.certManager.dnsNames={batch-gateway-apiserver,batch-gateway-apiserver.${BATCH_NS}.svc.cluster.local,localhost}" \
-    --set apiserver.podSecurityContext=null \
-    --set processor.podSecurityContext=null
+    --set "apiserver.tls.certManager.dnsNames={batch-gateway-apiserver,batch-gateway-apiserver.${BATCH_NS}.svc.cluster.local,localhost}"
 ```
 
 > - **`modelGateways.<model>.url`**: The processor uses the MaaS Gateway's **external hostname** (`https://maas.<domain>/...`) because the Gateway listener requires SNI matching. Internal Service FQDN causes TLS handshake failure.
 > - **`passThroughHeaders: {Authorization, X-MaaS-Subscription}`**: Ensures the processor sends inference requests on behalf of the original user, so the LLM route's AuthPolicy can enforce model-level authorization and the correct subscription is used for token rate limiting.
-> - **`podSecurityContext=null`**: Required on OpenShift for SCC (Security Context Constraints) compatibility.
 > - **File storage**: This example uses `global.fileClient.type=fs` with a PVC. To use S3-compatible storage instead, replace the `fs` options with:
 >   ```
 >   --set "global.fileClient.type=s3"
@@ -758,10 +755,16 @@ curl -sk -o /dev/null -w "%{http_code}" \
 # Unauthorized user creates a batch — batch is accepted (batch route validates API key only),
 # but the processor forwards requests to the LLM route with the unauthorized API key,
 # and the LLM route's AuthPolicy rejects with 403 (user not in authorized group).
+
+# Create input file
+cat > /tmp/batch-input.jsonl <<EOF
+{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"${MAAS_MODEL_NAME}","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}
+EOF
+
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${UNAUTH_API_KEY}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MAAS_MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
@@ -770,7 +773,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll until completed/failed — expect failed requests with 403
+# Wait for processing, then check status — expect failed requests with 403
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${UNAUTH_API_KEY}" | jq '{status, request_counts}'
 ```
@@ -778,11 +782,11 @@ curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
 ### 4.8 Batch Lifecycle
 
 ```bash
-# Upload input file
+# Upload input file (reuse /tmp/batch-input.jsonl from 4.7, or create it)
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${API_KEY}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MAAS_MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 # Create batch (include X-MaaS-Subscription for token rate limiting)
@@ -793,7 +797,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll status until completed
+# Wait for processing, then check status
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${API_KEY}" | jq '.status'
 

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -11,6 +11,7 @@ This guide demonstrates how to deploy batch-gateway on OpenShift with RHOAI (Red
 | `openshift-ingress` | Gateway data plane (Istio/Envoy proxy), managed by Ingress Operator |
 | `cert-manager-operator` | cert-manager operator subscription |
 | `cert-manager` | cert-manager controller, webhook, cainjector |
+| `openshift-lws-operator` | LeaderWorkerSet operator (required by LLMInferenceService) |
 | `kuadrant-system` | Kuadrant operator, Authorino, Limitador |
 | `redhat-ods-operator` | RHOAI operator |
 | `redhat-ods-applications` | RHOAI controllers (KServe, model controller) |
@@ -119,8 +120,9 @@ spec:
   controllerName: openshift.io/gateway-controller/v1
 EOF
 
-# Verify that the new Istiod deployment, istiod-openshift-gateway, is ready and available
-oc get deployment istiod-openshift-gateway -n openshift-ingress
+# Wait for the Istiod deployment to appear and become ready (~20s)
+until oc get deployment istiod-openshift-gateway -n openshift-ingress &>/dev/null; do sleep 5; done
+oc rollout status deployment/istiod-openshift-gateway -n openshift-ingress --timeout=120s
 ```
 </details>
 
@@ -161,8 +163,9 @@ spec:
         from: All
 EOF
 
-# Verify that the new Envoy proxy deployment, openshift-ai-inference-openshift-default, is ready and available
-oc get deployment openshift-ai-inference-openshift-default -n openshift-ingress
+# Wait for the Envoy proxy deployment to become ready
+until oc get deployment openshift-ai-inference-openshift-default -n openshift-ingress &>/dev/null; do sleep 5; done
+oc rollout status deployment/openshift-ai-inference-openshift-default -n openshift-ingress --timeout=120s
 ```
 
 > **Note**: The Gateway uses the OpenShift default router certificate (`router-certs-default`). The hostname must match the cluster's wildcard DNS for external access.
@@ -211,7 +214,8 @@ EOF
 Wait for the operator to be ready, then create the Kuadrant CR:
 
 ```bash
-oc get csv -n "${KUADRANT_NS}" -w
+# Wait for RHCL operator to be ready
+until oc get csv -n "${KUADRANT_NS}" 2>/dev/null | grep rhcl-operator | grep -q Succeeded; do sleep 10; done
 
 oc apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
@@ -222,9 +226,7 @@ metadata:
 spec: {}
 EOF
 
-# wait for kuadrant instance to be ready
-oc get kuadrant kuadrant -n "${KUADRANT_NS}"
-
+# Wait for Kuadrant instance to be ready
 oc wait kuadrant/kuadrant --for="condition=Ready=true" \
     -n "${KUADRANT_NS}" --timeout=300s
 ```
@@ -266,7 +268,105 @@ oc wait --for=condition=ready pod -l authorino-resource=authorino \
 
 </details>
 
-### 3.3 Install RHOAI
+### 3.3 Install cert-manager
+
+The LeaderWorkerSet operator (required by LLMInferenceService) depends on cert-manager. Install the OpenShift cert-manager operator:
+
+<details>
+<summary>Install cert-manager operator</summary>
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: cert-manager-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+# Wait for cert-manager webhook to be ready (this implies the operator CSV succeeded)
+until oc get deployment cert-manager-webhook -n cert-manager &>/dev/null; do sleep 10; done
+oc rollout status deployment/cert-manager-webhook -n cert-manager --timeout=300s
+```
+
+</details>
+
+### 3.4 Install LeaderWorkerSet operator
+
+LLMInferenceService requires the LeaderWorkerSet (LWS) CRD. Install the LWS operator:
+
+<details>
+<summary>Install LWS operator</summary>
+
+```bash
+oc apply -f - <<'EOF'
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-lws-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: leader-worker-set
+  namespace: openshift-lws-operator
+spec:
+  targetNamespaces:
+  - openshift-lws-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: leader-worker-set
+  namespace: openshift-lws-operator
+spec:
+  channel: stable-v1.0
+  installPlanApproval: Automatic
+  name: leader-worker-set
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+# Wait for the operator deployment to be ready
+until oc get deployment openshift-lws-operator -n openshift-lws-operator &>/dev/null; do sleep 10; done
+oc rollout status deployment/openshift-lws-operator -n openshift-lws-operator --timeout=300s
+
+# Create the LeaderWorkerSetOperator CR
+oc apply -f - <<'EOF'
+apiVersion: operator.openshift.io/v1
+kind: LeaderWorkerSetOperator
+metadata:
+  name: cluster
+  namespace: openshift-lws-operator
+spec:
+  managementState: Managed
+EOF
+
+# Wait for the LWS CRD to be available (may take ~30s for the controller to deploy)
+until oc get crd leaderworkersets.leaderworkerset.x-k8s.io &>/dev/null; do sleep 5; done
+oc wait crd/leaderworkersets.leaderworkerset.x-k8s.io --for=condition=Established --timeout=120s
+```
+
+</details>
+
+### 3.5 Install RHOAI
 
 Follow [RHOAI Installation Guide](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.3/html/installing_and_uninstalling_openshift_ai_self-managed/index) to install RHOAI
 
@@ -274,6 +374,8 @@ Follow [RHOAI Installation Guide](https://docs.redhat.com/en/documentation/red_h
 <summary>Install RHOAI operator</summary>
 
 ```bash
+oc create namespace redhat-ods-operator 2>/dev/null || true
+
 oc apply -f - <<'EOF'
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -301,7 +403,17 @@ EOF
 <details>
 <summary>Create DataScienceCluster instance</summary>
 
-Wait for the operator, then create DataScienceCluster:
+Wait for the RHOAI operator CSV to succeed, then create DataScienceCluster:
+
+```bash
+# Wait for the RHOAI operator CSV and DataScienceCluster CRD to be ready
+until oc get csv -n redhat-ods-operator 2>/dev/null | grep -q Succeeded; do sleep 10; done
+until oc get crd datascienceclusters.datasciencecluster.opendatahub.io &>/dev/null; do sleep 5; done
+
+# Wait for the RHOAI operator webhook to be ready
+until oc get deployment rhods-operator -n redhat-ods-operator &>/dev/null; do sleep 10; done
+oc rollout status deployment/rhods-operator -n redhat-ods-operator --timeout=120s
+```
 
 ```bash
 oc apply -f - <<'EOF'
@@ -339,7 +451,7 @@ oc wait datasciencecluster/default-dsc --for=jsonpath='{.status.phase}'=Ready --
 
 </details>
 
-### 3.4 Deploy model with llm-d
+### 3.6 Deploy model with llm-d
 
 Follow [deploy model doc](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.3/html/deploying_models/deploying_models#deploying-models-using-distributed-inference_rhoai-user) to deploy model with LLM-D
 
@@ -417,7 +529,7 @@ EOF
 Wait for the LLMInferenceService to be ready:
 ```bash
 oc wait llminferenceservice/${ISVC_NAME} -n ${LLM_NS} \
-    --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True --timeout=600s
+    --for=condition=Ready --timeout=600s
 ```
 > **Key annotation**: `security.opendatahub.io/enable-auth: "true"` enables the Gateway-level AuthPolicy that uses SubjectAccessReview to check if the user has RBAC permission to `get` the specific `LLMInferenceService` resource.
 </details>
@@ -453,7 +565,7 @@ facebook-opt-125m-kserve-route               13m
 ```
 </details>
 
-### 3.5 Configure TokenRateLimitPolicy for LLMInferenceService
+### 3.7 Configure TokenRateLimitPolicy for LLMInferenceService
 
 > **Note**: The TokenRateLimitPolicy targets the Gateway (not HTTPRoute) because LLMInferenceService dynamically generates the inference HTTPRoute name.
 
@@ -491,7 +603,7 @@ oc wait tokenratelimitpolicy/inference-token-limit \
 </details>
 
 
-### 3.6 Install Batch Gateway
+### 3.8 Install Batch Gateway
 
 Deploy batch-gateway with the model gateway URL from the LLMInferenceService status:
 
@@ -579,8 +691,6 @@ helm install batch-gateway ./charts/batch-gateway \
     --set apiserver.tls.certManager.issuerName=selfsigned-issuer \
     --set apiserver.tls.certManager.issuerKind=ClusterIssuer \
     --set "apiserver.tls.certManager.dnsNames={batch-gateway-apiserver,batch-gateway-apiserver.${BATCH_NS}.svc.cluster.local,localhost}" \
-    --set apiserver.podSecurityContext=null \
-    --set processor.podSecurityContext=null
 ```
 
 > - **`modelGateways.<model>.url`**: The processor uses this URL to send inference requests. It should point to the Gateway's model endpoint (from `llminferenceservice.status.url`), not directly to the model server, so that requests go through the Gateway's AuthPolicy and rate limiting.
@@ -601,7 +711,7 @@ helm install batch-gateway ./charts/batch-gateway \
 </details>
 
 
-### 3.7 Configure HTTPRoute and Policies for Batch Gateway
+### 3.9 Configure HTTPRoute and Policies for Batch Gateway
 
 Create the batch route, authentication policy, and rate limit:
 
@@ -832,10 +942,16 @@ curl -sk -o /dev/null -w "%{http_code}" \
 # Unauthorized user creates a batch — batch is accepted (batch route has no authz),
 # but the processor forwards requests to the LLM route with the unauthorized token,
 # and the LLM route's AuthPolicy rejects with 403.
+
+# Create input file
+cat > /tmp/batch-input.jsonl <<EOF
+{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"${MODEL_NAME}","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}
+EOF
+
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${UNAUTH_TOKEN}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
@@ -844,7 +960,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll until completed/failed — expect failed requests with 403
+# Wait for processing, then check status — expect failed requests with 403
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${UNAUTH_TOKEN}" | jq '{status, request_counts}'
 ```
@@ -852,11 +969,11 @@ curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
 ### 4.7 Batch Lifecycle
 
 ```bash
-# Upload input file
+# Upload input file (reuse /tmp/batch-input.jsonl from 4.6, or create it)
 FILE_ID=$(curl -sk ${GW_URL}/v1/files \
     -H "Authorization: Bearer ${AUTH_TOKEN}" \
     -F purpose=batch \
-    -F "file=@<(echo '{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"'${MODEL_NAME}'","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}')" \
+    -F "file=@/tmp/batch-input.jsonl" \
     | jq -r '.id')
 
 # Create batch
@@ -866,7 +983,8 @@ BATCH_ID=$(curl -sk ${GW_URL}/v1/batches \
     -d '{"input_file_id":"'${FILE_ID}'","endpoint":"/v1/chat/completions","completion_window":"24h"}' \
     | jq -r '.id')
 
-# Poll status until completed
+# Wait for processing, then check status
+sleep 30
 curl -sk ${GW_URL}/v1/batches/${BATCH_ID} \
     -H "Authorization: Bearer ${AUTH_TOKEN}" | jq '.status'
 

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -545,14 +545,6 @@ do_deploy_batch_gateway() {
         )
     fi
 
-    if is_openshift; then
-        log "OpenShift detected, clearing podSecurityContext for SCC compatibility"
-        helm_args+=(
-            --set "apiserver.podSecurityContext=null"
-            --set "processor.podSecurityContext=null"
-        )
-    fi
-
     # Append caller-specific args (modelGateways, passThroughHeaders, etc.)
     install_batch_gateway "${helm_args[@]}" "$@"
     create_batch_httproute


### PR DESCRIPTION
## Why is this PR needed?

The Helm chart's default `podSecurityContext` hardcoded `runAsUser: 65532`, `fsGroup: 65532`, and `seccompProfile: RuntimeDefault`, which are rejected by OpenShift's `restricted-v2` SCC when the UID falls outside the namespace's allowed range. This required every OpenShift deployment to pass `--set podSecurityContext=null`, which was error-prone and inconsistent across docs and scripts.

The `deploy-rhoai.md` guide was also missing two critical operator prerequisites (cert-manager and LeaderWorkerSet), causing `LLMInferenceService` creation to fail with `no matches for kind "LeaderWorkerSet"`. Additionally, the guide had numerous usability issues: `oc get -w` commands that never exit, `oc rollout status` calls that fail when deployments haven't appeared yet, missing namespace creation, and broken `oc wait` jsonpath syntax.

The batch test sections across all three deployment guides used `<(echo ...)` process substitution for file upload, which causes exit code 26 in some environments, and lacked wait time for batch processing.

## What does this PR do?

**Helm chart (`values.yaml`)**:
- Remove hardcoded UIDs from default `podSecurityContext` — only set `runAsNonRoot: true`
- The actual UID comes from the Dockerfile `USER 65532:65532` on vanilla Kubernetes, or from the namespace UID range on OpenShift (assigned by the `restricted-v2` SCC)
- This follows the same pattern as cert-manager and other projects that work on both Kubernetes and OpenShift without platform-specific overrides

**deploy-rhoai.md**:
- Add missing installation steps for **cert-manager** (new section 3.3) and **LeaderWorkerSet operator** (new section 3.4), both required prerequisites for LLMInferenceService
- Add `until oc get deployment ... &>/dev/null; do sleep N; done` before all `oc rollout status` calls (istiod, envoy proxy, cert-manager webhook, LWS operator) — `oc rollout status` fails with NotFound if the deployment hasn't appeared yet
- Replace `oc get csv -w` (watches forever, requires manual Ctrl+C) with `until ... grep Succeeded` loops
- Add `oc create namespace redhat-ods-operator` (was missing, causing apply to fail)
- Add CRD + webhook readiness checks before creating DataScienceCluster
- Fix `oc wait` jsonpath array filter syntax (`[?(@.type=="Ready")]` not supported) to use `--for=condition=Ready`
- Remove `--set podSecurityContext=null` overrides from helm install command
- Renumber sections (3.3 to 3.5 through 3.7 to 3.9)

**deploy-k8s.md / deploy-maas.md**:
- Replace `<(echo ...)` process substitution with temp file (`/tmp/batch-input.jsonl`) for batch file upload — fixes exit code 26
- Add `sleep 30` for batch processing wait
- Remove `podSecurityContext=null` overrides and related notes

**scripts/demo/common.sh**:
- Remove OpenShift SCC workaround block (`--set podSecurityContext=null`) since chart defaults are now compatible

**Helm tests (`deployment_test.yaml`)**:
- Update assertions to match new defaults: `isNull` for `runAsUser` instead of `equal: 65532`

## How was this tested?

All changes were verified end-to-end by following each doc step-by-step on **3 separate fresh OpenShift 4.19 clusters**, running all 8 test cases:

| Test | Result |
|------|--------|
| LLM Authentication (401/200) | Pass on 3/3 clusters |
| LLM Authorization (403/200) | Pass on 3/3 clusters |
| LLM Token Rate Limit (429) | Pass on 3/3 clusters |
| Batch Authentication (401/200) | Pass on 3/3 clusters |
| Batch Authorization via LLM route (failed=1) | Pass on 3/3 clusters |
| Batch Lifecycle (completed + results) | Pass on 3/3 clusters |
| Batch Request Rate Limit (429) | Pass on 3/3 clusters |

- [x] Unit tests added/updated/verified (`helm unittest` — 69/69 pass)
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (3 OpenShift 4.19 clusters)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)
