### PR TITLE
fix: add dedicated ServiceAccount for GC deployment

### DIFF
--- a/charts/batch-gateway/templates/_helpers.tpl
+++ b/charts/batch-gateway/templates/_helpers.tpl
@@ -214,6 +214,17 @@ app.kubernetes.io/component: gc
 {{- end }}
 
 {{/*
+GC service account name
+*/}}
+{{- define "batch-gateway.gc.serviceAccountName" -}}
+{{- if .Values.gc.serviceAccount.create }}
+{{- default (include "batch-gateway.gc.fullname" .) .Values.gc.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.gc.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 GC image string
 */}}
 {{- define "batch-gateway.gc.image" -}}

--- a/charts/batch-gateway/templates/gc-deployment.yaml
+++ b/charts/batch-gateway/templates/gc-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         {{- include "batch-gateway.gc.labels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ include "batch-gateway.gc.serviceAccountName" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/batch-gateway/templates/gc-serviceaccount.yaml
+++ b/charts/batch-gateway/templates/gc-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.gc.enabled .Values.gc.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "batch-gateway.gc.serviceAccountName" . }}
+  labels:
+    {{- include "batch-gateway.gc.labels" . | nindent 4 }}
+  {{- with .Values.gc.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.gc.serviceAccount.automount }}
+{{- end }}

--- a/charts/batch-gateway/tests/deployment_test.yaml
+++ b/charts/batch-gateway/tests/deployment_test.yaml
@@ -125,6 +125,61 @@ tests:
           path: spec.template.spec.securityContext.runAsUser
         template: templates/gc-deployment.yaml
 
+  # --- ServiceAccount ---
+
+  - it: should set default serviceAccountName on all Deployments
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-batch-gateway-apiserver
+        template: templates/apiserver-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-batch-gateway-processor
+        template: templates/processor-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-batch-gateway-gc
+        template: templates/gc-deployment.yaml
+
+  - it: should use custom serviceAccountName when specified
+    set:
+      apiserver.serviceAccount.name: "custom-apiserver-sa"
+      processor.serviceAccount.name: "custom-processor-sa"
+      gc.serviceAccount.name: "custom-gc-sa"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-apiserver-sa
+        template: templates/apiserver-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-processor-sa
+        template: templates/processor-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-gc-sa
+        template: templates/gc-deployment.yaml
+
+  - it: should use default SA when serviceAccount.create is false
+    set:
+      apiserver.serviceAccount.create: false
+      processor.serviceAccount.create: false
+      gc.serviceAccount.create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/apiserver-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/processor-deployment.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/gc-deployment.yaml
+
   # --- OTel env vars ---
 
   - it: should not inject OTel env vars when endpoint is empty

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -406,6 +406,12 @@ gc:
     pullPolicy: IfNotPresent
     tag: "latest"
 
+  serviceAccount:
+    create: true
+    automount: true
+    annotations: {}
+    name: ""
+
   # GC application config (rendered into a ConfigMap and mounted as config.yaml)
   config:
     dryRun: false


### PR DESCRIPTION
## Why is this PR needed?

The GC deployment uses the namespace default ServiceAccount, while both apiserver and processor have dedicated ServiceAccounts with full Helm chart support (serviceAccount.create, automount, annotations, name). This is a security concern — OpenShift security scans flag usage of the default SA — and breaks consistency across the three components. It also blocks future needs like IRSA/Workload Identity that require SA annotations.

## What does this PR do?

Adds the same ServiceAccount pattern used by apiserver and processor to the GC component:

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues
https://github.com/llm-d-incubation/batch-gateway/issues/279
