### PR TITLE
feature: skip inference request early if SLO deadline expired

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -684,8 +684,7 @@ func (p *Processor) executeOneRequest(
 		Headers:   headers,
 	}
 
-	switch sloCtx.Err() {
-	case context.DeadlineExceeded:
+	if sloCtx.Err() == context.DeadlineExceeded {
 		logger.V(logging.INFO).Info("SLO expired during execution, skipping request", "error", sloCtx.Err())
 		result := &outputLine{
 			ID:       newBatchRequestID(requestID),
@@ -693,18 +692,6 @@ func (p *Processor) executeOneRequest(
 			Error: &outputError{
 				Code:    batch_types.ErrCodeBatchExpired,
 				Message: "This request could not be executed before the completion window expired.",
-			},
-		}
-		metrics.RecordRequestError(modelID)
-		return result, nil
-	case context.Canceled:
-		logger.V(logging.INFO).Info("Execution context cancelled, skipping request", "error", sloCtx.Err())
-		result := &outputLine{
-			ID:       newBatchRequestID(requestID),
-			CustomID: req.CustomID,
-			Error: &outputError{
-				Code:    batch_types.ErrCodeBatchCancelled,
-				Message: "This request was not executed because the batch was cancelled.",
 			},
 		}
 		metrics.RecordRequestError(modelID)

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -591,11 +591,11 @@ func (p *Processor) drainUnprocessedRequests(
 
 const sloTTFTMSHeader = "x-slo-ttft-ms"
 
-// mergeSLOTTFTIntoHeaders sets sloTTFTMSHeader to the remaining time until
-// sloCtx's deadline in whole milliseconds, clamped to >= 0. If sloCtx has no
-// deadline or is cancelled, the headers map is returned unchanged.
+// mergeSLOTTFTIntoHeaders sets sloTTFTMSHeader to the remaining time until sloCtx's deadline
+// in whole milliseconds, clamped to >= 0. If sloCtx has no deadline, is cancelled, or has an
+// expired deadline, the headers map is returned unchanged.
 func mergeSLOTTFTIntoHeaders(headers map[string]string, sloCtx context.Context) map[string]string {
-	if sloCtx.Err() == context.Canceled {
+	if sloCtx.Err() != nil {
 		return headers
 	}
 	dl, ok := sloCtx.Deadline()
@@ -604,7 +604,9 @@ func mergeSLOTTFTIntoHeaders(headers map[string]string, sloCtx context.Context) 
 	}
 	sloMs := time.Until(dl).Milliseconds()
 	if sloMs < 0 {
-		sloMs = 0
+		// this should never happen as we check for context deadline exceeded in sloCtx.Err() above
+		// the check is maintained to avoid sending a negative value to the inference gateway
+		return headers
 	}
 	if headers == nil {
 		headers = make(map[string]string)
@@ -679,6 +681,20 @@ func (p *Processor) executeOneRequest(
 		Endpoint:  req.URL,
 		Params:    req.Body,
 		Headers:   headers,
+	}
+
+	if sloCtx.Err() != nil {
+		logger.V(logging.INFO).Info("SLO expired during execution or execution context cancelled, skipping request", "error", sloCtx.Err())
+		result := &outputLine{
+			ID:       newBatchRequestID(requestID),
+			CustomID: req.CustomID,
+			Error: &outputError{
+				Code:    string(httpclient.ErrCategoryServer),
+				Message: sloCtx.Err().Error(),
+			},
+		}
+		metrics.RecordRequestError(modelID)
+		return result, nil
 	}
 
 	start := time.Now()

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -604,8 +604,9 @@ func mergeSLOTTFTIntoHeaders(headers map[string]string, sloCtx context.Context) 
 	}
 	sloMs := time.Until(dl).Milliseconds()
 	if sloMs < 0 {
-		// this should never happen as we check for context deadline exceeded in sloCtx.Err() above
-		// the check is maintained to avoid sending a negative value to the inference gateway
+		// this check is needed in case the context deadline was exceeded between the sloCtx.Err() check
+		// and the time.Until call above. We return the headers unchanged to avoid sending a negative value
+		// to the inference gateway.
 		return headers
 	}
 	if headers == nil {
@@ -683,14 +684,27 @@ func (p *Processor) executeOneRequest(
 		Headers:   headers,
 	}
 
-	if sloCtx.Err() != nil {
-		logger.V(logging.INFO).Info("SLO expired during execution or execution context cancelled, skipping request", "error", sloCtx.Err())
+	switch sloCtx.Err() {
+	case context.DeadlineExceeded:
+		logger.V(logging.INFO).Info("SLO expired during execution, skipping request", "error", sloCtx.Err())
 		result := &outputLine{
 			ID:       newBatchRequestID(requestID),
 			CustomID: req.CustomID,
 			Error: &outputError{
 				Code:    batch_types.ErrCodeBatchExpired,
 				Message: "This request could not be executed before the completion window expired.",
+			},
+		}
+		metrics.RecordRequestError(modelID)
+		return result, nil
+	case context.Canceled:
+		logger.V(logging.INFO).Info("Execution context cancelled, skipping request", "error", sloCtx.Err())
+		result := &outputLine{
+			ID:       newBatchRequestID(requestID),
+			CustomID: req.CustomID,
+			Error: &outputError{
+				Code:    batch_types.ErrCodeBatchCancelled,
+				Message: "This request was not executed because the batch was cancelled.",
 			},
 		}
 		metrics.RecordRequestError(modelID)

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -690,7 +690,7 @@ func (p *Processor) executeOneRequest(
 			CustomID: req.CustomID,
 			Error: &outputError{
 				Code:    string(httpclient.ErrCategoryServer),
-				Message: sloCtx.Err().Error(),
+				Message: fmt.Sprintf("SLO deadline expired: %v", sloCtx.Err()),
 			},
 		}
 		metrics.RecordRequestError(modelID)

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -689,8 +689,8 @@ func (p *Processor) executeOneRequest(
 			ID:       newBatchRequestID(requestID),
 			CustomID: req.CustomID,
 			Error: &outputError{
-				Code:    string(httpclient.ErrCategoryServer),
-				Message: fmt.Sprintf("SLO deadline expired: %v", sloCtx.Err()),
+				Code:    batch_types.ErrCodeBatchExpired,
+				Message: "This request could not be executed before the completion window expired.",
 			},
 		}
 		metrics.RecordRequestError(modelID)

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -557,46 +557,6 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	}
 }
 
-func TestExecuteOneRequest_SLOCancelledDuringExecution(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.WorkDir = t.TempDir()
-
-	mock := &mockInferenceClient{
-		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
-		},
-	}
-
-	requests := []batch_types.Request{
-		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
-	}
-	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-
-	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
-	inputFile, _ := os.Open(inputPath)
-	defer inputFile.Close()
-
-	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
-	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
-
-	ctx := testLoggerCtx(t)
-	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
-	sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
-	if err != nil {
-		t.Fatalf("executeOneRequest error: %v", err)
-	}
-	if result.Error == nil {
-		t.Fatalf("expected error for SLO expired during execution")
-	}
-	if result.Error.Code != string(batch_types.ErrCodeBatchCancelled) {
-		t.Fatalf("error code = %q, want %q", result.Error.Code, batch_types.ErrCodeBatchCancelled)
-	}
-	if result.Error.Message != "This request was not executed because the batch was cancelled." {
-		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request was not executed because the batch was cancelled.")
-	}
-}
-
 // =====================================================================
 // Tests: processModel
 // =====================================================================

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -477,7 +477,7 @@ func TestExecuteOneRequest_BadOffset(t *testing.T) {
 	}
 }
 
-func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
+func TestExecuteOneRequest_SLOExpiredBeforeExecution(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -514,6 +514,86 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	}
 	if result.Error.Message != "This request could not be executed before the completion window expired." {
 		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request could not be executed before the completion window expired.")
+	}
+}
+
+func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(10*time.Nanosecond))
+	defer sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error == nil {
+		t.Fatalf("expected error for SLO expired during execution")
+	}
+	if result.Error.Code != string(batch_types.ErrCodeBatchExpired) {
+		t.Fatalf("error code = %q, want %q", result.Error.Code, batch_types.ErrCodeBatchExpired)
+	}
+	if result.Error.Message != "This request could not be executed before the completion window expired." {
+		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request could not be executed before the completion window expired.")
+	}
+}
+
+func TestExecuteOneRequest_SLOCancelledDuringExecution(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
+	sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error == nil {
+		t.Fatalf("expected error for SLO expired during execution")
+	}
+	if result.Error.Code != string(batch_types.ErrCodeBatchCancelled) {
+		t.Fatalf("error code = %q, want %q", result.Error.Code, batch_types.ErrCodeBatchCancelled)
+	}
+	if result.Error.Message != "This request was not executed because the batch was cancelled." {
+		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request was not executed because the batch was cancelled.")
 	}
 }
 

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -477,6 +477,46 @@ func TestExecuteOneRequest_BadOffset(t *testing.T) {
 	}
 }
 
+func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
+	defer sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error == nil {
+		t.Fatalf("expected error for SLO expired during execution")
+	}
+	if result.Error.Code != string(httpclient.ErrCategoryServer) {
+		t.Fatalf("error code = %q, want %q", result.Error.Code, httpclient.ErrCategoryServer)
+	}
+	if result.Error.Message != sloCtx.Err().Error() {
+		t.Fatalf("error message = %q, want %q", result.Error.Message, sloCtx.Err().Error())
+	}
+}
+
 // =====================================================================
 // Tests: processModel
 // =====================================================================
@@ -2356,12 +2396,22 @@ func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
 		}
 	})
 
-	t.Run("deadline in the past clamps to zero", func(t *testing.T) {
+	t.Run("deadline in the past leaves headers unchanged", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		h := mergeSLOTTFTIntoHeaders(nil, ctx)
-		if got := h[sloTTFTMSHeader]; got != "0" {
-			t.Fatalf("x-slo-ttft-ms = %q, want 0", got)
+		if got := mergeSLOTTFTIntoHeaders(nil, ctx); got != nil {
+			t.Fatalf("nil headers: got %v, want nil (expired deadline => no merge)", got)
+		}
+		in := map[string]string{"a": "b"}
+		got := mergeSLOTTFTIntoHeaders(in, ctx)
+		if len(got) != 1 {
+			t.Fatalf("expected no new keys, got len=%d %#v", len(got), got)
+		}
+		if _, ok := got[sloTTFTMSHeader]; ok {
+			t.Fatalf("unexpected %s with expired deadline", sloTTFTMSHeader)
+		}
+		if got["a"] != "b" {
+			t.Fatal("lost existing header")
 		}
 	})
 

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -512,8 +512,8 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	if result.Error.Code != string(httpclient.ErrCategoryServer) {
 		t.Fatalf("error code = %q, want %q", result.Error.Code, httpclient.ErrCategoryServer)
 	}
-	if result.Error.Message != sloCtx.Err().Error() {
-		t.Fatalf("error message = %q, want %q", result.Error.Message, sloCtx.Err().Error())
+	if result.Error.Message != "This request could not be executed before the completion window expired." {
+		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request could not be executed before the completion window expired.")
 	}
 }
 

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -509,8 +509,8 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	if result.Error == nil {
 		t.Fatalf("expected error for SLO expired during execution")
 	}
-	if result.Error.Code != string(httpclient.ErrCategoryServer) {
-		t.Fatalf("error code = %q, want %q", result.Error.Code, httpclient.ErrCategoryServer)
+	if result.Error.Code != string(batch_types.ErrCodeBatchExpired) {
+		t.Fatalf("error code = %q, want %q", result.Error.Code, batch_types.ErrCodeBatchExpired)
 	}
 	if result.Error.Message != "This request could not be executed before the completion window expired." {
 		t.Fatalf("error message = %q, want %q", result.Error.Message, "This request could not be executed before the completion window expired.")


### PR DESCRIPTION
## Why is this PR needed?

Return early from the request processing if SLO deadline is exceeded.

## What does this PR do?

Return an error result as soon as the deadline on sloCtx is exceeded. Also avoid adding SLO headers to the request if the deadline is exceeded.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #296 
