### PR TITLE
feat: support installing batch-gateway from OCI Helm chart

### DIFF
--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -608,10 +608,11 @@ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
 kubectl rollout status statefulset/postgresql -n ${BATCH_NS} --timeout=120s
 
 # Create application secret
+# Replace <your-password> with your actual PostgreSQL password
 kubectl create secret generic batch-gateway-secrets \
     --namespace ${BATCH_NS} \
     --from-literal=redis-url="redis://redis-master.${BATCH_NS}.svc.cluster.local:6379/0" \
-    --from-literal=postgresql-url="postgresql://postgres:postgres@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
+    --from-literal=postgresql-url="postgresql://postgres:<your-password>@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
 
 # Create PVC for batch file storage (alternatively, S3-compatible storage can be used — see Helm chart values for s3 configuration)
 kubectl apply -f - <<EOF

--- a/docs/guides/deploy-maas.md
+++ b/docs/guides/deploy-maas.md
@@ -354,10 +354,11 @@ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
 oc rollout status statefulset/postgresql -n ${BATCH_NS} --timeout=120s
 
 # Create application secret
+# Replace <your-password> with your actual PostgreSQL password
 kubectl create secret generic batch-gateway-secrets \
     --namespace ${BATCH_NS} \
     --from-literal=redis-url="redis://redis-master.${BATCH_NS}.svc.cluster.local:6379/0" \
-    --from-literal=postgresql-url="postgresql://postgres:postgres@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
+    --from-literal=postgresql-url="postgresql://postgres:<your-password>@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
 
 # Create PVC for batch file storage (alternatively, S3-compatible storage can be used — see Helm chart values for s3 configuration)
 oc apply -f - <<EOF

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -647,10 +647,11 @@ helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql \
 oc rollout status statefulset/postgresql -n ${BATCH_NS} --timeout=120s
 
 # Create application secret
+# Replace <your-password> with your actual PostgreSQL password
 kubectl create secret generic batch-gateway-secrets \
     --namespace ${BATCH_NS} \
     --from-literal=redis-url="redis://redis-master.${BATCH_NS}.svc.cluster.local:6379/0" \
-    --from-literal=postgresql-url="postgresql://postgres:postgres@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
+    --from-literal=postgresql-url="postgresql://postgres:<your-password>@postgresql.${BATCH_NS}.svc.cluster.local:5432/batch?sslmode=disable"
 
 # Create PVC for batch file storage (alternatively, S3-compatible storage can be used — see Helm chart values for s3 configuration)
 oc apply -f - <<EOF

--- a/docs/guides/maas-integration.md
+++ b/docs/guides/maas-integration.md
@@ -170,9 +170,10 @@ $ helm install postgresql bitnami/postgresql -n batch-api \
 
 ```bash
 # App secret with database connection URLs
+# Replace <your-password> with your actual PostgreSQL password
 $ kubectl create secret generic batch-gateway-secrets -n batch-api \
     --from-literal=redis-url=redis://redis-master.batch-api.svc.cluster.local:6379/0 \
-    --from-literal=postgresql-url=postgresql://postgres:postgres@postgresql.batch-api.svc.cluster.local:5432/postgres
+    --from-literal=postgresql-url=postgresql://postgres:<your-password>@postgresql.batch-api.svc.cluster.local:5432/postgres
 
 # PVC for file storage
 $ kubectl apply -f - <<EOF

--- a/examples/deploy-demo/README.md
+++ b/examples/deploy-demo/README.md
@@ -105,12 +105,34 @@ bash examples/deploy-demo/deploy-maas.sh uninstall
 ```
 
 
+## Installation Modes
+
+**Local chart (default):**
+```bash
+bash examples/deploy-demo/deploy-rhoai.sh install
+```
+
+**Install from a specific commit (chart + image):**
+```bash
+BATCH_DEV_VERSION=1f925ff \
+  bash examples/deploy-demo/deploy-rhoai.sh install
+```
+
+**Install from released OCI Helm chart:**
+```bash
+BATCH_RELEASE_VERSION=v1.0.0 \
+  bash examples/deploy-demo/deploy-rhoai.sh install
+```
+
+> `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together.
+
 ## Environment Variables
 
 | Variable | Default | Scope | Description |
 |----------|---------|-------|-------------|
 | `BATCH_HELM_RELEASE` | `batch-gateway` | all | Helm release name |
-| `BATCH_DEV_VERSION` | `latest` | all | apiserver/processor image tag |
+| `BATCH_RELEASE_VERSION` | — | all | Install from released OCI chart (e.g. `v1.0.0`). Cannot be used with `BATCH_DEV_VERSION` |
+| `BATCH_DEV_VERSION` | `local` | all | Image tag / commit SHA. `local` uses local chart + `latest` image. Cannot be used with `BATCH_RELEASE_VERSION` |
 | `BATCH_DB_TYPE` | `postgresql` | all | Database backend: `postgresql` or `redis` |
 | `BATCH_STORAGE_TYPE` | `s3` | all | File storage: `fs` or `s3` |
 | `BATCH_NAMESPACE` | `batch-api` | all | Namespace for batch-gateway |

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -28,7 +28,24 @@ TLS_ISSUER_NAME="${TLS_ISSUER_NAME:-selfsigned-issuer}"
 # Batch Gateway configuration
 BATCH_NAMESPACE="${BATCH_NAMESPACE:-batch-api}"
 BATCH_HELM_RELEASE="${BATCH_HELM_RELEASE:-batch-gateway}"
-BATCH_DEV_VERSION="${BATCH_DEV_VERSION:-latest}"
+BATCH_RELEASE_VERSION="${BATCH_RELEASE_VERSION:-}"
+BATCH_DEV_VERSION="${BATCH_DEV_VERSION:-}"
+if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+    if [[ "${BATCH_RELEASE_VERSION}" != v* ]]; then
+        echo "[ERROR] BATCH_RELEASE_VERSION must start with 'v' (e.g. 'v1.0.0')" >&2
+        exit 1
+    fi
+    if [ -n "${BATCH_DEV_VERSION}" ]; then
+        echo "[ERROR] BATCH_RELEASE_VERSION and BATCH_DEV_VERSION cannot both be set" >&2
+        exit 1
+    fi
+else
+    BATCH_DEV_VERSION="${BATCH_DEV_VERSION:-local}"
+    # Truncate full commit SHA (40 hex chars) to 7-char short SHA to match CI image tags
+    if [[ "${BATCH_DEV_VERSION}" =~ ^[0-9a-f]{40}$ ]]; then
+        BATCH_DEV_VERSION="${BATCH_DEV_VERSION:0:7}"
+    fi
+fi
 BATCH_INFERENCE_SERVICE="${BATCH_INFERENCE_SERVICE:-${BATCH_HELM_RELEASE}-apiserver}"
 BATCH_INFERENCE_PORT="${BATCH_INFERENCE_PORT:-8000}"
 BATCH_APP_SECRET_NAME="${BATCH_APP_SECRET_NAME:-${BATCH_HELM_RELEASE}-secrets}"
@@ -50,6 +67,12 @@ MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
 MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
 MINIO_BUCKET="${MINIO_BUCKET:-batch-gateway}"
 
+# Temp directory cleanup (used by install_batch_gateway)
+_BATCH_TMP_DIR=""
+_cleanup() {
+    [ -n "${_BATCH_TMP_DIR}" ] && rm -rf "${_BATCH_TMP_DIR}" && _BATCH_TMP_DIR=""
+}
+trap _cleanup EXIT
 
 # ── Helper Functions ──────────────────────────────────────────────────────────
 
@@ -487,21 +510,71 @@ EOF
 install_batch_gateway() {
     step "Installing batch-gateway via Helm..."
 
-    local repo_root
-    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    local chart version_args=()
+    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+        chart="oci://ghcr.io/llm-d-incubation/charts/batch-gateway"
+        version_args=(--version "${BATCH_RELEASE_VERSION#v}")
+    elif [ "${BATCH_DEV_VERSION}" = "local" ]; then
+        local repo_root
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        chart="${repo_root}/charts/batch-gateway"
+    else
+        # Download chart from GitHub at the specific commit
+        _BATCH_TMP_DIR=$(mktemp -d)
+        local tarball_url="https://github.com/llm-d-incubation/batch-gateway/archive/${BATCH_DEV_VERSION}.tar.gz"
+        step "Downloading chart from commit ${BATCH_DEV_VERSION}..."
+        local http_code
+        http_code=$(curl -sL -o "${_BATCH_TMP_DIR}/archive.tar.gz" -w '%{http_code}' "${tarball_url}")
+        if [ "${http_code}" != "200" ]; then
+            die "Failed to download chart (HTTP ${http_code}). Is '${BATCH_DEV_VERSION}' a valid commit?"
+        fi
+        tar xz -C "${_BATCH_TMP_DIR}" --strip-components=1 -f "${_BATCH_TMP_DIR}/archive.tar.gz"
+        chart="${_BATCH_TMP_DIR}/charts/batch-gateway"
+        if [ ! -f "${chart}/Chart.yaml" ]; then
+            die "Chart not found at commit ${BATCH_DEV_VERSION}"
+        fi
+    fi
 
     if helm status "${BATCH_HELM_RELEASE}" -n "${BATCH_NAMESPACE}" &>/dev/null; then
         log "Release '${BATCH_HELM_RELEASE}' already exists. Upgrading..."
-        helm upgrade "${BATCH_HELM_RELEASE}" "${repo_root}/charts/batch-gateway" "$@"
+        helm upgrade "${BATCH_HELM_RELEASE}" "${chart}" --reset-values "${version_args[@]+"${version_args[@]}"}" "$@"
     else
-        helm install "${BATCH_HELM_RELEASE}" "${repo_root}/charts/batch-gateway" "$@"
+        helm install "${BATCH_HELM_RELEASE}" "${chart}" "${version_args[@]+"${version_args[@]}"}" "$@"
     fi
 
     wait_for_deployment "${BATCH_HELM_RELEASE}-apiserver" "${BATCH_NAMESPACE}" 180s
     wait_for_deployment "${BATCH_HELM_RELEASE}-processor" "${BATCH_NAMESPACE}" 180s
     wait_for_deployment "${BATCH_HELM_RELEASE}-gc" "${BATCH_NAMESPACE}" 180s
 
-    log "batch-gateway installed (apiserver + processor + gc)."
+    # Print installed versions and verify image tags
+    local expected_tag
+    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+        expected_tag="${BATCH_RELEASE_VERSION}"
+    else
+        if [ "${BATCH_DEV_VERSION}" = "local" ]; then
+            expected_tag="latest"
+        else
+            expected_tag="${BATCH_DEV_VERSION}"
+        fi
+    fi
+    step "Installed batch-gateway components:"
+    local mismatch=false
+    for component in apiserver processor gc; do
+        local actual_image
+        actual_image=$(kubectl get deploy "${BATCH_HELM_RELEASE}-${component}" -n "${BATCH_NAMESPACE}" \
+            -o jsonpath='{.spec.template.spec.containers[0].image}')
+        local actual_tag="${actual_image##*:}"
+        log "  ${component}: ${actual_image}"
+        if [ "${actual_tag}" != "${expected_tag}" ]; then
+            warn "  ${component} tag '${actual_tag}' does not match expected '${expected_tag}'"
+            mismatch=true
+        fi
+    done
+    if [ "${mismatch}" = "true" ]; then
+        warn "Image tags do not match expected version."
+    fi
+
+    log "batch-gateway installed."
 }
 
 # do_deploy_batch_gateway [extra_helm_args...]
@@ -522,9 +595,22 @@ do_deploy_batch_gateway() {
 
     local helm_args=(
         --namespace "${BATCH_NAMESPACE}"
-        --set "apiserver.image.tag=${BATCH_DEV_VERSION}"
-        --set "processor.image.tag=${BATCH_DEV_VERSION}"
         --set "global.secretName=${BATCH_APP_SECRET_NAME}"
+    )
+
+    # Only override image tags for non-release installs.
+    # Released OCI charts already have correct image tags baked in.
+    if [ -z "${BATCH_RELEASE_VERSION}" ]; then
+        local image_tag="latest"
+        [ "${BATCH_DEV_VERSION}" != "local" ] && image_tag="${BATCH_DEV_VERSION}"
+        helm_args+=(
+            --set "apiserver.image.tag=${image_tag}"
+            --set "processor.image.tag=${image_tag}"
+            --set "gc.image.tag=${image_tag}"
+        )
+    fi
+
+    helm_args+=(
         --set "global.dbClient.type=${BATCH_DB_TYPE}"
         --set "global.fileClient.type=${BATCH_STORAGE_TYPE}"
         --set "apiserver.tls.enabled=true"

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -543,7 +543,15 @@ cmd_install() {
     apply_batch_auth_policy
     apply_batch_request_rate_limit
 
-    log "Deployment complete! Run '$0 test' to verify."
+    log "Deployment complete!"
+    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+        log "  Batch Gateway version: ${BATCH_RELEASE_VERSION} (OCI chart)"
+    elif [ "${BATCH_DEV_VERSION}" != "local" ]; then
+        log "  Batch Gateway image tag: ${BATCH_DEV_VERSION} (commit chart)"
+    else
+        log "  Batch Gateway image tag: latest (local chart)"
+    fi
+    log "Run '$0 test' to verify."
 }
 
 # ── Test ─────────────────────────────────────────────────────────────────────
@@ -706,7 +714,8 @@ usage() {
     echo "  LLMD_RELEASE_POSTFIX   Release name postfix (default: llmd)"
     echo "  BATCH_HELM_RELEASE     Helm release name (default: batch-gateway)"
     echo "  GATEWAY_LOCAL_PORT     Port-forward fallback port (default: 8080)"
-    echo "  BATCH_DEV_VERSION      Image tag (default: latest)"
+    echo "  BATCH_DEV_VERSION      Batch gateway image tag / commit SHA (default: local)"
+    echo "  BATCH_RELEASE_VERSION  Install released OCI chart (e.g. v1.0.0)"
     echo ""
     echo "Examples:"
     echo "  $0 install"

--- a/examples/deploy-demo/deploy-maas.sh
+++ b/examples/deploy-demo/deploy-maas.sh
@@ -562,6 +562,13 @@ cmd_install() {
     log "  MaaS Gateway: ${host}"
     log "  Batch API:    ${host}/v1/batches"
     log "  Test user:    ${MAAS_TEST_USER} / ${MAAS_TEST_PASS} (group: ${MAAS_TEST_GROUP})"
+    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+        log "  Batch Gateway version: ${BATCH_RELEASE_VERSION} (OCI chart)"
+    elif [ "${BATCH_DEV_VERSION}" != "local" ]; then
+        log "  Batch Gateway image tag: ${BATCH_DEV_VERSION} (commit chart)"
+    else
+        log "  Batch Gateway image tag: latest (local chart)"
+    fi
     log ""
     log "Run '$0 test' to verify."
 }

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -246,13 +246,16 @@ EOF
         done
     fi
 
-    # Wait for operator to detect sub-operators before creating CR
-    log "Waiting 15s for Kuadrant operator to register sub-operators..."
-    sleep 15
+    # Create Kuadrant CR with retry.
+    # The operator may not detect sub-operators immediately after they become ready,
+    # so we retry by restarting the operator pod if the CR fails to become Ready.
+    local kuadrant_ready=false
+    for attempt in 1 2 3; do
+        log "Waiting 15s for Kuadrant operator to register sub-operators..."
+        sleep 15
 
-    # Create Kuadrant CR
-    step "Creating Kuadrant CR..."
-    kubectl apply -f - <<EOF
+        step "Creating Kuadrant CR (attempt ${attempt}/3)..."
+        kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
@@ -261,9 +264,21 @@ metadata:
 spec: {}
 EOF
 
-    step "Waiting for Kuadrant CR to be ready..."
-    kubectl wait kuadrant/kuadrant --for="condition=Ready=true" \
-        -n "${ns}" --timeout=300s
+        if kubectl wait kuadrant/kuadrant --for="condition=Ready=true" \
+            -n "${ns}" --timeout=180s 2>/dev/null; then
+            kuadrant_ready=true
+            break
+        fi
+
+        warn "Kuadrant CR not ready, restarting operator pod..."
+        kubectl delete kuadrant/kuadrant -n "${ns}" --ignore-not-found 2>/dev/null || true
+        kubectl rollout restart deploy/kuadrant-operator-controller-manager -n "${ns}"
+        kubectl rollout status deploy/kuadrant-operator-controller-manager -n "${ns}" --timeout=60s
+    done
+
+    if [ "${kuadrant_ready}" != "true" ]; then
+        die "Kuadrant CR did not become ready after 3 attempts"
+    fi
 
     # Configure Authorino for authentication (SSL with OpenShift serving certs)
     step "Configuring Authorino SSL..."
@@ -694,6 +709,13 @@ cmd_install() {
     log "  Operator: ${OPERATOR_TYPE}"
     log "  Model: ${MODEL_NAME} (simulator, ${MODEL_REPLICAS} replicas, no GPU)"
     log "  Batch Gateway: ${BATCH_HELM_RELEASE} (${BATCH_NAMESPACE})"
+    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+        log "  Batch Gateway version: ${BATCH_RELEASE_VERSION} (OCI chart)"
+    elif [ "${BATCH_DEV_VERSION}" != "local" ]; then
+        log "  Batch Gateway image tag: ${BATCH_DEV_VERSION} (commit chart)"
+    else
+        log "  Batch Gateway image tag: latest (local chart)"
+    fi
     log ""
     log "Run '$0 test' to verify."
 }
@@ -890,7 +912,8 @@ usage() {
     echo "  MODEL_NAME       Model name for simulator (default: facebook/opt-125m)"
     echo "  MODEL_REPLICAS   Number of replicas (default: 2)"
     echo "  SIM_IMAGE        Simulator image (default: ghcr.io/llm-d/llm-d-inference-sim:v0.7.1)"
-    echo "  BATCH_DEV_VERSION      Batch gateway image tag (default: latest)"
+    echo "  BATCH_DEV_VERSION      Batch gateway image tag / commit SHA (default: local)"
+    echo "  BATCH_RELEASE_VERSION  Install released OCI chart (e.g. v1.0.0)"
     echo "  BATCH_DB_TYPE          Database: postgresql or redis (default: postgresql)"
     echo "  BATCH_STORAGE_TYPE     File storage: fs or s3 (default: s3)"
     exit "${1:-0}"


### PR DESCRIPTION
## Why is this PR needed?

The demo deploy scripts currently install batch-gateway from the local `charts/` directory only. 

After a release, users should be able to install directly from the published OCI Helm chart on GHCR (`oci://ghcr.io/llm-d-incubation/charts/batch-gateway`) without cloning the repository.

## What does this PR do?

Adds `BATCH_RELEASE_VERSION` and updates `BATCH_DEV_VERSION` to support three installation modes:

**Local chart with `latest` image (default):**
```bash
./deploy-rhoai.sh install
```

**Install from a specific commit (chart downloaded from GitHub + matching image tag):**
```bash
BATCH_DEV_VERSION=1f925ff ./deploy-rhoai.sh install
```

**Install from released OCI Helm chart:**
```bash
BATCH_RELEASE_VERSION=v0.1.0-RC1 ./deploy-rhoai.sh install
```

## How was this tested?

- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (local chart mode on OpenShift)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Pre-commit checks pass (`make pre-commit`)
- [ ] Unit tests pass (`make test`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->