### PR TITLE
feature: send x-priority header on inference requests for GIE flow control

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -88,6 +88,8 @@ data:
       {{- end }}
     {{- end }}
 
+    inference_priority: {{ .Values.processor.config.inferencePriority }}
+
     default_output_expiration_seconds: {{ .Values.processor.config.defaultOutputExpirationSeconds }}
     progress_ttl_seconds: {{ .Values.processor.config.progressTTLSeconds }}
 

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -231,6 +231,20 @@ tests:
           path: data["config.yaml"]
           pattern: 'retry:\n\s+max_retries: 3\n\s+initial_backoff: "1s"\n\s+max_backoff: "10s"'
 
+  - it: should render default inferencePriority as -1
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'inference_priority: -1'
+
+  - it: should render custom inferencePriority
+    set:
+      processor.config.inferencePriority: 0
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'inference_priority: 0'
+
   - it: should not render ConfigMap when processor is disabled
     set:
       processor.enabled: false

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -349,6 +349,10 @@ processor:
     #     maxRetries: 1
     defaultOutputExpirationSeconds: 7776000  # 90 days
     progressTTLSeconds: 86400  # 24 hours
+    # Priority value sent in the x-priority header on inference requests.
+    # Used by GIE's flow control to assign batch requests to a priority band.
+    # -1 (default) means the header is not sent.
+    inferencePriority: -1
     # Enable pprof profiling endpoints on the observability server (/debug/pprof/)
     enablePprof: false
 

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -100,6 +100,11 @@ type ProcessorConfig struct {
 	// Each recovery can involve DB lookups, S3 uploads, and status updates.
 	RecoveryMaxConcurrency int `yaml:"recovery_max_concurrency"`
 
+	// InferencePriority is the priority value sent in the x-priority header on inference requests.
+	// Used by GIE's flow control to assign batch requests to a priority band.
+	// -1 (default) means the header is not sent.
+	InferencePriority int `yaml:"inference_priority"`
+
 	// EnablePprof enables pprof profiling endpoints on the observability server.
 	EnablePprof bool `yaml:"enable_pprof"`
 
@@ -201,6 +206,7 @@ func NewConfig() *ProcessorConfig {
 				MaxBackoff:     10 * time.Second,
 			},
 		},
+		InferencePriority:              -1,                 // disabled by default
 		DefaultOutputExpirationSeconds: 90 * 24 * 60 * 60, // 90 days
 		ProgressTTLSeconds:             24 * 60 * 60,      // 24 hours
 		RecoveryMaxConcurrency:         5,

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -206,7 +206,7 @@ func NewConfig() *ProcessorConfig {
 				MaxBackoff:     10 * time.Second,
 			},
 		},
-		InferencePriority:              -1,                 // disabled by default
+		InferencePriority:              -1,                // disabled by default
 		DefaultOutputExpirationSeconds: 90 * 24 * 60 * 60, // 90 days
 		ProgressTTLSeconds:             24 * 60 * 60,      // 24 hours
 		RecoveryMaxConcurrency:         5,

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -589,30 +589,46 @@ func (p *Processor) drainUnprocessedRequests(
 	}
 }
 
-const sloTTFTMSHeader = "x-slo-ttft-ms"
+const (
+	sloTTFTMSHeader  = "x-slo-ttft-ms"
+	priorityHeader   = "x-priority"
+	priorityDisabled = -1
+)
 
-// mergeSLOTTFTIntoHeaders sets sloTTFTMSHeader to the remaining time until sloCtx's deadline
-// in whole milliseconds, clamped to >= 0. If sloCtx has no deadline, is cancelled, or has an
-// expired deadline, the headers map is returned unchanged.
-func mergeSLOTTFTIntoHeaders(headers map[string]string, sloCtx context.Context) map[string]string {
-	if sloCtx.Err() != nil {
+// mergeFlowControlHeaders sets flow-control-related headers on inference requests:
+//   - x-slo-ttft-ms: remaining time until sloCtx's deadline in whole milliseconds (>= 0).
+//     Omitted if sloCtx has no deadline, is cancelled, or has an expired deadline.
+//   - x-priority: the configured inference priority value for GIE flow control band assignment.
+//     Omitted if inference_priority is -1 (disabled).
+func mergeFlowControlHeaders(headers map[string]string, sloCtx context.Context, inferencePriority int) map[string]string {
+	hasSLO := false
+	var sloMs int64
+
+	if sloCtx.Err() == nil {
+		if dl, ok := sloCtx.Deadline(); ok {
+			ms := time.Until(dl).Milliseconds()
+			if ms >= 0 {
+				hasSLO = true
+				sloMs = ms
+			}
+		}
+	}
+
+	hasPriority := inferencePriority != priorityDisabled
+
+	if !hasSLO && !hasPriority {
 		return headers
 	}
-	dl, ok := sloCtx.Deadline()
-	if !ok {
-		return headers
-	}
-	sloMs := time.Until(dl).Milliseconds()
-	if sloMs < 0 {
-		// this check is needed in case the context deadline was exceeded between the sloCtx.Err() check
-		// and the time.Until call above. We return the headers unchanged to avoid sending a negative value
-		// to the inference gateway.
-		return headers
-	}
+
 	if headers == nil {
 		headers = make(map[string]string)
 	}
-	headers[sloTTFTMSHeader] = strconv.FormatInt(sloMs, 10)
+	if hasSLO {
+		headers[sloTTFTMSHeader] = strconv.FormatInt(sloMs, 10)
+	}
+	if hasPriority {
+		headers[priorityHeader] = strconv.Itoa(inferencePriority)
+	}
 	return headers
 }
 
@@ -675,7 +691,7 @@ func (p *Processor) executeOneRequest(
 	}
 
 	headers := maps.Clone(passThroughHeaders)
-	headers = mergeSLOTTFTIntoHeaders(headers, sloCtx)
+	headers = mergeFlowControlHeaders(headers, sloCtx, p.cfg.InferencePriority)
 
 	inferReq := &inference.GenerateRequest{
 		RequestID: newBatchRequestID(requestID),

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2397,21 +2397,18 @@ func TestJsonNumericToFloat64(t *testing.T) {
 }
 
 // =====================================================================
-// Tests: mergeSLOTTFTIntoHeaders
+// Tests: mergeFlowControlHeaders
 // =====================================================================
 
-func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
-	t.Run("no deadline leaves headers unchanged", func(t *testing.T) {
-		if got := mergeSLOTTFTIntoHeaders(nil, context.Background()); got != nil {
-			t.Fatalf("nil headers: got %v, want nil (no deadline => no merge)", got)
+func TestMergeFlowControlHeaders(t *testing.T) {
+	t.Run("no deadline and priority disabled leaves headers unchanged", func(t *testing.T) {
+		if got := mergeFlowControlHeaders(nil, context.Background(), priorityDisabled); got != nil {
+			t.Fatalf("nil headers: got %v, want nil", got)
 		}
 		in := map[string]string{"a": "b"}
-		got := mergeSLOTTFTIntoHeaders(in, context.Background())
+		got := mergeFlowControlHeaders(in, context.Background(), priorityDisabled)
 		if len(got) != 1 {
 			t.Fatalf("expected no new keys, got len=%d %#v", len(got), got)
-		}
-		if _, ok := got[sloTTFTMSHeader]; ok {
-			t.Fatalf("unexpected %s without deadline", sloTTFTMSHeader)
 		}
 		if got["a"] != "b" {
 			t.Fatal("lost existing header")
@@ -2422,12 +2419,11 @@ func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
 		want := 5*time.Second + 123*time.Millisecond
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(want))
 		defer cancel()
-		h := mergeSLOTTFTIntoHeaders(nil, ctx)
+		h := mergeFlowControlHeaders(nil, ctx, priorityDisabled)
 		got, err := strconv.ParseInt(h[sloTTFTMSHeader], 10, 64)
 		if err != nil {
 			t.Fatalf("parse header: %v", err)
 		}
-		// Allow slack between deadline creation and time.Until inside merge.
 		const slackMs int64 = 150
 		hi := want.Milliseconds()
 		lo := hi - slackMs
@@ -2439,26 +2435,23 @@ func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
 	t.Run("deadline in the past leaves headers unchanged", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		if got := mergeSLOTTFTIntoHeaders(nil, ctx); got != nil {
+		if got := mergeFlowControlHeaders(nil, ctx, priorityDisabled); got != nil {
 			t.Fatalf("nil headers: got %v, want nil (expired deadline => no merge)", got)
 		}
 		in := map[string]string{"a": "b"}
-		got := mergeSLOTTFTIntoHeaders(in, ctx)
+		got := mergeFlowControlHeaders(in, ctx, priorityDisabled)
 		if len(got) != 1 {
 			t.Fatalf("expected no new keys, got len=%d %#v", len(got), got)
 		}
 		if _, ok := got[sloTTFTMSHeader]; ok {
 			t.Fatalf("unexpected %s with expired deadline", sloTTFTMSHeader)
 		}
-		if got["a"] != "b" {
-			t.Fatal("lost existing header")
-		}
 	})
 
 	t.Run("preserves existing headers", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
 		defer cancel()
-		h := mergeSLOTTFTIntoHeaders(map[string]string{"a": "b"}, ctx)
+		h := mergeFlowControlHeaders(map[string]string{"a": "b"}, ctx, priorityDisabled)
 		if h["a"] != "b" {
 			t.Fatal("lost existing header")
 		}
@@ -2473,7 +2466,7 @@ func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(want))
 		defer cancel()
 		in := map[string]string{}
-		h := mergeSLOTTFTIntoHeaders(in, ctx)
+		h := mergeFlowControlHeaders(in, ctx, priorityDisabled)
 		got, err := strconv.ParseInt(in[sloTTFTMSHeader], 10, 64)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -2486,6 +2479,54 @@ func TestMergeSLOTTFTIntoHeaders(t *testing.T) {
 		}
 		if h[sloTTFTMSHeader] != in[sloTTFTMSHeader] {
 			t.Fatalf("returned map header %q != in-place %q", h[sloTTFTMSHeader], in[sloTTFTMSHeader])
+		}
+	})
+
+	t.Run("priority header sent when enabled", func(t *testing.T) {
+		h := mergeFlowControlHeaders(nil, context.Background(), 0)
+		if h[priorityHeader] != "0" {
+			t.Fatalf("x-priority = %q, want %q", h[priorityHeader], "0")
+		}
+		if _, ok := h[sloTTFTMSHeader]; ok {
+			t.Fatalf("unexpected %s without deadline", sloTTFTMSHeader)
+		}
+	})
+
+	t.Run("priority header with custom value", func(t *testing.T) {
+		h := mergeFlowControlHeaders(nil, context.Background(), 50)
+		if h[priorityHeader] != "50" {
+			t.Fatalf("x-priority = %q, want %q", h[priorityHeader], "50")
+		}
+	})
+
+	t.Run("priority header not sent when disabled", func(t *testing.T) {
+		h := mergeFlowControlHeaders(nil, context.Background(), priorityDisabled)
+		if h != nil {
+			t.Fatalf("expected nil headers when priority disabled and no deadline, got %v", h)
+		}
+	})
+
+	t.Run("both SLO and priority headers", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
+		defer cancel()
+		h := mergeFlowControlHeaders(nil, ctx, 0)
+		if _, ok := h[sloTTFTMSHeader]; !ok {
+			t.Fatal("missing x-slo-ttft-ms header")
+		}
+		if h[priorityHeader] != "0" {
+			t.Fatalf("x-priority = %q, want %q", h[priorityHeader], "0")
+		}
+	})
+
+	t.Run("priority only with expired deadline", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		h := mergeFlowControlHeaders(nil, ctx, 10)
+		if h[priorityHeader] != "10" {
+			t.Fatalf("x-priority = %q, want %q", h[priorityHeader], "10")
+		}
+		if _, ok := h[sloTTFTMSHeader]; ok {
+			t.Fatalf("unexpected %s with expired deadline", sloTTFTMSHeader)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Add configurable `inference_priority` field to processor config (default `-1` = disabled) that sends an `x-priority` header on inference requests for GIE flow control band assignment.
- Consolidate flow control header logic by renaming `mergeSLOTTFTIntoHeaders` → `mergeFlowControlHeaders`, handling both `x-slo-ttft-ms` and `x-priority` in one place.
- Add Helm values, configmap template rendering, and Helm unit tests for the new field.

Closes #301

## Test plan

- [x] Unit tests for `mergeFlowControlHeaders` cover: priority enabled (0, 50), disabled (-1), combined with SLO header, combined with expired deadline.
- [x] Helm unit tests verify default `-1` and custom `0` rendering in processor configmap.
- [x] `go build ./...` passes.
- [x] `go test ./internal/processor/...` passes.
- [x] `make test-helm` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)