### PR TITLE
fix: omit expires_at when output has no expiration

### DIFF
--- a/internal/apiserver/file/file_handler.go
+++ b/internal/apiserver/file/file_handler.go
@@ -360,11 +360,15 @@ func (c *FileAPIHandler) CreateFile(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// Construct the FileObject domain object
+	var expiresAtPtr *int64
+	if expiresAt > 0 {
+		expiresAtPtr = &expiresAt
+	}
 	fileObj := openai.FileObject{
 		ID:        fileID,
 		Bytes:     fileMeta.Size,
 		CreatedAt: createdAt,
-		ExpiresAt: &expiresAt,
+		ExpiresAt: expiresAtPtr,
 		Filename:  origName,
 		Object:    "file",
 		Purpose:   purpose,

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -229,12 +229,16 @@ func (p *Processor) storeFileRecord(
 	now := time.Now().Unix()
 
 	expiresAt := p.resolveOutputExpiration(now, batchTags)
+	var expiresAtPtr *int64
+	if expiresAt > 0 {
+		expiresAtPtr = &expiresAt
+	}
 
 	fileObj := &openai.FileObject{
 		ID:        fileID,
 		Bytes:     size,
 		CreatedAt: now,
-		ExpiresAt: &expiresAt,
+		ExpiresAt: expiresAtPtr,
 		Filename:  fileName,
 		Object:    "file",
 		Purpose:   openai.FileObjectPurposeBatchOutput,

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -224,6 +224,33 @@ func TestStoreOutputFileRecord_Success(t *testing.T) {
 	}
 }
 
+func TestStoreFileRecord_NoExpiration_NilExpiresAt(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.DefaultOutputExpirationSeconds = 0
+	fileDB := newMockFileDBClient()
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		FileDB: fileDB,
+	})
+
+	ctx := testLoggerCtx(t)
+	err := p.storeFileRecord(ctx, "file_no_exp", "output.jsonl", "tenant-1", 1024, nil)
+	if err != nil {
+		t.Fatalf("storeFileRecord: %v", err)
+	}
+
+	items, _, _, err := fileDB.DBGet(ctx, &db.FileQuery{BaseQuery: db.BaseQuery{IDs: []string{"file_no_exp"}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	fileObj, err := converter.DBItemToFile(items[0])
+	if err != nil {
+		t.Fatalf("DBItemToFile: %v", err)
+	}
+	if fileObj.ExpiresAt != nil {
+		t.Fatalf("ExpiresAt = %v, want nil when resolveOutputExpiration returns 0", fileObj.ExpiresAt)
+	}
+}
+
 func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	cfg := config.NewConfig()


### PR DESCRIPTION
## Why is this PR needed?

OpenAI-compatible `FileObject` uses `expires_at` as an optional Unix timestamp. When there is no expiration policy, the field should be omitted (`null` in JSON), not set to `0`. Previously we always set `ExpiresAt: &expiresAt`, so when `resolveOutputExpiration` (or equivalent) returned `0`, clients and reviewers could interpret that as “expires at epoch” instead of “no expiry”.

## What does this PR do?

- **Processor (`storeFileRecord`):** After resolving output expiration, set `ExpiresAt` only when `expiresAt > 0`; otherwise leave it `nil`.
- **API server (`CreateFile`):** Same pattern when building the `FileObject` returned to the client—defensive alignment with “no expiration ⇒ nil”. (this is defensive as it won't be 0 in any cases for now)
- **Tests:** Add `TestStoreFileRecord_NoExpiration_NilExpiresAt` with `DefaultOutputExpirationSeconds = 0` and assert `ExpiresAt` is `nil` after round-trip through the DB converter.

## How was this tested?

- [x] Unit tests added/updated/verified (`go test` on finalizer/worker package covering the new test)
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Fixes #..., Related to CodeRabbit release review — expires_at semantics -->