### PR TITLE
docs(demo): note htpass-secret delete when changing MaaS test users

### DIFF
--- a/examples/deploy-demo/README.md
+++ b/examples/deploy-demo/README.md
@@ -104,6 +104,7 @@ bash examples/deploy-demo/deploy-maas.sh test
 bash examples/deploy-demo/deploy-maas.sh uninstall
 ```
 
+If you change MaaS test user/password env vars and run `install` again on the **same** cluster, delete the OAuth htpasswd secret first so it is recreated: `oc delete secret htpass-secret -n openshift-config`.
 
 ## Installation Modes
 

--- a/examples/deploy-demo/deploy-maas.sh
+++ b/examples/deploy-demo/deploy-maas.sh
@@ -445,6 +445,10 @@ EOF
 }
 
 # ── Create MaaS Test User ───────────────────────────────────────────────────
+#
+# Demo-only: if you change MAAS_* user/password env vars and re-run install on the
+# same cluster, delete htpass-secret first or OAuth may keep stale credentials:
+#   oc delete secret htpass-secret -n openshift-config
 
 create_maas_test_user() {
     step "Creating MaaS test users..."


### PR DESCRIPTION
## Why is this PR needed?

`deploy-maas.sh` only recreates the OpenShift OAuth `htpass-secret` when the primary test user does not yet exist. If someone changes `MAAS_*` user or password environment variables and runs `install` again on the **same** cluster, the old secret can remain and OAuth stays out of sync with the intended credentials.

## What does this PR do?

- Adds a short note in `examples/deploy-demo/README.md` under the MaaS demo usage.
- Adds a matching comment block above `create_maas_test_user` in `deploy-maas.sh`.

Both point operators to delete `openshift-config/htpass-secret` before re-running install when test user env vars change:

`oc delete secret htpass-secret -n openshift-config`

## How was this tested?

- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (documentation / script comment only)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- e.g. Fixes #NNN -->