### PR TITLE
fix(processor): reject nil task in Poller.enqueueOne

### DIFF
--- a/internal/processor/worker/poller.go
+++ b/internal/processor/worker/poller.go
@@ -68,6 +68,9 @@ func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
 }
 
 func (p *Poller) enqueueOne(ctx context.Context, task *db.BatchJobPriority) error {
+	if task == nil {
+		return fmt.Errorf("cannot enqueue nil batch job task")
+	}
 	logger := logr.FromContextOrDiscard(ctx)
 	err := p.pq.PQEnqueue(ctx, task)
 	if err != nil {

--- a/internal/processor/worker/poller.go
+++ b/internal/processor/worker/poller.go
@@ -68,10 +68,12 @@ func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
 }
 
 func (p *Poller) enqueueOne(ctx context.Context, task *db.BatchJobPriority) error {
-	if task == nil {
-		return fmt.Errorf("cannot enqueue nil batch job task")
-	}
 	logger := logr.FromContextOrDiscard(ctx)
+	if task == nil {
+		err := fmt.Errorf("cannot enqueue nil batch job task")
+		logger.Error(err, "CRITICAL: Failed to enqueue a job")
+		return err
+	}
 	err := p.pq.PQEnqueue(ctx, task)
 	if err != nil {
 		logger.Error(err, "CRITICAL: Failed to enqueue a job")

--- a/internal/processor/worker/poller_test.go
+++ b/internal/processor/worker/poller_test.go
@@ -170,6 +170,24 @@ func TestPoller_DequeueOne_ReturnsFirstTask(t *testing.T) {
 	}
 }
 
+func TestPoller_EnqueueOne_NilTask_ReturnsErrorWithoutCallingPQ(t *testing.T) {
+	ctx := context.Background()
+	pq := &pqSpy{inner: mockdb.NewMockBatchPriorityQueueClient()}
+	dbClient := mockdb.NewMockDBClient(
+		func(b *db.BatchItem) string { return b.ID },
+		func(q *db.BatchQuery) *db.BaseQuery { return &q.BaseQuery },
+	)
+	p := NewPoller(pq, dbClient)
+
+	err := p.enqueueOne(ctx, nil)
+	if err == nil {
+		t.Fatal("enqueueOne(nil) err=nil, want error")
+	}
+	if pq.enqueueCalled != 0 {
+		t.Fatalf("PQEnqueue called=%d, want 0", pq.enqueueCalled)
+	}
+}
+
 func TestPoller_FetchJobItem_DBError_ReturnsErrorWithoutEnqueue(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Why is this PR needed?

`Poller.enqueueOne` forwarded the task pointer to `PQEnqueue` without a nil check. The Redis implementation already rejects nil with an error, but the mock queue client dereferences the task and can panic. A nil task is not expected from current call sites (the polling loop skips nil after dequeue), but validating at the poller boundary makes the contract explicit and keeps adapter behavior consistent.

## What does this PR do?

- Return `fmt.Errorf("cannot enqueue nil batch job task")` from `enqueueOne` when `task` is nil, before calling the queue client.
- Add `TestPoller_EnqueueOne_NilTask_ReturnsErrorWithoutCallingPQ` to assert an error is returned and `PQEnqueue` is not invoked.

## How was this tested?

- [x] Unit tests added/updated/verified (`go test ./internal/processor/worker/... -run TestPoller_`)
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- e.g. CodeRabbit / internal review — nil guard on enqueue -->