### PR TITLE
fix(apiserver): align dev config tenant header with chart default

### DIFF
--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -14,7 +14,7 @@ port: "8000"
 
 # Input headers for special processing (key: logical name, value: HTTP header name)
 input_headers:
-  tenant: "X-MaaS-User"
+  tenant: "X-MaaS-Username"
 
 # HTTP server timeout configurations (in seconds)
 # These values should accommodate large file uploads and batch operations


### PR DESCRIPTION
## Why is this PR needed?

`cmd/apiserver/config.yaml` used `X-MaaS-User` for `input_headers.tenant`, while the Go default (`DefaultTenantHeader`), Helm `values.yaml`, MaaS AuthPolicy examples, e2e defaults, and POC docs all use `X-MaaS-Username`. Developers running the API server with the shipped local config could send or expect a different tenant header than cluster deployments, making local vs Kubernetes behavior diverge.

## What does this PR do?

- Sets `input_headers.tenant` to `X-MaaS-Username` in `cmd/apiserver/config.yaml` so local dev matches charted defaults and MaaS integration docs.

## How was this tested?

- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (YAML-only change; behavior matches existing `DefaultTenantHeader` / chart)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- CodeRabbit — tenant header alignment -->