### PR TITLE
fix(demo): scope uninstall for shared clusters (#309)

### DIFF
--- a/examples/deploy-demo/README.md
+++ b/examples/deploy-demo/README.md
@@ -2,6 +2,22 @@
 
 One-click deployment scripts for batch-gateway on different platforms. Each script supports `install`, `test`, and `uninstall` commands.
 
+## Safety: shared clusters and `uninstall`
+
+**Default `uninstall` (no env var) is OK on many shared clusters** if you only want to drop this demo’s batch-gateway footprint: it removes Helm releases and CRs in the batch namespace, named routes/policies, the **single** Gateway named `GATEWAY_NAME`, demo RBAC patches, and demo test users (MaaS/OpenShift). It does **not** remove MaaS/ODH, Kuadrant, Istio, cert-manager, operators, or cluster-wide CRDs—so other teams’ platform pieces stay. Still skim the list below before you run it in production.
+
+**Do not use `UNINSTALL_ALL=1` on shared production or multi-team clusters** — that mode tears down operators and platform components others may depend on.
+
+**Full teardown** (throwaway / dedicated demo cluster only) — prefix the command with `UNINSTALL_ALL=1`:
+
+```bash
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-k8s.sh uninstall
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-rhoai.sh uninstall
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-maas.sh uninstall
+```
+
+Use that only on **ephemeral or dedicated** demo clusters. See [issue #309](https://github.com/opendatahub-io/batch-gateway/issues/309) for background.
+
 ## 1) Overview
 
 | Script | Cluster | Description |
@@ -41,6 +57,7 @@ One-click deployment scripts for batch-gateway on different platforms. Each scri
 bash examples/deploy-demo/deploy-k8s.sh install
 bash examples/deploy-demo/deploy-k8s.sh test
 bash examples/deploy-demo/deploy-k8s.sh uninstall
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-k8s.sh uninstall   # optional: remove Kuadrant/Istio/cert-manager too
 ```
 
 
@@ -73,6 +90,7 @@ bash examples/deploy-demo/deploy-k8s.sh uninstall
 bash examples/deploy-demo/deploy-rhoai.sh install
 bash examples/deploy-demo/deploy-rhoai.sh test
 bash examples/deploy-demo/deploy-rhoai.sh uninstall
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-rhoai.sh uninstall   # optional: remove RHOAI operators, Kuadrant, cert-manager, etc.
 ```
 
 
@@ -102,6 +120,9 @@ bash examples/deploy-demo/deploy-rhoai.sh uninstall
 bash examples/deploy-demo/deploy-maas.sh install
 bash examples/deploy-demo/deploy-maas.sh test
 bash examples/deploy-demo/deploy-maas.sh uninstall
+
+# Optional — ephemeral/demo clusters only: MaaS cleanup + cert-manager/LWS (legacy full teardown).
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-maas.sh uninstall
 ```
 
 If you change MaaS test user/password env vars and run `install` again on the **same** cluster, delete the OAuth htpasswd secret first so it is recreated: `oc delete secret htpass-secret -n openshift-config`.

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -25,6 +25,16 @@ banner() {
 
 TLS_ISSUER_NAME="${TLS_ISSUER_NAME:-selfsigned-issuer}"
 
+# Demo uninstall safety: default uninstall removes batch-gateway-scoped
+# resources and the named Gateway only. Set UNINSTALL_ALL=1 to also tear down Kuadrant,
+# Istio, cert-manager, operators, cluster CRDs, and other shared platform pieces.
+is_demo_uninstall_all() {
+    case "${UNINSTALL_ALL:-0}" in
+        1|true|yes|TRUE|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Batch Gateway configuration
 BATCH_NAMESPACE="${BATCH_NAMESPACE:-batch-api}"
 BATCH_HELM_RELEASE="${BATCH_HELM_RELEASE:-batch-gateway}"

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -647,47 +647,54 @@ cmd_uninstall() {
     kubectl delete pvc "${BATCH_FILES_PVC_NAME}" -n "${BATCH_NAMESPACE}" 2>/dev/null || true
 
     step "Removing batch Gateway (${GATEWAY_NAMESPACE})..."
-    timeout_delete 30s gateway --all -n "${GATEWAY_NAMESPACE}" || true
+    timeout_delete 30s gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" || true
     kubectl delete destinationrule "${BATCH_HELM_RELEASE}-backend-tls" -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
 
-    step "Removing Kuadrant..."
-    timeout_delete 30s kuadrant kuadrant -n "${KUADRANT_NAMESPACE}" || true
-    helm uninstall "${KUADRANT_RELEASE}" -n "${KUADRANT_NAMESPACE}" --timeout 60s 2>/dev/null || true
-    force_delete_crds 'kuadrant|authorino|limitador'
-    force_delete_namespace "${KUADRANT_NAMESPACE}"
+    if is_demo_uninstall_all; then
+        step "Removing Kuadrant..."
+        timeout_delete 30s kuadrant kuadrant -n "${KUADRANT_NAMESPACE}" || true
+        helm uninstall "${KUADRANT_RELEASE}" -n "${KUADRANT_NAMESPACE}" --timeout 60s 2>/dev/null || true
+        force_delete_crds 'kuadrant|authorino|limitador'
+        force_delete_namespace "${KUADRANT_NAMESPACE}"
 
-    step "Removing llm-d stack (${LLM_NAMESPACE})..."
-    uninstall_llmd
+        step "Removing llm-d stack (${LLM_NAMESPACE})..."
+        uninstall_llmd
 
-    step "Uninstalling Istio..."
-    local istio_helmfile="${LLMD_GIT_DIR}/guides/prereq/gateway-provider/istio.helmfile.yaml"
-    if [ -f "${istio_helmfile}" ]; then
-        helmfile destroy -f "${istio_helmfile}" 2>/dev/null \
-            || warn "helmfile destroy failed"
+        step "Uninstalling Istio..."
+        local istio_helmfile="${LLMD_GIT_DIR}/guides/prereq/gateway-provider/istio.helmfile.yaml"
+        if [ -f "${istio_helmfile}" ]; then
+            helmfile destroy -f "${istio_helmfile}" 2>/dev/null \
+                || warn "helmfile destroy failed"
+        fi
+        helm uninstall istiod -n istio-system --timeout 60s 2>/dev/null || true
+        helm uninstall istio-base -n istio-system --timeout 60s 2>/dev/null || true
+        force_delete_crds 'istio\.io|sail'
+        force_delete_namespace "istio-system"
+
+        step "Removing CRDs..."
+        local crd_script="${LLMD_GIT_DIR}/guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh"
+        [ -f "${crd_script}" ] && bash "${crd_script}" delete 2>/dev/null || true
+
+        step "Cleaning up cache..."
+        rm -rf "${LLMD_GIT_DIR}"
+
+        step "Removing TLS resources..."
+        kubectl delete clusterissuer "${TLS_ISSUER_NAME}" 2>/dev/null || true
+
+        step "Uninstalling cert-manager..."
+        helm uninstall cert-manager -n cert-manager --timeout 60s 2>/dev/null || true
+        force_delete_crds 'cert-manager'
+        force_delete_namespace "cert-manager"
+
+        for ns in "${BATCH_NAMESPACE}" "${LLM_NAMESPACE}" "${GATEWAY_NAMESPACE}"; do
+            [ "${ns}" != "default" ] && force_delete_namespace "${ns}"
+        done
+    else
+        warn "Skipping Kuadrant, llm-d, Istio, cert-manager, CRD teardown, and deletes for '${LLM_NAMESPACE}' / '${GATEWAY_NAMESPACE}' (shared-cluster safety)."
+        warn "For full teardown on an ephemeral demo cluster only: UNINSTALL_ALL=1 $0 uninstall"
+        step "Removing batch namespace (${BATCH_NAMESPACE})..."
+        force_delete_namespace "${BATCH_NAMESPACE}"
     fi
-    helm uninstall istiod -n istio-system --timeout 60s 2>/dev/null || true
-    helm uninstall istio-base -n istio-system --timeout 60s 2>/dev/null || true
-    force_delete_crds 'istio\.io|sail'
-    force_delete_namespace "istio-system"
-
-    step "Removing CRDs..."
-    local crd_script="${LLMD_GIT_DIR}/guides/prereq/gateway-provider/install-gateway-provider-dependencies.sh"
-    [ -f "${crd_script}" ] && bash "${crd_script}" delete 2>/dev/null || true
-
-    step "Cleaning up cache..."
-    rm -rf "${LLMD_GIT_DIR}"
-
-    step "Removing TLS resources..."
-    kubectl delete clusterissuer "${TLS_ISSUER_NAME}" 2>/dev/null || true
-
-    step "Uninstalling cert-manager..."
-    helm uninstall cert-manager -n cert-manager --timeout 60s 2>/dev/null || true
-    force_delete_crds 'cert-manager'
-    force_delete_namespace "cert-manager"
-
-    for ns in "${BATCH_NAMESPACE}" "${LLM_NAMESPACE}" "${GATEWAY_NAMESPACE}"; do
-        [ "${ns}" != "default" ] && force_delete_namespace "${ns}"
-    done
 
     echo ""
     log "Uninstallation complete!"
@@ -705,7 +712,7 @@ usage() {
     echo "Commands:"
     echo "  install    Deploy llm-d stack + Kuadrant + batch-gateway"
     echo "  test       Run auth, batch lifecycle, and rate limit tests"
-    echo "  uninstall  Remove all components"
+    echo "  uninstall  Remove demo resources (use UNINSTALL_ALL=1 for full stack teardown)"
     echo "  help       Show this help"
     echo ""
     echo "Environment Variables:"
@@ -716,6 +723,7 @@ usage() {
     echo "  GATEWAY_LOCAL_PORT     Port-forward fallback port (default: 8080)"
     echo "  BATCH_DEV_VERSION      Batch gateway image tag / commit SHA (default: local)"
     echo "  BATCH_RELEASE_VERSION  Install released OCI chart (e.g. v1.0.0)"
+    echo "  UNINSTALL_ALL          Set to 1 to also remove Kuadrant/Istio/cert-manager and CRDs (ephemeral clusters only)"
     echo ""
     echo "Examples:"
     echo "  $0 install"

--- a/examples/deploy-demo/deploy-maas.sh
+++ b/examples/deploy-demo/deploy-maas.sh
@@ -631,10 +631,9 @@ cmd_uninstall() {
     kubectl delete namespace "${BATCH_NAMESPACE}" --timeout=60s 2>/dev/null || true
     log "Batch gateway uninstalled."
 
-    # RBAC patch and ClusterIssuer
+    # RBAC patch created by this demo (safe to remove; does not delete MaaS core).
     kubectl delete clusterrolebinding maas-api-extra 2>/dev/null || true
     kubectl delete clusterrole maas-api-extra 2>/dev/null || true
-    kubectl delete clusterissuer "${TLS_ISSUER_NAME}" 2>/dev/null || true
 
     # Test user
     step "Removing test users..."
@@ -645,42 +644,49 @@ cmd_uninstall() {
     oc delete user "${MAAS_UNAUTH_USER}" 2>/dev/null || true
     oc delete identity "htpasswd:${MAAS_UNAUTH_USER}" 2>/dev/null || true
 
-    # MaaS platform (reuse cleanup-odh.sh from MaaS repo)
-    step "Removing MaaS platform..."
-    local cleanup_script="${MAAS_DIR}/.github/hack/cleanup-odh.sh"
-    if [ -f "${cleanup_script}" ]; then
-        log "Using MaaS cleanup script: ${cleanup_script}"
-        bash "${cleanup_script}" --include-crds || warn "cleanup-odh.sh returned non-zero"
+    if is_demo_uninstall_all; then
+        kubectl delete clusterissuer "${TLS_ISSUER_NAME}" 2>/dev/null || true
+
+        # MaaS platform (reuse cleanup-odh.sh from MaaS repo)
+        step "Removing MaaS platform..."
+        local cleanup_script="${MAAS_DIR}/.github/hack/cleanup-odh.sh"
+        if [ -f "${cleanup_script}" ]; then
+            log "Using MaaS cleanup script: ${cleanup_script}"
+            bash "${cleanup_script}" --include-crds || warn "cleanup-odh.sh returned non-zero"
+        else
+            warn "MaaS cleanup script not found at ${cleanup_script}, cleaning up manually..."
+            kubectl delete datasciencecluster --all -A --timeout=180s 2>/dev/null || true
+            kubectl delete dscinitialization --all -A --timeout=180s 2>/dev/null || true
+            kubectl delete namespace "${MAAS_NAMESPACE}" --timeout=180s 2>/dev/null || true
+            kubectl delete namespace "${MAAS_POLICY_NAMESPACE}" --timeout=60s 2>/dev/null || true
+            kubectl delete namespace kuadrant-system --timeout=60s 2>/dev/null || true
+            kubectl delete gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
+        fi
+
+        # Operators not covered by cleanup-odh.sh
+        step "Removing cert-manager and LWS operators..."
+        local cm_csv
+        cm_csv=$(kubectl get csv -n cert-manager-operator -o name 2>/dev/null | grep cert-manager || true)
+        if [ -n "${cm_csv}" ]; then
+            kubectl delete subscription openshift-cert-manager-operator -n cert-manager-operator 2>/dev/null || true
+            kubectl delete "${cm_csv}" -n cert-manager-operator 2>/dev/null || true
+        fi
+        kubectl delete namespace cert-manager-operator --timeout=60s 2>/dev/null || true
+
+        local lws_csv
+        lws_csv=$(kubectl get csv -n openshift-lws-operator -o name 2>/dev/null | grep leader-worker || true)
+        if [ -n "${lws_csv}" ]; then
+            kubectl delete subscription leader-worker-set -n openshift-lws-operator 2>/dev/null || true
+            kubectl delete "${lws_csv}" -n openshift-lws-operator 2>/dev/null || true
+        fi
+        kubectl delete namespace openshift-lws-operator --timeout=60s 2>/dev/null || true
     else
-        warn "MaaS cleanup script not found at ${cleanup_script}, cleaning up manually..."
-        kubectl delete datasciencecluster --all -A --timeout=180s 2>/dev/null || true
-        kubectl delete dscinitialization --all -A --timeout=180s 2>/dev/null || true
-        kubectl delete namespace "${MAAS_NAMESPACE}" --timeout=180s 2>/dev/null || true
-        kubectl delete namespace "${MAAS_POLICY_NAMESPACE}" --timeout=60s 2>/dev/null || true
-        kubectl delete namespace kuadrant-system --timeout=60s 2>/dev/null || true
-        kubectl delete gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
+        warn "Skipping ClusterIssuer, MaaS/ODH cleanup, Kuadrant namespaces, and cert-manager/LWS operators (shared-cluster safety)."
+        warn "For full teardown on an ephemeral cluster only: UNINSTALL_ALL=1 $0 uninstall"
     fi
-
-    # Operators not covered by cleanup-odh.sh
-    step "Removing cert-manager and LWS operators..."
-    local cm_csv
-    cm_csv=$(kubectl get csv -n cert-manager-operator -o name 2>/dev/null | grep cert-manager || true)
-    if [ -n "${cm_csv}" ]; then
-        kubectl delete subscription openshift-cert-manager-operator -n cert-manager-operator 2>/dev/null || true
-        kubectl delete "${cm_csv}" -n cert-manager-operator 2>/dev/null || true
-    fi
-    kubectl delete namespace cert-manager-operator --timeout=60s 2>/dev/null || true
-
-    local lws_csv
-    lws_csv=$(kubectl get csv -n openshift-lws-operator -o name 2>/dev/null | grep leader-worker || true)
-    if [ -n "${lws_csv}" ]; then
-        kubectl delete subscription leader-worker-set -n openshift-lws-operator 2>/dev/null || true
-        kubectl delete "${lws_csv}" -n openshift-lws-operator 2>/dev/null || true
-    fi
-    kubectl delete namespace openshift-lws-operator --timeout=60s 2>/dev/null || true
 
     echo ""
-    log "Uninstallation complete (batch-gateway + MaaS)."
+    log "Uninstallation complete (batch-gateway + optional MaaS teardown)."
 
     set -e
 }
@@ -693,13 +699,14 @@ usage() {
     echo "Commands:"
     echo "  install    Install MaaS platform + sample model + batch-gateway"
     echo "  test       Run integration tests (MaaS auth + batch lifecycle)"
-    echo "  uninstall  Remove everything (batch-gateway + MaaS + operators)"
+    echo "  uninstall  Remove batch-gateway + demo RBAC/users (use UNINSTALL_ALL=1 for MaaS/operators)"
     echo "  help       Show this help message"
     echo ""
     echo "Environment Variables:"
     echo "  MAAS_REF              MaaS git ref (default: main)"
     echo "  MAAS_TEST_USER        Test username (default: testuser)"
     echo "  MAAS_TEST_GROUP       Test user group (default: tier-free-users)"
+    echo "  UNINSTALL_ALL            Set to 1 to run MaaS cleanup script / remove operators (ephemeral clusters only)"
     exit "${1:-0}"
 }
 

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -825,68 +825,75 @@ cmd_uninstall() {
     step "Removing TokenRateLimitPolicy..."
     kubectl delete tokenratelimitpolicy inference-token-limit -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
 
-    # LLMInferenceService
-    step "Removing LLMInferenceService..."
-    kubectl delete llminferenceservice --all -n "${LLM_NAMESPACE}" --timeout=180s 2>/dev/null || true
+    # Named Gateway only (never delete all Gateways in a shared ingress namespace).
+    step "Removing Gateway ${GATEWAY_NAME}..."
+    kubectl delete gateway "${GATEWAY_NAME}" -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
 
-    # DSC + DSCI
-    step "Removing DataScienceCluster and DSCInitialization..."
-    kubectl delete datasciencecluster --all --timeout=180s 2>/dev/null || true
-    kubectl delete dscinitializations --all --timeout=180s 2>/dev/null || true
+    if is_demo_uninstall_all; then
+        # LLMInferenceService
+        step "Removing LLMInferenceService..."
+        kubectl delete llminferenceservice --all -n "${LLM_NAMESPACE}" --timeout=180s 2>/dev/null || true
 
-    # RHOAI/ODH operator
-    local operator_name namespace
-    case "${OPERATOR_TYPE}" in
-        rhoai) operator_name="rhods-operator"; namespace="redhat-ods-operator" ;;
-        odh)   operator_name="opendatahub-operator"; namespace="opendatahub" ;;
-    esac
-    step "Removing ${OPERATOR_TYPE} operator..."
-    kubectl delete subscription.operators.coreos.com "${operator_name}" -n "${namespace}" 2>/dev/null || true
-    local csv
-    csv=$(kubectl get csv -n "${namespace}" --no-headers 2>/dev/null | grep "${operator_name}" | awk '{print $1}')
-    [ -n "${csv}" ] && kubectl delete csv "${csv}" -n "${namespace}" 2>/dev/null || true
+        # DSC + DSCI
+        step "Removing DataScienceCluster and DSCInitialization..."
+        kubectl delete datasciencecluster --all --timeout=180s 2>/dev/null || true
+        kubectl delete dscinitializations --all --timeout=180s 2>/dev/null || true
 
-    # Red Hat Connectivity Link (Kuadrant)
-    step "Removing Connectivity Link..."
-    kubectl delete kuadrant kuadrant -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
-    kubectl delete subscription.operators.coreos.com rhcl-operator -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
-    csv=$(kubectl get csv -n "${KUADRANT_NAMESPACE}" --no-headers 2>/dev/null | grep "rhcl-operator" | awk '{print $1}')
-    [ -n "${csv}" ] && kubectl delete csv "${csv}" -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
-    kubectl delete namespace "${KUADRANT_NAMESPACE}" --timeout=60s 2>/dev/null || true
-    kubectl get crd -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador' | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get clusterrole -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador|^clusterrole.*/dns-operator-' | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get clusterrolebinding -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador|^clusterrolebinding.*/dns-operator-' | xargs -r kubectl delete 2>/dev/null || true
+        # RHOAI/ODH operator
+        local operator_name namespace
+        case "${OPERATOR_TYPE}" in
+            rhoai) operator_name="rhods-operator"; namespace="redhat-ods-operator" ;;
+            odh)   operator_name="opendatahub-operator"; namespace="opendatahub" ;;
+        esac
+        step "Removing ${OPERATOR_TYPE} operator..."
+        kubectl delete subscription.operators.coreos.com "${operator_name}" -n "${namespace}" 2>/dev/null || true
+        local csv
+        csv=$(kubectl get csv -n "${namespace}" --no-headers 2>/dev/null | grep "${operator_name}" | awk '{print $1}')
+        [ -n "${csv}" ] && kubectl delete csv "${csv}" -n "${namespace}" 2>/dev/null || true
 
-    # Gateway
-    step "Removing Gateway..."
-    kubectl delete gateway ${GATEWAY_NAME} -n "${GATEWAY_NAMESPACE}" 2>/dev/null || true
-    kubectl delete gatewayclass openshift-default 2>/dev/null || true
+        # Red Hat Connectivity Link (Kuadrant)
+        step "Removing Connectivity Link..."
+        kubectl delete kuadrant kuadrant -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
+        kubectl delete subscription.operators.coreos.com rhcl-operator -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
+        csv=$(kubectl get csv -n "${KUADRANT_NAMESPACE}" --no-headers 2>/dev/null | grep "rhcl-operator" | awk '{print $1}')
+        [ -n "${csv}" ] && kubectl delete csv "${csv}" -n "${KUADRANT_NAMESPACE}" 2>/dev/null || true
+        kubectl delete namespace "${KUADRANT_NAMESPACE}" --timeout=60s 2>/dev/null || true
+        kubectl get crd -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador' | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get clusterrole -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador|^clusterrole.*/dns-operator-' | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get clusterrolebinding -o name 2>/dev/null | grep -E 'kuadrant|authorino|limitador|^clusterrolebinding.*/dns-operator-' | xargs -r kubectl delete 2>/dev/null || true
 
-    # LWS
-    step "Removing LWS operator..."
-    kubectl delete leaderworkersetoperator cluster -n openshift-lws-operator 2>/dev/null || true
-    kubectl delete subscription.operators.coreos.com leader-worker-set -n openshift-lws-operator 2>/dev/null || true
-    csv=$(kubectl get csv -n openshift-lws-operator --no-headers 2>/dev/null | grep "leader-worker" | awk '{print $1}')
-    [ -n "${csv}" ] && kubectl delete csv "${csv}" -n openshift-lws-operator 2>/dev/null || true
-    kubectl delete namespace openshift-lws-operator --timeout=60s 2>/dev/null || true
+        step "Removing GatewayClass openshift-default..."
+        kubectl delete gatewayclass openshift-default 2>/dev/null || true
 
-    # cert-manager (OLM operator lives in cert-manager-operator, workloads in cert-manager)
-    step "Removing cert-manager operator..."
-    kubectl delete subscription.operators.coreos.com openshift-cert-manager-operator -n cert-manager-operator 2>/dev/null || true
-    csv=$(kubectl get csv -n cert-manager-operator --no-headers 2>/dev/null | grep "cert-manager" | awk '{print $1}')
-    [ -n "${csv}" ] && kubectl delete csv "${csv}" -n cert-manager-operator 2>/dev/null || true
-    kubectl delete namespace cert-manager-operator --timeout=60s 2>/dev/null || true
-    kubectl delete namespace cert-manager --timeout=60s 2>/dev/null || true
-    kubectl get crd -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get clusterrole -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get clusterrolebinding -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get validatingwebhookconfiguration -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get mutatingwebhookconfiguration -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
-    kubectl get role -n kube-system -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete -n kube-system 2>/dev/null || true
-    kubectl get rolebinding -n kube-system -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete -n kube-system 2>/dev/null || true
+        # LWS
+        step "Removing LWS operator..."
+        kubectl delete leaderworkersetoperator cluster -n openshift-lws-operator 2>/dev/null || true
+        kubectl delete subscription.operators.coreos.com leader-worker-set -n openshift-lws-operator 2>/dev/null || true
+        csv=$(kubectl get csv -n openshift-lws-operator --no-headers 2>/dev/null | grep "leader-worker" | awk '{print $1}')
+        [ -n "${csv}" ] && kubectl delete csv "${csv}" -n openshift-lws-operator 2>/dev/null || true
+        kubectl delete namespace openshift-lws-operator --timeout=60s 2>/dev/null || true
 
-    # LLM namespace
-    force_delete_namespace "${LLM_NAMESPACE}"
+        # cert-manager (OLM operator lives in cert-manager-operator, workloads in cert-manager)
+        step "Removing cert-manager operator..."
+        kubectl delete subscription.operators.coreos.com openshift-cert-manager-operator -n cert-manager-operator 2>/dev/null || true
+        csv=$(kubectl get csv -n cert-manager-operator --no-headers 2>/dev/null | grep "cert-manager" | awk '{print $1}')
+        [ -n "${csv}" ] && kubectl delete csv "${csv}" -n cert-manager-operator 2>/dev/null || true
+        kubectl delete namespace cert-manager-operator --timeout=60s 2>/dev/null || true
+        kubectl delete namespace cert-manager --timeout=60s 2>/dev/null || true
+        kubectl get crd -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get clusterrole -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get clusterrolebinding -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get validatingwebhookconfiguration -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get mutatingwebhookconfiguration -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete 2>/dev/null || true
+        kubectl get role -n kube-system -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete -n kube-system 2>/dev/null || true
+        kubectl get rolebinding -n kube-system -o name 2>/dev/null | grep cert-manager | xargs -r kubectl delete -n kube-system 2>/dev/null || true
+
+        # LLM namespace
+        force_delete_namespace "${LLM_NAMESPACE}"
+    else
+        warn "Skipping LLMInferenceService, OpenShift AI operators, Kuadrant, GatewayClass, LWS, cert-manager, and '${LLM_NAMESPACE}' namespace delete (shared-cluster safety)."
+        warn "For full teardown on an ephemeral cluster only: UNINSTALL_ALL=1 $0 uninstall"
+    fi
 
     echo ""
     log "RHOAI platform + batch gateway uninstalled."
@@ -904,7 +911,7 @@ usage() {
     echo "Commands:"
     echo "  install    Install RHOAI platform, LLMInferenceService, and batch-gateway"
     echo "  test       Run inference + batch lifecycle tests"
-    echo "  uninstall  Remove all components"
+    echo "  uninstall  Remove demo resources (use UNINSTALL_ALL=1 for full platform teardown)"
     echo "  help       Show this help"
     echo ""
     echo "Environment Variables:"
@@ -916,6 +923,7 @@ usage() {
     echo "  BATCH_RELEASE_VERSION  Install released OCI chart (e.g. v1.0.0)"
     echo "  BATCH_DB_TYPE          Database: postgresql or redis (default: postgresql)"
     echo "  BATCH_STORAGE_TYPE     File storage: fs or s3 (default: s3)"
+    echo "  UNINSTALL_ALL            Set to 1 to remove RHOAI operators, Kuadrant, cert-manager, etc. (ephemeral clusters only)"
     exit "${1:-0}"
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Demo `uninstall` scripts removed more than this repo’s demo owns (e.g. all Gateways in an ingress namespace, cluster-wide CRD/operator teardown). On shared OpenShift/Kubernetes clusters that is a high-impact footgun ([#309](https://github.com/opendatahub-io/batch-gateway/issues/309)).

## What does this PR do?

- **Default `uninstall`:** Removes batch-gateway Helm releases and related CRs in the batch namespace, named routes/policies, the **single** Gateway named `GATEWAY_NAME`, and demo-only RBAC/users (MaaS path). Does **not** remove Kuadrant, Istio, cert-manager, operators, or broad CRD/namespace teardown.
- **`UNINSTALL_ALL=1`:** Opt-in to the previous “tear down the whole demo stack” behavior (ephemeral/dedicated clusters only).
- **`deploy-k8s.sh`:** Replace `gateway --all` with delete of `GATEWAY_NAME` only.
- **`deploy-rhoai.sh` / `deploy-maas.sh`:** Gate DSC, operators, Kuadrant CRD/role scraping, GatewayClass, cert-manager, LWS, and MaaS bulk cleanup behind `UNINSTALL_ALL=1`; keep named Gateway (and rhoai TokenRateLimitPolicy) in the default path where appropriate.
- **`common.sh`:** Add `is_demo_uninstall_all` helper; **`README.md`:** Document default vs full teardown and copy-paste examples.

## How was this tested?

- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (`bash -n` on modified scripts; logical review of uninstall branches)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #309