### PR TITLE
docs: clarify batch-route vs llm-route security boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The system is designed to facilitate efficient processing of batch workloads in 
 - **Kubernetes Native**: Helm charts with OpenShift compatibility.
 - **Observability**: Prometheus metrics and Open Telemetry integration.
 - **Health Checks**: Liveness and readiness probes for the system components.
-- **Security**: TLS support, non-root execution, capability dropping, read-only filesystem.
+- **Security**: TLS support, non-root execution, capability dropping, read-only filesystem. Gateway deployments: batch API admission and per-model inference authorization are enforced on separate routes; see **Security boundary** in the [Kubernetes](docs/guides/deploy-k8s.md#15-security-boundary-batch-route-vs-llm-route), [RHOAI](docs/guides/deploy-rhoai.md#15-security-boundary-batch-route-vs-llm-route), and [MaaS](docs/guides/deploy-maas.md#15-security-boundary-batch-route-vs-llm-route) deployment guides.
 
 ## Architecture
 

--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -94,6 +94,15 @@ HTTPRoute authorization behavior:
 - **LLM route**: SubjectAccessReview checks if user can `get inferencepools/<model-name>` (extracted from URL path) — unauthorized requests are rejected with **403**
 - **Batch route**: No authorization check — authorization is enforced by the LLM route when the processor forwards inference requests with the user's original token
 
+### 1.5 Security boundary: batch-route vs llm-route
+
+For security and operations readers: **admission on the batch API is not the same as authorization for inference.**
+
+- **batch-route** proves the caller has a valid Kubernetes token and applies batch-side **RateLimitPolicy**. Invalid or missing credentials are rejected with **401**; excess batch API traffic is rejected with **429**. It does **not** evaluate whether the caller may use a specific model.
+- **llm-route** runs **authentication and authorization** (SubjectAccessReview on `inferencepools` as above) on each inference request the processor sends through the gateway. A user can create a batch job and still see **per-request failures** (often surfaced as failed lines or job errors) when the llm-route returns **403** — this is **by design**, not a bypass of model access control.
+
+Configure **`passThroughHeaders: {Authorization}`** so the processor forwards the end user’s bearer token on inference calls. Without that, the gateway cannot attribute inference traffic to the original caller and model-level checks cannot run as intended.
+
 ## 2. Prerequisites
 
 - Kubernetes cluster (or OpenShift 4.x)

--- a/docs/guides/deploy-maas.md
+++ b/docs/guides/deploy-maas.md
@@ -84,6 +84,15 @@ HTTPRoute authorization behavior:
 - **LLM route**: Group-based authorization via MaaSAuthPolicy (maas-controller auto-generates Kuadrant AuthPolicy) — users not in an authorized group are rejected with **403**
 - **Batch route**: No authorization check — authorization is enforced by the LLM route when the processor forwards inference requests with the user's original API key
 
+### 1.5 Security boundary: batch-route vs llm-route
+
+For security and operations readers: **admission on the batch API is not the same as authorization for inference.**
+
+- **batch-route** validates the MaaS API key (same HTTP callback as other MaaS routes) and applies batch-side **RateLimitPolicy**. Invalid or missing keys are rejected with **401**; excess batch API traffic is rejected with **429**. It does **not** prove the caller is in a group allowed to use a given model (**MaaSAuthPolicy**).
+- **llm-route** validates the key **and** enforces group-based model access (auto-generated policies from MaaS). A user can create a batch job and still see **per-request failures** (often surfaced as failed lines or job errors) when the llm-route returns **403** — this is **by design**, not a bypass of model access control.
+
+Configure **`passThroughHeaders: {Authorization, X-MaaS-Subscription}`** (or the subset your deployment needs) so the processor forwards the end user’s credentials on inference calls. Without that, the gateway cannot apply the same model-route checks to batch-driven inference that direct clients receive.
+
 ## 2. Prerequisites
 
 - OpenShift cluster (self-managed, not ROSA/HyperShift)

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -92,6 +92,15 @@ HTTPRoute authorization behavior:
 - **LLM route**: SubjectAccessReview checks if user can `get llminferenceservices/<name>` — unauthorized requests are rejected with **403**
 - **Batch route**: No authorization check — authorization is enforced by the LLM route when the processor forwards inference requests with the user's original token
 
+### 1.5 Security boundary: batch-route vs llm-route
+
+For security and operations readers: **admission on the batch API is not the same as authorization for inference.**
+
+- **batch-route** proves the caller has a valid Kubernetes token and applies batch-side **RateLimitPolicy**. Invalid or missing credentials are rejected with **401**; excess batch API traffic is rejected with **429**. It does **not** evaluate whether the caller may use a specific `LLMInferenceService`.
+- **llm-route** runs **authentication and authorization** (SubjectAccessReview on `llminferenceservices` as above) on each inference request the processor sends through the gateway. A user can create a batch job and still see **per-request failures** (often surfaced as failed lines or job errors) when the llm-route returns **403** — this is **by design**, not a bypass of model access control.
+
+Configure **`passThroughHeaders: {Authorization}`** so the processor forwards the end user’s bearer token on inference calls. Without that, the gateway cannot attribute inference traffic to the original caller and model-level checks cannot run as intended.
+
 ## 2. Prerequisites
 - OpenShift cluster 4.19.9 or later.
 - OpenShift Service Mesh v2 is not installed in the cluster.

--- a/docs/guides/kuadrant-integration.md
+++ b/docs/guides/kuadrant-integration.md
@@ -20,7 +20,11 @@ This doc demonstrates how to integrate batch inference with Kuadrant, GAIE, and 
    - Forwards to `EPP` service
 5. EPP picks the best vLLM pod, vLLM processes inference and returns response
 
-### 1.2 Component Versions
+### 1.2 Security boundary: batch-route vs llm-route
+
+**Batch API admission is not model inference authorization.** The **batch-route** proves identity (API key or token, depending on your AuthPolicy) and applies request-count limits; it does not run the model-level checks described for **llm-route** in this document (OPA Rego or SubjectAccessReview). Expect **401** for failed authentication, **429** for batch-route rate limits, and **403** when llm-route authorization denies access to a model. A caller can submit a batch and still see failed inference lines or job errors when llm-route rejects requests — **by design**. Configure the batch processor to **forward the same credentials** the end user used (for example via `passThroughHeaders` on batch-gateway) so the gateway can enforce the llm-route boundary on processor-initiated traffic.
+
+### 1.3 Component Versions
 
 | Component | Version | Description |
 |-----------|---------|-------------|
@@ -30,7 +34,7 @@ This doc demonstrates how to integrate batch inference with Kuadrant, GAIE, and 
 | GAIE | v1.3.1 | Gateway API Inference Extension (InferencePool + EPP) |
 | cert-manager | v1.15.3 | TLS certificate management (required by Kuadrant) |
 
-### 1.3 Namespace Layout
+### 1.4 Namespace Layout
 
 | Namespace | Purpose |
 |-----------|---------|

--- a/docs/guides/maas-integration.md
+++ b/docs/guides/maas-integration.md
@@ -278,11 +278,11 @@ EOF
 
 ## 5. Create Policies
 
-### Security boundary: batch-route vs LLM (model) route
+### 5.1 Security boundary: batch-route vs LLM (model) route
 
 **Admission on the batch HTTPRoute is not authorization for model inference.** The batch-route policies below validate the MaaS API key and rate-limit batch API usage (**401** / **429** as configured). The auto-generated **llm-route** policies (from MaaSModelRef / MaaSAuthPolicy) perform **model access** checks; a valid batch submission can still yield inference **403** or failed batch lines when the user lacks group access — by design. Use **`passThroughHeaders`** on batch-gateway so the processor forwards **`Authorization`** (and **`X-MaaS-Subscription`** if required) on processor-initiated inference calls; otherwise the gateway cannot enforce the same boundary as for direct model clients.
 
-### 5.1 Batch AuthPolicy
+### 5.2 Batch AuthPolicy
 
 The MaaS gateway has a default-deny AuthPolicy. Create a per-route AuthPolicy for the batch-route that validates MaaS API keys via the same HTTP callback that MaaS uses for model routes:
 
@@ -360,7 +360,7 @@ EOF
 
 This AuthPolicy validates API keys by calling the MaaS API's `/internal/v1/api-keys/validate` endpoint — the same mechanism MaaS uses for model inference routes. Authorino sends the API key to maas-api, which checks the hash against PostgreSQL and returns `{valid, username, groups, keyId}`.
 
-### 5.2 Batch RateLimitPolicy
+### 5.3 Batch RateLimitPolicy
 
 Request-count-based rate limiting on the batch-route, keyed per user:
 
@@ -386,7 +386,7 @@ spec:
 EOF
 ```
 
-### 5.3 MaaS Model Policies
+### 5.4 MaaS Model Policies
 
 Register the model in MaaS and configure token-based rate limiting on the model inference route. The MaaS controller automatically generates a Kuadrant `AuthPolicy` (API key validation + group membership) and `TokenRateLimitPolicy` from these CRs.
 

--- a/docs/guides/maas-integration.md
+++ b/docs/guides/maas-integration.md
@@ -278,6 +278,10 @@ EOF
 
 ## 5. Create Policies
 
+### Security boundary: batch-route vs LLM (model) route
+
+**Admission on the batch HTTPRoute is not authorization for model inference.** The batch-route policies below validate the MaaS API key and rate-limit batch API usage (**401** / **429** as configured). The auto-generated **llm-route** policies (from MaaSModelRef / MaaSAuthPolicy) perform **model access** checks; a valid batch submission can still yield inference **403** or failed batch lines when the user lacks group access — by design. Use **`passThroughHeaders`** on batch-gateway so the processor forwards **`Authorization`** (and **`X-MaaS-Subscription`** if required) on processor-initiated inference calls; otherwise the gateway cannot enforce the same boundary as for direct model clients.
+
 ### 5.1 Batch AuthPolicy
 
 The MaaS gateway has a default-deny AuthPolicy. Create a per-route AuthPolicy for the batch-route that validates MaaS API keys via the same HTTP callback that MaaS uses for model routes:


### PR DESCRIPTION
## Why is this PR needed?

Security and ops readers need an explicit statement that **batch API admission** (who may call `/v1/batches` / `/v1/files`) is **not** the same as **per-model inference authorization** on the LLM HTTPRoute. Without this, it is easy to assume that “passing the batch gateway” implies access to every model the processor might call. Issue #308 asks to document that boundary, expected **401 / 403 / 429** roles, and why **`passThroughHeaders`** matters for processor-initiated inference.

## What does this PR do?

- Adds a **“Security boundary: batch-route vs llm-route”** subsection to:
  - `docs/guides/deploy-k8s.md`
  - `docs/guides/deploy-rhoai.md`
  - `docs/guides/deploy-maas.md`
- Adds a matching **Security boundary** note at the start of the policies section in `docs/guides/maas-integration.md`.
- Adds the same idea to `docs/guides/kuadrant-integration.md` (same two-route pattern; section numbering adjusted).
- Extends the README **Security** bullet with one sentence and links to the **Security boundary** anchors in the Kubernetes, RHOAI, and MaaS deployment guides.

No AuthPolicy, Helm, or processor behavior changes—documentation only.

## How was this tested?

- [ ] Unit tests added/updated/verified — N/A (docs only)
- [ ] Integration/e2e tests added/updated/verified — N/A
- [x] Manual testing performed — Read-through for consistency across guides; verify GitHub heading anchors if desired.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`) — *optional for doc-only; run if your workflow requires it*
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #308