### PR TITLE
fix: default TLS verification on in guides, demos, and processor Conf…

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -42,7 +42,7 @@ data:
       max_retries: {{ .maxRetries }}
       initial_backoff: {{ .initialBackoff | quote }}
       max_backoff: {{ .maxBackoff | quote }}
-      tls_insecure_skip_verify: {{ .tlsInsecureSkipVerify }}
+      tls_insecure_skip_verify: {{ .tlsInsecureSkipVerify | default false }}
       {{- if .apiKeyName }}
       api_key_name: {{ .apiKeyName | quote }}
       {{- end }}
@@ -69,7 +69,7 @@ data:
         max_retries: {{ $cfg.maxRetries }}
         initial_backoff: {{ $cfg.initialBackoff | quote }}
         max_backoff: {{ $cfg.maxBackoff | quote }}
-        tls_insecure_skip_verify: {{ $cfg.tlsInsecureSkipVerify }}
+        tls_insecure_skip_verify: {{ $cfg.tlsInsecureSkipVerify | default false }}
         {{- if $cfg.apiKeyName }}
         api_key_name: {{ $cfg.apiKeyName | quote }}
         {{- end }}

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -13,6 +13,34 @@ tests:
           path: data["config.yaml"]
           pattern: 'model_gateways:'
 
+  - it: should default tls_insecure_skip_verify to false when omitted from global_inference_gateway
+    set:
+      processor.config.globalInferenceGateway:
+        url: "http://global-gw:8000"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "1s"
+        maxBackoff: "60s"
+      processor.config.modelGateways: null
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'global_inference_gateway:[\s\S]*tls_insecure_skip_verify: false'
+
+  - it: should default tls_insecure_skip_verify to false when omitted from model gateway
+    set:
+      processor.config.modelGateways:
+        "llama-3":
+          url: "http://gw:8000"
+          requestTimeout: "5m"
+          maxRetries: 3
+          initialBackoff: "1s"
+          maxBackoff: "60s"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '"llama-3":[\s\S]*tls_insecure_skip_verify: false'
+
   - it: should render global_inference_gateway when set
     set:
       processor.config.globalInferenceGateway:

--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -656,7 +656,6 @@ helm install batch-gateway ./charts/batch-gateway \
     --set "processor.config.modelGateways.${MODEL_NAME}.maxRetries=3" \
     --set "processor.config.modelGateways.${MODEL_NAME}.initialBackoff=1s" \
     --set "processor.config.modelGateways.${MODEL_NAME}.maxBackoff=60s" \
-    --set "processor.config.modelGateways.${MODEL_NAME}.tlsInsecureSkipVerify=true" \
     --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}" \
     --set apiserver.tls.enabled=true \
     --set apiserver.tls.certManager.enabled=true \
@@ -667,7 +666,7 @@ helm install batch-gateway ./charts/batch-gateway \
 
 > - **`modelGateways.<model>.url`**: The processor uses this URL to send inference requests. It points to the Gateway's model endpoint (via in-cluster Service DNS), not directly to the model server, so that requests go through the Gateway's AuthPolicy and rate limiting.
 > - **`passThroughHeaders: {Authorization}`**: Ensures the processor sends inference requests on behalf of the original user, so the LLM route's AuthPolicy can enforce model-level authorization on batch requests.
-> - **`apiserver.tls.certManager.*`**: Enables TLS for the batch API server using cert-manager. The `dnsNames` should include the Service name and FQDN so the Gateway can verify the backend certificate when re-encrypting traffic (see DestinationRule in 3.8).
+> - **`apiserver.tls.certManager.*`**: Enables TLS for the batch API server using cert-manager. The `dnsNames` should include the Service name and FQDN so the Gateway can verify the backend certificate when re-encrypting traffic (see DestinationRule in 3.8). The Helm chart defaults `processor` `tls_insecure_skip_verify` to **`false`** when omitted.
 > - **File storage**: This example uses `global.fileClient.type=fs` with a PVC. To use S3-compatible storage instead, replace the `fs` options with:
 >   ```
 >   --set "global.fileClient.type=s3"
@@ -681,6 +680,8 @@ helm install batch-gateway ./charts/batch-gateway \
 >   and add `--from-literal=s3-secret-access-key=<secret-key>` to the application secret.
 
 </details>
+
+> **TLS verification (lab vs production)**: The install snippet omits `tlsInsecureSkipVerify` (processor verifies the model-gateway certificate) and the DestinationRule below uses **`insecureSkipVerify: false`** so Istio verifies the batch apiserver certificate. If a quick lab setup fails with x509 errors (self-signed or mismatched SANs), you may **temporarily** add `--set "processor.config.modelGateways.${MODEL_NAME}.tlsInsecureSkipVerify=true"` and set `insecureSkipVerify: true` in the DestinationRule — **demo/lab only**; do not copy that into production without addressing trust (see [CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Demo scripts use the same idea via `DEMO_TLS_INSECURE_SKIP_VERIFY=1` (see `examples/deploy-demo/README.md`).
 
 ### 3.8 Configure HTTPRoute and Policies for Batch Gateway
 
@@ -727,7 +728,7 @@ spec:
         number: 8000
       tls:
         mode: SIMPLE
-        insecureSkipVerify: true
+        insecureSkipVerify: false
 EOF
 ```
 

--- a/docs/guides/deploy-maas.md
+++ b/docs/guides/deploy-maas.md
@@ -399,7 +399,6 @@ helm install batch-gateway ./charts/batch-gateway \
     --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.maxRetries=3" \
     --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.initialBackoff=1s" \
     --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.maxBackoff=60s" \
-    --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.tlsInsecureSkipVerify=true" \
     --set "apiserver.config.batchAPI.passThroughHeaders={Authorization,X-MaaS-Subscription}" \
     --set apiserver.tls.enabled=true \
     --set apiserver.tls.certManager.enabled=true \
@@ -408,7 +407,7 @@ helm install batch-gateway ./charts/batch-gateway \
     --set "apiserver.tls.certManager.dnsNames={batch-gateway-apiserver,batch-gateway-apiserver.${BATCH_NS}.svc.cluster.local,localhost}"
 ```
 
-> - **`modelGateways.<model>.url`**: The processor uses the MaaS Gateway's **external hostname** (`https://maas.<domain>/...`) because the Gateway listener requires SNI matching. Internal Service FQDN causes TLS handshake failure.
+> - **`modelGateways.<model>.url`**: The processor uses the MaaS Gateway's **external hostname** (`https://maas.<domain>/...`) because the Gateway listener requires SNI matching. Internal Service FQDN causes TLS handshake failure. The Helm chart defaults `tls_insecure_skip_verify` to **`false`** when omitted; use strict verification when your cluster trusts the ingress/Gateway CA.
 > - **`passThroughHeaders: {Authorization, X-MaaS-Subscription}`**: Ensures the processor sends inference requests on behalf of the original user, so the LLM route's AuthPolicy can enforce model-level authorization and the correct subscription is used for token rate limiting.
 > - **File storage**: This example uses `global.fileClient.type=fs` with a PVC. To use S3-compatible storage instead, replace the `fs` options with:
 >   ```
@@ -423,6 +422,8 @@ helm install batch-gateway ./charts/batch-gateway \
 >   and add `--from-literal=s3-secret-access-key=<secret-key>` to the application secret.
 
 </details>
+
+> **TLS verification (lab vs production)**: Copy-paste blocks omit `tlsInsecureSkipVerify` and use **`insecureSkipVerify: false`** on the DestinationRule. If the processor or Gateway cannot validate certificates in your environment (common with corporate ingress or quick self-signed labs), **temporarily** add `--set "processor.config.modelGateways.<model>.tlsInsecureSkipVerify=true"` and `insecureSkipVerify: true` — **demo/lab only** ([CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Demo scripts: `DEMO_TLS_INSECURE_SKIP_VERIFY=1` (see `examples/deploy-demo/README.md`).
 
 ### 3.5 Configure HTTPRoute and Policies for Batch Gateway
 
@@ -472,7 +473,7 @@ spec:
         number: 8000
       tls:
         mode: SIMPLE
-        insecureSkipVerify: true
+        insecureSkipVerify: false
 EOF
 ```
 

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -693,7 +693,6 @@ helm install batch-gateway ./charts/batch-gateway \
     --set "processor.config.modelGateways.facebook/opt-125m.maxRetries=3" \
     --set "processor.config.modelGateways.facebook/opt-125m.initialBackoff=1s" \
     --set "processor.config.modelGateways.facebook/opt-125m.maxBackoff=60s" \
-    --set "processor.config.modelGateways.facebook/opt-125m.tlsInsecureSkipVerify=true" \
     --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}" \
     --set apiserver.tls.enabled=true \
     --set apiserver.tls.certManager.enabled=true \
@@ -705,7 +704,7 @@ helm install batch-gateway ./charts/batch-gateway \
 > - **`modelGateways.<model>.url`**: The processor uses this URL to send inference requests. It should point to the Gateway's model endpoint (from `llminferenceservice.status.url`), not directly to the model server, so that requests go through the Gateway's AuthPolicy and rate limiting.
 > - **`passThroughHeaders: {Authorization}`**: Ensures the processor sends inference requests on behalf of the original user, so the LLM route's AuthPolicy can enforce model-level authorization on batch requests.
 >
-> - **`apiserver.tls.certManager.*`**: Enables TLS for the batch API server using cert-manager. The `issuerName` must match a ClusterIssuer (e.g. `selfsigned-issuer`). The `dnsNames` should include the Service name and FQDN so the Gateway can verify the backend certificate when re-encrypting traffic (see DestinationRule in 3.9).
+> - **`apiserver.tls.certManager.*`**: Enables TLS for the batch API server using cert-manager. The `issuerName` must match a ClusterIssuer (e.g. `selfsigned-issuer`). The `dnsNames` should include the Service name and FQDN so the Gateway can verify the backend certificate when re-encrypting traffic (see DestinationRule in 3.9). The Helm chart defaults `processor` `tls_insecure_skip_verify` to **`false`** when omitted.
 > - **File storage**: This example uses `global.fileClient.type=fs` with a PVC. To use S3-compatible storage instead, replace the `fs` options with:
 >   ```
 >   --set "global.fileClient.type=s3"
@@ -720,6 +719,7 @@ helm install batch-gateway ./charts/batch-gateway \
 
 </details>
 
+> **TLS verification (lab vs production)**: The install snippet omits `tlsInsecureSkipVerify` and the DestinationRule in 3.9 uses **`insecureSkipVerify: false`**. For self-signed or mismatched SANs in a lab, you may **temporarily** add `--set "processor.config.modelGateways.<model>.tlsInsecureSkipVerify=true"` and `insecureSkipVerify: true` in the DestinationRule — **demo/lab only** (see [CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Demo scripts: `DEMO_TLS_INSECURE_SKIP_VERIFY=1` (see `examples/deploy-demo/README.md`).
 
 ### 3.9 Configure HTTPRoute and Policies for Batch Gateway
 
@@ -768,7 +768,7 @@ spec:
         number: 8000
       tls:
         mode: SIMPLE
-        insecureSkipVerify: true
+        insecureSkipVerify: false
 EOF
 ```
 

--- a/docs/guides/maas-integration.md
+++ b/docs/guides/maas-integration.md
@@ -194,6 +194,8 @@ EOF
 
 The processor calls models through the MaaS gateway using HTTPS. `passThroughHeaders={Authorization,X-MaaS-Subscription}` ensures the API key and subscription header are forwarded to the model for authentication and rate limiting.
 
+By default, omit `tlsInsecureSkipVerify` so the processor verifies the gateway certificate (Helm renders `tls_insecure_skip_verify: false`). If your lab uses a cert the processor cannot validate, see the note after §4.4.
+
 ```bash
 $ helm install batch-gateway ./charts/batch-gateway -n batch-api \
     --set "global.secretName=batch-gateway-secrets" \
@@ -202,7 +204,6 @@ $ helm install batch-gateway ./charts/batch-gateway -n batch-api \
     --set "global.fileClient.fs.basePath=/tmp/batch-gateway" \
     --set "global.fileClient.fs.pvcName=batch-gateway-files" \
     --set 'processor.config.modelGateways.facebook/opt-125m.url=https://maas-default-gateway-istio.openshift-ingress.svc.cluster.local/llm/facebook-opt-125m-simulated' \
-    --set 'processor.config.modelGateways.facebook/opt-125m.tlsInsecureSkipVerify=true' \
     --set 'processor.config.modelGateways.facebook/opt-125m.requestTimeout=5m' \
     --set 'processor.config.modelGateways.facebook/opt-125m.maxRetries=3' \
     --set 'processor.config.modelGateways.facebook/opt-125m.initialBackoff=1s' \
@@ -243,9 +244,11 @@ spec:
         number: 8000
       tls:
         mode: SIMPLE
-        insecureSkipVerify: true
+        insecureSkipVerify: false
 EOF
 ```
+
+> **Lab-only TLS skip**: If you see x509 verification errors from the processor or from Istio re-encrypt to the apiserver, you may **temporarily** add `--set 'processor.config.modelGateways.facebook/opt-125m.tlsInsecureSkipVerify=true'` and set `insecureSkipVerify: true` in the DestinationRule above — **not for production** without proper CA trust ([CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Demo scripts: `DEMO_TLS_INSECURE_SKIP_VERIFY=1`.
 
 ### 4.5 Create HTTPRoute
 

--- a/examples/deploy-demo/README.md
+++ b/examples/deploy-demo/README.md
@@ -136,6 +136,7 @@ BATCH_RELEASE_VERSION=v1.0.0 \
 | `BATCH_DEV_VERSION` | `local` | all | Image tag / commit SHA. `local` uses local chart + `latest` image. Cannot be used with `BATCH_RELEASE_VERSION` |
 | `BATCH_DB_TYPE` | `postgresql` | all | Database backend: `postgresql` or `redis` |
 | `BATCH_STORAGE_TYPE` | `s3` | all | File storage: `fs` or `s3` |
+| `DEMO_TLS_INSECURE_SKIP_VERIFY` | `0` | all | Set to `1` to disable TLS certificate verification for processor → model gateway and for Istio Gateway → batch apiserver (**demo/lab only**, [CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Default `0` verifies certificates. Use if you hit x509 errors with self-signed or untrusted CAs. |
 | `BATCH_NAMESPACE` | `batch-api` | all | Namespace for batch-gateway |
 | `LLM_NAMESPACE` | `llm` | all | Namespace for model serving |
 | `LLMD_VERSION` | `main` | k8s | llm-d git ref to install |

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -62,6 +62,9 @@ BATCH_POSTGRESQL_RELEASE="${BATCH_POSTGRESQL_RELEASE:-postgresql}"
 # WARNING: Default passwords are for demo only. For production, override via env vars or use K8s secrets.
 BATCH_POSTGRESQL_PASSWORD="${BATCH_POSTGRESQL_PASSWORD:-postgres}"
 BATCH_STORAGE_TYPE="${BATCH_STORAGE_TYPE:-s3}"
+# When 1, disables TLS certificate verification for (a) processor -> model gateway HTTPS and
+# (b) Istio Gateway -> batch apiserver (DestinationRule). Demo/lab only (CWE-295); default 0 verifies certs.
+DEMO_TLS_INSECURE_SKIP_VERIFY="${DEMO_TLS_INSECURE_SKIP_VERIFY:-0}"
 BATCH_MINIO_RELEASE="${BATCH_MINIO_RELEASE:-minio}"
 MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
 MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
@@ -326,6 +329,12 @@ EOF
 # Without this, the Gateway would send plaintext to the HTTPS apiserver port.
 create_batch_destinationrule() {
     step "Creating DestinationRule for backend TLS (Gateway -> apiserver)..."
+    local skip="${DEMO_TLS_INSECURE_SKIP_VERIFY:-0}"
+    local istio_skip="false"
+    if [[ "${skip}" == "1" ]]; then
+        istio_skip="true"
+        warn "DEMO_TLS_INSECURE_SKIP_VERIFY=1: Istio insecureSkipVerify enabled (demo/lab only; do not use in production)."
+    fi
     kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
@@ -340,9 +349,9 @@ spec:
         number: ${BATCH_INFERENCE_PORT}
       tls:
         mode: SIMPLE
-        insecureSkipVerify: true
+        insecureSkipVerify: ${istio_skip}
 EOF
-    log "DestinationRule created (Gateway -> apiserver: TLS re-encrypt)."
+    log "DestinationRule created (Gateway -> apiserver: TLS re-encrypt, insecureSkipVerify=${istio_skip})."
 }
 
 # ── Database / Storage Functions ──────────────────────────────────────────────

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -360,9 +360,12 @@ deploy_batch_gateway_k8s() {
         --set "processor.config.modelGateways.${MODEL_NAME}.maxRetries=${GW_MAX_RETRIES}"
         --set "processor.config.modelGateways.${MODEL_NAME}.initialBackoff=${GW_INITIAL_BACKOFF}"
         --set "processor.config.modelGateways.${MODEL_NAME}.maxBackoff=${GW_MAX_BACKOFF}"
-        --set "processor.config.modelGateways.${MODEL_NAME}.tlsInsecureSkipVerify=true"
         --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}"
     )
+    if [[ "${DEMO_TLS_INSECURE_SKIP_VERIFY:-0}" == "1" ]]; then
+        helm_args+=(--set "processor.config.modelGateways.${MODEL_NAME}.tlsInsecureSkipVerify=true")
+        warn "DEMO_TLS_INSECURE_SKIP_VERIFY=1: processor TLS verify disabled for model gateway (demo/lab only)."
+    fi
 
     do_deploy_batch_gateway "${helm_args[@]}"
 }

--- a/examples/deploy-demo/deploy-maas.sh
+++ b/examples/deploy-demo/deploy-maas.sh
@@ -178,9 +178,12 @@ deploy_batch_gateway_maas() {
         --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.maxRetries=${GW_MAX_RETRIES}"
         --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.initialBackoff=${GW_INITIAL_BACKOFF}"
         --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.maxBackoff=${GW_MAX_BACKOFF}"
-        --set "processor.config.modelGateways.${MAAS_MODEL_NAME}.tlsInsecureSkipVerify=true"
         --set "apiserver.config.batchAPI.passThroughHeaders={Authorization,X-MaaS-Subscription}"
     )
+    if [[ "${DEMO_TLS_INSECURE_SKIP_VERIFY:-0}" == "1" ]]; then
+        helm_args+=(--set "processor.config.modelGateways.${MAAS_MODEL_NAME}.tlsInsecureSkipVerify=true")
+        warn "DEMO_TLS_INSECURE_SKIP_VERIFY=1: processor TLS verify disabled for model gateway (demo/lab only)."
+    fi
 
     do_deploy_batch_gateway "${helm_args[@]}"
 }

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -666,9 +666,12 @@ deploy_batch_gateway_rhoai() {
         --set "processor.config.modelGateways.${model_key}.maxRetries=${GW_MAX_RETRIES}"
         --set "processor.config.modelGateways.${model_key}.initialBackoff=${GW_INITIAL_BACKOFF}"
         --set "processor.config.modelGateways.${model_key}.maxBackoff=${GW_MAX_BACKOFF}"
-        --set "processor.config.modelGateways.${model_key}.tlsInsecureSkipVerify=true"
         --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}"
     )
+    if [[ "${DEMO_TLS_INSECURE_SKIP_VERIFY:-0}" == "1" ]]; then
+        helm_args+=(--set "processor.config.modelGateways.${model_key}.tlsInsecureSkipVerify=true")
+        warn "DEMO_TLS_INSECURE_SKIP_VERIFY=1: processor TLS verify disabled for model gateway (demo/lab only)."
+    fi
 
     do_deploy_batch_gateway "${helm_args[@]}"
 }


### PR DESCRIPTION
## Why is this PR needed?

CodeRabbit finding: Copy-paste examples and demo scripts previously enabled **TLS certificate verification bypass** by default (`tlsInsecureSkipVerify` on the processor and `insecureSkipVerify` on Istio `DestinationRule`). That is reasonable for some self-signed lab setups but is easy to carry into production ([CWE-295](https://cwe.mitre.org/data/definitions/295.html)). The Helm processor ConfigMap could also render `tls_insecure_skip_verify: <nil>` when the value was unset, which is unclear for operators.

We are **not** rejecting `TLSInsecureSkipVerify == true` in processor `Validate()` at startup — that remains an intentional escape hatch per issue discussion. (Issue #307)

## What does this PR do?

- **Helm** (`processor-configmap.yaml`): `tls_insecure_skip_verify` uses `| default false` for `globalInferenceGateway` and each `modelGateways` entry so rendered YAML is always a boolean.
- **Helm tests**: Assert `false` when `tlsInsecureSkipVerify` is omitted.
- **Demo scripts** (`common.sh`, `deploy-k8s.sh`, `deploy-rhoai.sh`, `deploy-maas.sh`): Default path verifies certificates; **`DEMO_TLS_INSECURE_SKIP_VERIFY=1`** opts into processor skip-verify and Istio `insecureSkipVerify: true`, with **`warn`** when enabled.
- **Guides** (`deploy-k8s.md`, `deploy-rhoai.md`, `deploy-maas.md`, `maas-integration.md`): Main snippets omit processor skip-verify and set **`insecureSkipVerify: false`** on `DestinationRule`; add short **lab vs production** notes and the insecure escape hatch.
- **README** (`examples/deploy-demo/README.md`): Document **`DEMO_TLS_INSECURE_SKIP_VERIFY`**.

## How was this tested?

- [x] `helm unittest charts/batch-gateway`
- [x] Unit tests (`make test`) — unchanged Go code paths; optional full `make pre-commit`
- [x] Manual cluster run — recommend spot-check: default install vs `DEMO_TLS_INSECURE_SKIP_VERIFY=1` if x509 issues appear

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #307