### PR TITLE
fix(demo): wait for TokenRateLimitPolicy in LLM_NAMESPACE (deploy-maas)

### DIFF
--- a/examples/deploy-demo/deploy-maas.sh
+++ b/examples/deploy-demo/deploy-maas.sh
@@ -300,7 +300,7 @@ EOF
     # Wait for TokenRateLimitPolicy to be generated from MaaSSubscription
     step "Waiting for TokenRateLimitPolicy..."
     for i in $(seq 1 30); do
-        if kubectl get tokenratelimitpolicy -n llm 2>/dev/null | grep -q "${isvc_name}"; then
+        if kubectl get tokenratelimitpolicy -n "${LLM_NAMESPACE}" 2>/dev/null | grep -q "${isvc_name}"; then
             log "TokenRateLimitPolicy generated for model."
             return
         fi


### PR DESCRIPTION
## Why is this PR needed?

`deploy-maas.sh` waits for a `TokenRateLimitPolicy` after the model is ready, but the wait loop used a hardcoded `-n llm` while the rest of the script (including `MaaSModelRef` checks) uses `${LLM_NAMESPACE}`. If operators override `LLM_NAMESPACE`, the policy exists in the configured namespace but the script never finds it and fails after the retry loop.

## What does this PR do?

- Change the `kubectl get tokenratelimitpolicy` wait to use `-n "${LLM_NAMESPACE}"` so it matches where the model / MaaS resources are deployed.

## How was this tested?

- [ ] Unit tests — N/A (shell demo script)
- [ ] Integration/e2e — N/A
- [x] Manual reasoning — namespace alignment with existing `MaaSModelRef` / model namespace usage

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`) — optional for one-line shell change
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)