### PR TITLE
fix: allow cancel retry when batch is already cancelling

### DIFF
--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -505,6 +505,25 @@ func (c *BatchAPIHandler) CancelBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Idempotent cancel retry: DB already shows cancelling (e.g. first attempt updated DB
+	// but ECProducerSendEvents failed). Re-send the event only — skip queue removal and DB write.
+	if batch.Status == openai.BatchStatusCancelling {
+		event := []api.BatchEvent{
+			{
+				ID:   batch.ID,
+				Type: api.BatchEventCancel,
+				TTL:  c.config.BatchAPI.GetBatchEventTTLSeconds(),
+			},
+		}
+		if _, err := c.clients.Event.ECProducerSendEvents(ctx, event); err != nil {
+			logger.Error(err, "failed to send cancel event")
+			common.WriteInternalServerError(w, r)
+			return
+		}
+		common.WriteJSONResponse(w, r, http.StatusOK, batch)
+		return
+	}
+
 	// Try to remove from the priority queue first.
 	// Reconstruct the exact SLO score from the stored tag.
 	removedFromQueue := false

--- a/internal/apiserver/batch/batch_handler_test.go
+++ b/internal/apiserver/batch/batch_handler_test.go
@@ -1028,6 +1028,114 @@ func TestBatchHandler(t *testing.T) {
 				t.Errorf("expected status %d, got %d: %s", http.StatusInternalServerError, rr.Code, rr.Body.String())
 			}
 		})
+
+		t.Run("CancelCancellingBatch_ResendsEvent", func(t *testing.T) {
+			handler := setupTestHandler()
+
+			batchID := "batch-test-cancel-retry"
+			cancellingAt := int64(1700000000)
+			batch := openai.Batch{
+				ID: batchID,
+				BatchSpec: openai.BatchSpec{
+					Object:           "batch",
+					InputFileID:      "file-abc123",
+					Endpoint:         openai.EndpointChatCompletions,
+					CompletionWindow: "24h",
+					CreatedAt:        time.Now().UTC().Unix(),
+				},
+				BatchStatusInfo: openai.BatchStatusInfo{
+					Status:       openai.BatchStatusCancelling,
+					CancellingAt: &cancellingAt,
+				},
+			}
+			slo := time.Now().UTC().Add(24 * time.Hour)
+			item, err := converter.BatchToDBItem(&batch, common.DefaultTenantID, map[string]string{
+				batch_types.TagSLO: fmt.Sprintf("%d", slo.UnixMicro()),
+			})
+			if err != nil {
+				t.Fatalf("Failed to convert batch to database item: %v", err)
+			}
+			if err := handler.clients.BatchDB.DBStore(context.Background(), item); err != nil {
+				t.Fatalf("Failed to store item: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/batches/"+batchID+"/cancel", nil)
+			req.SetPathValue("batch_id", batchID)
+			rr := httptest.NewRecorder()
+			handler.CancelBatch(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rr.Code, rr.Body.String())
+			}
+
+			var respBatch openai.Batch
+			if err := json.NewDecoder(rr.Body).Decode(&respBatch); err != nil {
+				t.Fatalf("Failed to decode response body: %v", err)
+			}
+			if respBatch.Status != openai.BatchStatusCancelling {
+				t.Errorf("Expected status %s, got %s", openai.BatchStatusCancelling, respBatch.Status)
+			}
+			if respBatch.CancellingAt == nil || *respBatch.CancellingAt != cancellingAt {
+				t.Errorf("Expected cancelling_at unchanged (%d), got %v", cancellingAt, respBatch.CancellingAt)
+			}
+		})
+
+		t.Run("CancelCancellingBatch_EventSendFailure", func(t *testing.T) {
+			failingEvent := &failingEventClient{
+				MockBatchEventChannelClient: mockapi.NewMockBatchEventChannelClient(),
+				sendErr:                     fmt.Errorf("event broker unavailable"),
+			}
+			clients := &clientset.Clientset{
+				BatchDB: mockapi.NewMockDBClient[dbapi.BatchItem, dbapi.BatchQuery](
+					func(b *dbapi.BatchItem) string { return b.ID },
+					func(q *dbapi.BatchQuery) *dbapi.BaseQuery { return &q.BaseQuery },
+				),
+				FileDB: mockapi.NewMockDBClient[dbapi.FileItem, dbapi.FileQuery](
+					func(f *dbapi.FileItem) string { return f.ID },
+					func(q *dbapi.FileQuery) *dbapi.BaseQuery { return &q.BaseQuery },
+				),
+				Queue:  mockapi.NewMockBatchPriorityQueueClient(),
+				Event:  failingEvent,
+				Status: mockapi.NewMockBatchStatusClient(),
+			}
+			handler := NewBatchAPIHandler(&common.ServerConfig{}, clients)
+
+			batchID := "batch-test-cancel-retry-event-fail"
+			cancellingAt := int64(1700000001)
+			batch := openai.Batch{
+				ID: batchID,
+				BatchSpec: openai.BatchSpec{
+					Object:           "batch",
+					InputFileID:      "file-abc123",
+					Endpoint:         openai.EndpointChatCompletions,
+					CompletionWindow: "24h",
+					CreatedAt:        time.Now().UTC().Unix(),
+				},
+				BatchStatusInfo: openai.BatchStatusInfo{
+					Status:       openai.BatchStatusCancelling,
+					CancellingAt: &cancellingAt,
+				},
+			}
+			slo := time.Now().UTC().Add(24 * time.Hour)
+			item, err := converter.BatchToDBItem(&batch, common.DefaultTenantID, map[string]string{
+				batch_types.TagSLO: fmt.Sprintf("%d", slo.UnixMicro()),
+			})
+			if err != nil {
+				t.Fatalf("Failed to convert batch to database item: %v", err)
+			}
+			if err := clients.BatchDB.DBStore(context.Background(), item); err != nil {
+				t.Fatalf("Failed to store item: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/batches/"+batchID+"/cancel", nil)
+			req.SetPathValue("batch_id", batchID)
+			rr := httptest.NewRecorder()
+			handler.CancelBatch(rr, req)
+
+			if rr.Code != http.StatusInternalServerError {
+				t.Errorf("expected status %d, got %d: %s", http.StatusInternalServerError, rr.Code, rr.Body.String())
+			}
+		})
 	})
 
 	t.Run("MergeProgressCounts", func(t *testing.T) {

--- a/internal/shared/openai/batch.go
+++ b/internal/shared/openai/batch.go
@@ -63,7 +63,7 @@ func (s BatchStatus) IsFinal() bool {
 }
 
 func (s BatchStatus) IsCancellable() bool {
-	return s == BatchStatusValidating || s == BatchStatusInProgress
+	return s == BatchStatusValidating || s == BatchStatusInProgress || s == BatchStatusCancelling
 }
 
 type BatchSpec struct {

--- a/internal/shared/openai/batch_test.go
+++ b/internal/shared/openai/batch_test.go
@@ -83,3 +83,24 @@ func TestValidate_MetadataAtLimits(t *testing.T) {
 		t.Errorf("expected no error at exact limits, got: %v", err)
 	}
 }
+
+func TestBatchStatus_IsCancellable(t *testing.T) {
+	cases := []struct {
+		status BatchStatus
+		want   bool
+	}{
+		{BatchStatusValidating, true},
+		{BatchStatusInProgress, true},
+		{BatchStatusCancelling, true},
+		{BatchStatusCompleted, false},
+		{BatchStatusFailed, false},
+		{BatchStatusCancelled, false},
+		{BatchStatusExpired, false},
+		{BatchStatusFinalizing, false},
+	}
+	for _, tc := range cases {
+		if got := tc.status.IsCancellable(); got != tc.want {
+			t.Errorf("IsCancellable(%q) = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

Fixes #300. If `CancelBatch` updates the DB to `cancelling` but `ECProducerSendEvents` fails, the client gets 500 while the DB already shows `cancelling`. Retrying cancel used to return 400 because `IsCancellable()` did not allow `cancelling`, so the cancel event could never be re-delivered and the worker could keep running.

## What does this PR do?

- Extend `BatchStatus.IsCancellable()` to include `cancelling`.
- In `CancelBatch`, when status is already `cancelling`, skip queue removal and `DBUpdate`; only re-send the cancel event and return 200 with the current batch (idempotent for the worker).

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #300