### PR TITLE
ci: skip DCO check for Dependabot PRs

### DIFF
--- a/.github/workflows/ci-dco-signoff.yml
+++ b/.github/workflows/ci-dco-signoff.yml
@@ -3,6 +3,7 @@ on: pull_request
 
 jobs:
   dco:
+    if: github.actor != 'dependabot[bot]'
     name: Check Signed-off-by (DCO)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Skip the DCO sign-off check when the PR author is `dependabot[bot]`.
- The DCO certifies that a *human* contributor has the right to submit code — bot-generated dependency bumps don't need this.
- Without this fix, all Dependabot PRs (e.g., #305) fail the DCO check.

## Test plan

- [x] DCO check still runs and passes on this (human-authored) PR
- [ ] After merge: verify DCO check is skipped on Dependabot PRs (re-run #305)

🤖 Generated with [Claude Code](https://claude.com/claude-code)