### PR TITLE
fix: use PR author instead of actor for DCO bot skip

### DIFF
--- a/.github/workflows/ci-dco-signoff.yml
+++ b/.github/workflows/ci-dco-signoff.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   dco:
-    if: github.actor != 'dependabot[bot]'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     name: Check Signed-off-by (DCO)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Change the DCO skip condition from `github.actor` to `github.event.pull_request.user.login`.
- `github.actor` reflects who *triggered* the workflow (e.g., a maintainer who pushed a merge commit), not who *opened* the PR. This caused the DCO check to incorrectly run on Dependabot PRs when a maintainer merged `main` into the branch (#305).

## Test plan

- [x] DCO check still runs and passes on this (human-authored) PR
- [ ] After merge: verify DCO check is skipped on Dependabot PR #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)