### PR TITLE
test(e2e): expand batch scenarios and fix comment accuracy

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,7 @@ This script:
 4. Installs PostgreSQL via Helm
 5. Deploys a vLLM simulator as the inference backend
 6. Deploys batch-gateway via Helm
-7. Starts a `kubectl port-forward` in the background at `http://localhost:8000`
+7. Creates NodePort services mapping to `https://localhost:8000` (apiserver), `http://localhost:8081` (apiserver observability), and `http://localhost:9090` (processor observability)
 
 **Environment variables**
 
@@ -30,12 +30,12 @@ This script:
 | `HELM_RELEASE`        | `batch-gateway`                            | Helm release name                                  |
 | `NAMESPACE`           | `default`                                  | Kubernetes namespace                               |
 | `DEV_VERSION`         | `0.0.1`                                    | Image tag to build and deploy                      |
-| `LOCAL_PORT`          | `8000`                                     | Local port for the port-forward                    |
-| `LOG_VERBOSITY`       | `4`                                        | klog verbosity for apiserver and processor         |
+| `LOCAL_PORT`          | `8000`                                     | Local port for the apiserver                       |
+| `LOG_VERBOSITY`       | `5`                                        | klog verbosity for apiserver and processor         |
 | `POSTGRESQL_RELEASE`  | `postgresql`                               | Helm release name for PostgreSQL                   |
 | `POSTGRESQL_PASSWORD` | `postgres`                                 | PostgreSQL admin password                          |
 | `INFERENCE_API_KEY`   | `dummy-api-key`                            | API key written to the app secret                  |
-| `S3_SECRET_ACCESS_KEY`| `dummy-s3-secret-access-key`               | S3 secret access key written to the app secret     |
+| `S3_SECRET_ACCESS_KEY`| `minioadmin`                               | S3 secret access key written to the app secret     |
 | `APP_SECRET_NAME`     | `<HELM_RELEASE>-secrets`                   | Name of the Kubernetes secret created by the script|
 | `FILES_PVC_NAME`      | `<HELM_RELEASE>-files`                     | Name of the PVC created for file storage           |
 | `VLLM_SIM_NAME`       | `vllm-sim`                                 | Name of the vLLM simulator deployment              |
@@ -45,7 +45,7 @@ This script:
 Example with overrides:
 
 ```bash
-NAMESPACE=dev LOCAL_PORT=9000 LOG_VERBOSITY=5 make dev-deploy
+NAMESPACE=dev LOCAL_PORT=9000 LOG_VERBOSITY=4 make dev-deploy
 ```
 
 ## 2. Run the tests
@@ -56,15 +56,25 @@ make test-e2e
 
 **Environment variables**
 
-| Variable         | Default                  | Description                              |
-|------------------|--------------------------|------------------------------------------|
-| `TEST_BASE_URL`  | `http://localhost:8000`  | Base URL of the running API server       |
-| `TEST_TENANT_ID` | `default`                | Tenant ID sent in the `X-MaaS-Username` header |
+| Variable                  | Default                          | Description                                                |
+|---------------------------|----------------------------------|------------------------------------------------------------|
+| `TEST_APISERVER_URL`      | `https://localhost:8000`         | Base URL of the running API server (TLS)                   |
+| `TEST_APISERVER_OBS_URL`  | `http://localhost:8081`          | Apiserver observability endpoint (health, metrics)         |
+| `TEST_PROCESSOR_OBS_URL`  | `http://localhost:9090`          | Processor observability endpoint (health, metrics)         |
+| `TEST_JAEGER_URL`         | `http://localhost:16686`         | Jaeger query endpoint for trace verification               |
+| `TEST_TENANT_HEADER`      | `X-MaaS-Username`               | HTTP header used to identify the tenant                    |
+| `TEST_TENANT_ID`          | `default`                        | Tenant ID sent in the tenant header                        |
+| `TEST_NAMESPACE`          | `default`                        | Kubernetes namespace of the deployment                     |
+| `TEST_HELM_RELEASE`       | `batch-gateway`                  | Helm release name (used for label selectors, rollouts)     |
+| `TEST_POSTGRESQL_RELEASE` | `postgresql`                     | Helm release name for PostgreSQL (used by GC tests)        |
+| `TEST_MODEL`              | `sim-model`                      | Primary model name for batch input                         |
+| `TEST_MODEL_B`            | `sim-model-b`                    | Secondary model name for multi-model tests                 |
+| `TEST_CHART_PATH`         | `../../charts/batch-gateway`     | Path to the Helm chart (used by HelmUpgrade tests)         |
 
 Example with overrides:
 
 ```bash
-TEST_BASE_URL=http://localhost:9000 TEST_TENANT_ID=my-tenant make test-e2e
+TEST_APISERVER_URL=https://localhost:9000 TEST_TENANT_ID=my-tenant make test-e2e
 ```
 
 ## 3. Cleanup

--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -16,7 +16,11 @@ package e2e_test
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os/exec"
 	"strings"
 	"testing"
@@ -35,11 +39,25 @@ func testBatches(t *testing.T) {
 	t.Run("Cancel", func(t *testing.T) {
 		t.Run("BeforeProcessing", doTestBatchCancelBeforeProcessing)
 		t.Run("InProgress", doTestBatchCancel)
+		t.Run("IdempotentRetry", doTestCancelIdempotentRetry)
+		t.Run("TerminalBatchRejected", doTestCancelTerminalBatchRejected)
 	})
 	t.Run("MixedSuccessFailure", doTestBatchMixedSuccessFailure)
 	t.Run("SharedInputFile", doTestBatchSharedInputFile)
 	t.Run("PassThroughHeaders", doTestPassThroughHeaders)
 	t.Run("Expiration", doTestBatchExpiration)
+	t.Run("MultiModel", doTestMultiModelBatch)
+	t.Run("ProgressPolling", doTestProgressPolling)
+	t.Run("Ingestion", func(t *testing.T) {
+		t.Run("DuplicateCustomID", doTestDuplicateCustomID)
+		t.Run("StreamingRejected", doTestStreamingRejected)
+		t.Run("AllModelsUnregistered", doTestAllModelsUnregistered)
+	})
+	t.Run("Validation", func(t *testing.T) {
+		t.Run("MissingInputFileID", doTestCreateBatchMissingInputFileID)
+		t.Run("InvalidEndpoint", doTestCreateBatchInvalidEndpoint)
+		t.Run("NonexistentFile", doTestCreateBatchNonexistentFile)
+	})
 }
 
 func doTestBatchCancel(t *testing.T) {
@@ -47,8 +65,9 @@ func doTestBatchCancel(t *testing.T) {
 
 	// Mix fast and slow requests to guarantee both output and error files exist after cancel:
 	//   - Fast requests (max_tokens=1): complete in ~150ms, ensuring output file has entries.
-	//   - Slow requests (max_tokens=200): take ~20s each at 100ms inter-token-latency,
-	//     ensuring cancel arrives while they are still in-flight or undispatched.
+	//   - Slow requests (max_tokens=200): take ~20s each with dev-deploy sim-model
+	//     defaults (~50ms TTFT + ~100ms inter-token), ensuring cancel arrives while
+	//     they are still in-flight or undispatched.
 	//   - 20 slow requests exceed PerModelMaxConcurrency (default 10), guaranteeing some
 	//     remain undispatched and get drained to the error file as batch_cancelled.
 	var lines []string
@@ -96,7 +115,8 @@ func doTestBatchCancel(t *testing.T) {
 		finalBatch.ErrorFileID)
 
 	// 25 requests total (5 fast + 20 slow). Fast requests should complete before
-	// cancel; slow ones are cancelled in-flight or undispatched → failed.
+	// cancel; undispatched slow requests are drained as batch_cancelled, and
+	// in-flight slow requests are aborted via abortCtx — both count as failed.
 	if finalBatch.RequestCounts.Total != int64(len(lines)) {
 		t.Errorf("total = %d, want %d", finalBatch.RequestCounts.Total, len(lines))
 	}
@@ -448,12 +468,15 @@ func doTestBatchPagination(t *testing.T) {
 }
 
 // doTestBatchExpiration creates a batch with slow requests and a very short
-// completion_window so the SLO fires during processing. It verifies the batch
-// transitions to "expired" status with correct timestamps and partial results.
+// completion_window so the SLO fires before any requests are dispatched. A
+// blocker batch saturates the processor first, so the expiration batch's
+// requests all remain undispatched and are drained as batch_expired.
+// Verifies: expired status, correct timestamps, completed==0, no output file,
+// and an error file with the expired entries.
 //
-// With the simulator configured at TTFT=50ms + inter-token=100ms, each slow
-// request (max_tokens=200) takes ~20s. A 5s completion_window guarantees the
-// SLO fires while requests are in-flight or undispatched.
+// With dev-deploy sim-model defaults (~50ms TTFT + ~100ms inter-token), each
+// slow request (max_tokens=200) takes ~20s. A 5s completion_window guarantees
+// the SLO fires while the blocker still holds all dispatch slots.
 func doTestBatchExpiration(t *testing.T) {
 	t.Helper()
 
@@ -496,8 +519,8 @@ func doTestBatchExpiration(t *testing.T) {
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-batch-expiration-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 
-	// The openai-go SDK's BatchNewParamsCompletionWindow is a string type, so we
-	// can cast any valid Go duration string.
+	// BatchNewParamsCompletionWindow is a string type; the batch-gateway API
+	// accepts Go duration strings like "5s" in addition to the standard "24h".
 	batch, err := client.Batches.New(ctx, openai.BatchNewParams{
 		InputFileID:      fileID,
 		Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
@@ -540,4 +563,346 @@ func doTestBatchExpiration(t *testing.T) {
 	}
 
 	// Blocker batch cleanup is handled by t.Cleanup() registered above.
+}
+
+// doTestCancelIdempotentRetry cancels an in-progress batch twice in a row.
+// Both calls should succeed (200) and the batch should reach cancelled.
+// Guards the idempotent cancel-retry path added.
+func doTestCancelIdempotentRetry(t *testing.T) {
+	t.Helper()
+
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"retry-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+	}
+	fileID := mustCreateFile(t, fmt.Sprintf("test-cancel-retry-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	batchID := mustCreateBatch(t, fileID)
+
+	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
+	time.Sleep(1 * time.Second)
+
+	client := newClient()
+	ctx := context.Background()
+
+	batch1, err := client.Batches.Cancel(ctx, batchID)
+	if err != nil {
+		t.Fatalf("first cancel failed: %v", err)
+	}
+	t.Logf("first cancel: status=%s", batch1.Status)
+
+	batch2, err := client.Batches.Cancel(ctx, batchID)
+	if err != nil {
+		t.Fatalf("second cancel (idempotent retry) failed: %v", err)
+	}
+	t.Logf("second cancel: status=%s", batch2.Status)
+
+	if batch2.Status != openai.BatchStatusCancelling && batch2.Status != openai.BatchStatusCancelled {
+		t.Errorf("expected cancelling or cancelled after retry, got %s", batch2.Status)
+	}
+
+	finalBatch, _ := waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusCancelled)
+	if finalBatch.Status != openai.BatchStatusCancelled {
+		t.Errorf("expected final status cancelled, got %s", finalBatch.Status)
+	}
+}
+
+// doTestCancelTerminalBatchRejected completes a batch, then attempts to cancel it.
+// The API should return 400.
+func doTestCancelTerminalBatchRejected(t *testing.T) {
+	t.Helper()
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-cancel-terminal-%s.jsonl", testRunID), testJSONL)
+	batchID := mustCreateBatch(t, fileID)
+
+	_, _ = waitForBatchStatus(t, batchID, 5*time.Minute, openai.BatchStatusCompleted)
+
+	_, err := newClient().Batches.Cancel(context.Background(), batchID)
+	if err == nil {
+		t.Fatal("expected error when cancelling a completed batch, got nil")
+	}
+
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected openai.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+	t.Logf("cancel of completed batch correctly rejected: %d", apiErr.StatusCode)
+}
+
+// doTestMultiModelBatch creates a batch with requests targeting two different
+// models (testModel and testModelB) and verifies both models appear in the output.
+func doTestMultiModelBatch(t *testing.T) {
+	t.Helper()
+
+	jsonl := strings.Join([]string{
+		fmt.Sprintf(`{"custom_id":"model-a-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello A"}]}}`, testModel),
+		fmt.Sprintf(`{"custom_id":"model-a-2","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"World A"}]}}`, testModel),
+		fmt.Sprintf(`{"custom_id":"model-b-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello B"}]}}`, testModelB),
+		fmt.Sprintf(`{"custom_id":"model-b-2","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"World B"}]}}`, testModelB),
+	}, "\n")
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-multi-model-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+
+	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute, openai.BatchStatusCompleted)
+
+	if finalBatch.RequestCounts.Total != 4 {
+		t.Errorf("total = %d, want 4", finalBatch.RequestCounts.Total)
+	}
+	if finalBatch.RequestCounts.Completed != 4 {
+		t.Errorf("completed = %d, want 4", finalBatch.RequestCounts.Completed)
+	}
+	if finalBatch.RequestCounts.Failed != 0 {
+		t.Errorf("failed = %d, want 0", finalBatch.RequestCounts.Failed)
+	}
+	if finalBatch.OutputFileID == "" {
+		t.Fatal("expected output_file_id to be set")
+	}
+
+	resp, err := newClient().Files.Content(context.Background(), finalBatch.OutputFileID)
+	if err != nil {
+		t.Fatalf("download output file failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	modelsFound := map[string]int{}
+	for _, line := range strings.Split(strings.TrimSpace(string(body)), "\n") {
+		var result struct {
+			Response *struct {
+				Body struct {
+					Model string `json:"model"`
+				} `json:"body"`
+			} `json:"response"`
+		}
+		if err := json.Unmarshal([]byte(line), &result); err != nil {
+			t.Errorf("invalid output line: %v", err)
+			continue
+		}
+		if result.Response != nil {
+			modelsFound[result.Response.Body.Model]++
+		}
+	}
+
+	if modelsFound[testModel] != 2 {
+		t.Errorf("expected 2 responses from %s, got %d", testModel, modelsFound[testModel])
+	}
+	if modelsFound[testModelB] != 2 {
+		t.Errorf("expected 2 responses from %s, got %d", testModelB, modelsFound[testModelB])
+	}
+	t.Logf("multi-model output: %v", modelsFound)
+}
+
+// doTestProgressPolling submits a batch with a mix of fast and slow requests
+// and verifies that request_counts.completed is non-zero while the batch is
+// still in_progress. The fast requests finish quickly, guaranteeing a non-zero
+// completed count well before the slow requests finish — this avoids flakiness
+// from tight timing windows.
+func doTestProgressPolling(t *testing.T) {
+	t.Helper()
+
+	// 5 fast requests (max_tokens=1, ~150ms each) complete almost immediately.
+	// 15 slow requests (max_tokens=200, ~20s each) keep the batch in_progress
+	// long enough for polling to observe completed > 0.
+	var lines []string
+	for i := 1; i <= 5; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"fast %d"}]}}`, i, testModel, i))
+	}
+	for i := 1; i <= 15; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+	}
+	fileID := mustCreateFile(t, fmt.Sprintf("test-progress-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	batchID := mustCreateBatch(t, fileID)
+
+	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
+
+	// Wait a few seconds for fast requests to complete and progress to flush.
+	time.Sleep(5 * time.Second)
+
+	client := newClient()
+	ctx := context.Background()
+	var sawNonZeroCompleted bool
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		b, err := client.Batches.Get(ctx, batchID)
+		if err != nil {
+			t.Fatalf("get batch failed: %v", err)
+		}
+		t.Logf("progress: status=%s completed=%d failed=%d total=%d",
+			b.Status, b.RequestCounts.Completed, b.RequestCounts.Failed, b.RequestCounts.Total)
+
+		if b.RequestCounts.Completed > 0 && b.Status == openai.BatchStatusInProgress {
+			sawNonZeroCompleted = true
+			break
+		}
+		if terminalBatchStatuses[b.Status] {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	if !sawNonZeroCompleted {
+		t.Error("never saw non-zero completed count while batch was in_progress")
+	}
+
+	finalBatch, _ := waitForBatchStatus(t, batchID, 3*time.Minute, openai.BatchStatusCompleted)
+	if finalBatch.RequestCounts.Completed != 20 {
+		t.Errorf("completed = %d, want 20", finalBatch.RequestCounts.Completed)
+	}
+}
+
+// doTestDuplicateCustomID submits a JSONL with duplicate custom_ids.
+// The batch should fail during ingestion.
+func doTestDuplicateCustomID(t *testing.T) {
+	t.Helper()
+
+	jsonl := strings.Join([]string{
+		fmt.Sprintf(`{"custom_id":"dup-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello"}]}}`, testModel),
+		fmt.Sprintf(`{"custom_id":"dup-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"World"}]}}`, testModel),
+	}, "\n")
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-dup-customid-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+
+	finalBatch := waitForIngestionFailure(t, batchID, 2*time.Minute)
+	t.Logf("duplicate custom_id batch reached %s", finalBatch.Status)
+}
+
+// doTestStreamingRejected submits a JSONL with stream:true in the body.
+// The batch should fail during ingestion.
+func doTestStreamingRejected(t *testing.T) {
+	t.Helper()
+
+	jsonl := fmt.Sprintf(`{"custom_id":"stream-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"stream":true,"messages":[{"role":"user","content":"Hello"}]}}`, testModel)
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-streaming-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+
+	finalBatch := waitForIngestionFailure(t, batchID, 2*time.Minute)
+	t.Logf("streaming batch reached %s", finalBatch.Status)
+}
+
+// doTestAllModelsUnregistered submits a JSONL where every request targets a
+// nonexistent model. In per-model mode the preprocessor rejects each line with
+// model_not_found (written to error.jsonl) during ingestion — the same rejection
+// mechanism as MixedSuccessFailure, but here every line is invalid so
+// completed stays 0. The batch still reaches "completed" (not "failed") because
+// the job finishes normally; only individual requests fail.
+// The batch should complete with failed == total.
+func doTestAllModelsUnregistered(t *testing.T) {
+	t.Helper()
+
+	jsonl := strings.Join([]string{
+		`{"custom_id":"bad-1","method":"POST","url":"/v1/chat/completions","body":{"model":"nonexistent-model-xyz","max_tokens":5,"messages":[{"role":"user","content":"Hello"}]}}`,
+		`{"custom_id":"bad-2","method":"POST","url":"/v1/chat/completions","body":{"model":"nonexistent-model-xyz","max_tokens":5,"messages":[{"role":"user","content":"World"}]}}`,
+	}, "\n")
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-all-unregistered-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+
+	finalBatch, _ := waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusCompleted)
+
+	if finalBatch.RequestCounts.Total != 2 {
+		t.Errorf("total = %d, want 2", finalBatch.RequestCounts.Total)
+	}
+	if finalBatch.RequestCounts.Failed != 2 {
+		t.Errorf("failed = %d, want 2", finalBatch.RequestCounts.Failed)
+	}
+	if finalBatch.RequestCounts.Completed != 0 {
+		t.Errorf("completed = %d, want 0", finalBatch.RequestCounts.Completed)
+	}
+	if finalBatch.ErrorFileID == "" {
+		t.Fatal("expected error_file_id to be set")
+	}
+
+	resp, err := newClient().Files.Content(context.Background(), finalBatch.ErrorFileID)
+	if err != nil {
+		t.Fatalf("download error file failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if !strings.Contains(string(body), "model_not_found") {
+		t.Error("expected error file to contain 'model_not_found'")
+	}
+	t.Logf("all-unregistered error file contains model_not_found")
+}
+
+// doTestCreateBatchMissingInputFileID attempts to create a batch without
+// input_file_id. The API should return 400.
+func doTestCreateBatchMissingInputFileID(t *testing.T) {
+	t.Helper()
+
+	_, err := createBatchRaw(newClient(), openai.BatchNewParams{
+		InputFileID:      "",
+		Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
+		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+	})
+	if err == nil {
+		t.Fatal("expected error for missing input_file_id, got nil")
+	}
+
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected openai.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+	t.Logf("missing input_file_id correctly rejected: %d", apiErr.StatusCode)
+}
+
+// doTestCreateBatchInvalidEndpoint attempts to create a batch with an
+// unsupported endpoint. The API should return 400.
+func doTestCreateBatchInvalidEndpoint(t *testing.T) {
+	t.Helper()
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-invalid-endpoint-%s.jsonl", testRunID), testJSONL)
+
+	_, err := createBatchRaw(newClient(), openai.BatchNewParams{
+		InputFileID:      fileID,
+		Endpoint:         openai.BatchNewParamsEndpoint("/v1/invalid"),
+		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid endpoint, got nil")
+	}
+
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected openai.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+	t.Logf("invalid endpoint correctly rejected: %d", apiErr.StatusCode)
+}
+
+// doTestCreateBatchNonexistentFile attempts to create a batch with a
+// file_id that does not exist. The API should return 400.
+func doTestCreateBatchNonexistentFile(t *testing.T) {
+	t.Helper()
+
+	_, err := createBatchRaw(newClient(), openai.BatchNewParams{
+		InputFileID:      "file-does-not-exist-12345",
+		Endpoint:         openai.BatchNewParamsEndpointV1ChatCompletions,
+		CompletionWindow: openai.BatchNewParamsCompletionWindow24h,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected openai.Error, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", apiErr.StatusCode)
+	}
+	t.Logf("nonexistent file correctly rejected: %d", apiErr.StatusCode)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -40,10 +40,12 @@ var (
 	testRunID = fmt.Sprintf("%d", time.Now().UnixNano())
 
 	// testModel is the model name used in batch input; configurable via TEST_MODEL env var.
-	testModel = getEnvOrDefault("TEST_MODEL", "sim-model")
+	testModel  = getEnvOrDefault("TEST_MODEL", "sim-model")
+	testModelB = getEnvOrDefault("TEST_MODEL_B", "sim-model-b")
 
 	// testJSONL is a valid batch input file with two requests.
-	// max_tokens is kept small to finish quickly with the simulator's 500ms inter-token-latency.
+	// max_tokens is kept small so batches finish quickly. Default TEST_MODEL (sim-model)
+	// on dev-deploy uses ~100ms inter-token latency (sim-model-b uses ~500ms).
 	testJSONL = strings.Join([]string{
 		fmt.Sprintf(`{"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello"}]}}`, testModel),
 		fmt.Sprintf(`{"custom_id":"req-2","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"World"}]}}`, testModel),
@@ -61,8 +63,9 @@ var (
 	// verifications that require kubectl (e.g. log grepping) are skipped.
 	testKubectlAvailable bool
 
-	// testPassThroughHeaders lists the headers configured in the apiserver's
-	// pass_through_headers setting (set via dev-deploy.sh).
+	// testPassThroughHeaders maps header names (matching apiserver pass_through_headers
+	// configured by dev-deploy.sh) to the values the e2e client sends when asserting
+	// pass-through behavior.
 	testPassThroughHeaders = map[string]string{
 		"X-E2E-Pass-Through-1": "test-value-1",
 		"X-E2E-Pass-Through-2": "test-value-2",
@@ -91,5 +94,6 @@ func TestE2E(t *testing.T) {
 	t.Run("MultiTenant", testMultiTenant)
 	t.Run("GarbageCollection", testGarbageCollection)
 	t.Run("Observability", testObservability)
+	t.Run("ProcessorGracefulShutdown", testProcessorGracefulShutdown)
 	t.Run("HelmUpgrade", testHelmUpgrade)
 }

--- a/test/e2e/files_test.go
+++ b/test/e2e/files_test.go
@@ -40,7 +40,7 @@ func testFiles(t *testing.T) {
 
 // doTestDuplicateFileUpload verifies that uploading two files with the same
 // filename under the same tenant succeeds. Each upload should get a unique
-// fileID and storage path. Reproduces https://github.com/llm-d-incubation/batch-gateway/issues/214
+// fileID. Reproduces https://github.com/llm-d-incubation/batch-gateway/issues/214
 func doTestDuplicateFileUpload(t *testing.T) {
 	t.Helper()
 

--- a/test/e2e/helm_upgrade_test.go
+++ b/test/e2e/helm_upgrade_test.go
@@ -236,7 +236,7 @@ func parseModelGatewayMaxRetries(t *testing.T, configYAML, model string) int {
 // used so the upgrade test asserts a real change rather than a hard-coded sentinel.
 func alternateIntForHelmTest(baseline int) int {
 	if baseline == 0 {
-		return 3 // typical chart default for model gateway maxRetries
+		return 3 // dev-deploy sets maxRetries=3 for model gateways
 	}
 	return 0
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -129,6 +129,12 @@ func mustCreateBatch(t *testing.T, fileID string, opts ...option.RequestOption) 
 	return batch.ID
 }
 
+// createBatchRaw calls the batch creation API and returns the response or error
+// without fataling. Used by validation tests that expect errors.
+func createBatchRaw(client *openai.Client, params openai.BatchNewParams) (*openai.Batch, error) {
+	return client.Batches.New(context.Background(), params)
+}
+
 // terminalBatchStatuses are statuses that a batch cannot transition out of.
 var terminalBatchStatuses = map[openai.BatchStatus]bool{
 	openai.BatchStatusCompleted: true,
@@ -187,6 +193,38 @@ func waitForBatchStatus(t *testing.T, batchID string, timeout time.Duration, tar
 	t.Fatalf("batch %s did not reach status %v within %v (last status: %q)",
 		batchID, targets, timeout, lastBatch.Status)
 	return nil, nil // unreachable
+}
+
+// waitForIngestionFailure polls a batch until it reaches "failed" status.
+// Unlike waitForBatchStatus, it skips validateBatchResults (which rejects
+// Total==0 for non-cancelled batches) and result-file fetching, since
+// ingestion failures legitimately have Total==0 and no output files.
+func waitForIngestionFailure(t *testing.T, batchID string, timeout time.Duration) *openai.Batch {
+	t.Helper()
+
+	client := newClient()
+	deadline := time.Now().Add(timeout)
+	if d, ok := t.Deadline(); ok && d.Before(deadline) {
+		deadline = d.Add(-5 * time.Second)
+	}
+
+	for time.Now().Before(deadline) {
+		b, err := client.Batches.Get(context.Background(), batchID)
+		if err != nil {
+			t.Fatalf("retrieve batch failed: %v", err)
+		}
+		t.Logf("batch %s status: %s", batchID, b.Status)
+
+		if b.Status == openai.BatchStatusFailed {
+			return b
+		}
+		if terminalBatchStatuses[b.Status] {
+			t.Fatalf("batch %s reached terminal status %q instead of failed", batchID, b.Status)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("batch %s did not reach failed within %v", batchID, timeout)
+	return nil
 }
 
 // ── Batch validation ─────────────────────────────────────────────────────
@@ -254,7 +292,7 @@ func validateTerminalBatch(t *testing.T, b *openai.Batch) {
 	}
 }
 
-// batchResults holds the line counts from output and error files.
+// batchResults holds downloaded output/error file bodies and derived line counts.
 type batchResults struct {
 	OutputLines int
 	ErrorLines  int
@@ -327,7 +365,7 @@ func fetchBatchResults(t *testing.T, batch *openai.Batch) batchResults {
 
 // validateBatchResults checks all universal invariants on the batch results:
 //   - input lines == Total, output lines == Completed, error lines == Failed
-//   - every input custom_id appears in either the output or error file
+//   - every non-empty input custom_id appears in either the output or error file
 //   - output lines have valid response structure (status_code=200, choices, model)
 //   - error lines have valid error structure (non-empty code and message)
 //   - no duplicate custom_ids within output or error files

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The llm-d Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+)
+
+// testProcessorGracefulShutdown covers the processor shutting down under Kubernetes
+// SIGTERM (pod delete or rollout restart), re-enqueuing the in-flight job, and a
+// replacement pod finishing the batch. Not recoverStaleJobs (workdir scan on startup).
+func testProcessorGracefulShutdown(t *testing.T) {
+	t.Run("PodDeletedMidJob", doTestPodDeletedMidJob)
+	t.Run("RollingRestartReEnqueue", doTestRollingRestartReEnqueue)
+}
+
+// doTestPodDeletedMidJob submits a batch with long-running requests (max_tokens=200
+// on testModel; dev-deploy's default sim-model uses ~50ms TTFT and ~100ms
+// inter-token latency), deletes the processor pod mid-execution, and verifies the
+// batch reaches a terminal state after a replacement pod comes up.
+//
+// Pod deletion usually delivers SIGTERM first; the processor then cancels work and
+// re-enqueues the job (see Processor.handleJobError in job_runner.go for the
+// context.Canceled path). A new pod dequeues and reprocesses the job from scratch
+// (no checkpoint/resume). This is not the same as recoverStaleJobs (workdir scan):
+// that path needs leftover on-disk job state inside the same pod volume.
+func doTestPodDeletedMidJob(t *testing.T) {
+	t.Helper()
+
+	if !testKubectlAvailable {
+		t.Skip("kubectl not available, skipping processor pod-delete graceful-shutdown test")
+	}
+
+	var lines []string
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"pod-del-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+	}
+	fileID := mustCreateFile(t, fmt.Sprintf("test-pod-delete-graceful-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	batchID := mustCreateBatch(t, fileID)
+
+	// Wait for in_progress so the processor has picked up the job.
+	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
+	time.Sleep(2 * time.Second)
+
+	// Delete the processor pod. The API typically SIGTERMs the container first (even
+	// with --grace-period=0 / --force the window may be short), which triggers the
+	// processor's shutdown path and often re-enqueues the in-flight job — unlike an
+	// immediate SIGKILL-only "hard crash".
+	t.Log("deleting processor pod...")
+	out, err := exec.Command("kubectl", "delete", "pod",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
+		"-n", testNamespace,
+		"--grace-period=0", "--force",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl delete pod failed: %v\n%s", err, out)
+	}
+	t.Logf("processor pod delete issued: %s", strings.TrimSpace(string(out)))
+
+	// Wait for the new pod to become ready.
+	waitForReady(t, testProcessorObsURL, 2*time.Minute)
+	t.Log("new processor pod is ready")
+
+	// Expect a terminal status after pod replacement. completed is the usual outcome
+	// when SIGTERM allows re-enqueue and the new pod finishes the job. failed is still
+	// allowed (e.g. re-enqueue failed, SIGKILL raced shutdown, or later processing error).
+	// The key assertion is that the job does NOT stay stuck in in_progress.
+	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
+		openai.BatchStatusCompleted, openai.BatchStatusFailed)
+
+	t.Logf("pod delete (graceful shutdown path): batch %s reached %s (completed=%d, failed=%d, total=%d)",
+		batchID, finalBatch.Status,
+		finalBatch.RequestCounts.Completed,
+		finalBatch.RequestCounts.Failed,
+		finalBatch.RequestCounts.Total)
+}
+
+// doTestRollingRestartReEnqueue submits a batch with the same slow-request pattern
+// as doTestPodDeletedMidJob, triggers a rolling restart of the processor deployment,
+// and verifies the batch eventually completes. Exercises the SIGTERM ->
+// context.Canceled -> re-enqueue path.
+func doTestRollingRestartReEnqueue(t *testing.T) {
+	t.Helper()
+
+	if !testKubectlAvailable {
+		t.Skip("kubectl not available, skipping rolling restart test")
+	}
+
+	var lines []string
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"restart-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+	}
+	fileID := mustCreateFile(t, fmt.Sprintf("test-rolling-restart-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	batchID := mustCreateBatch(t, fileID)
+
+	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
+	time.Sleep(2 * time.Second)
+
+	// Trigger a rolling restart (graceful shutdown via SIGTERM).
+	deployment := fmt.Sprintf("%s-processor", testHelmRelease)
+	t.Logf("triggering rolling restart of %s...", deployment)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "kubectl", "rollout", "restart",
+		fmt.Sprintf("deployment/%s", deployment),
+		"-n", testNamespace,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl rollout restart failed: %v\n%s", err, out)
+	}
+	t.Logf("rollout restart triggered: %s", strings.TrimSpace(string(out)))
+
+	// Wait for rollout to complete.
+	waitForRollout(t, deployment)
+	waitForReady(t, testProcessorObsURL, 2*time.Minute)
+	t.Log("processor rollout complete and ready")
+
+	// Graceful shutdown (SIGTERM) triggers context.Canceled in handleJobError,
+	// which re-enqueues the job via detached context. The new pod picks it up
+	// from the queue and completes it. Stricter than PodDeletedMidJob: we expect completed.
+	// failed is accepted in waitForBatchStatus to avoid a fatal on edge cases
+	// (e.g. re-enqueue itself failed), but we assert completed below.
+	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
+		openai.BatchStatusCompleted, openai.BatchStatusFailed)
+
+	t.Logf("rolling restart: batch %s reached %s (completed=%d, failed=%d, total=%d)",
+		batchID, finalBatch.Status,
+		finalBatch.RequestCounts.Completed,
+		finalBatch.RequestCounts.Failed,
+		finalBatch.RequestCounts.Total)
+
+	if finalBatch.Status != openai.BatchStatusCompleted {
+		t.Errorf("expected batch to complete after rolling restart, got %s", finalBatch.Status)
+	}
+}

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -25,29 +25,36 @@ import (
 	"github.com/openai/openai-go/v3"
 )
 
-// testProcessorGracefulShutdown covers the processor shutting down under Kubernetes
-// SIGTERM (pod delete or rollout restart), re-enqueuing the in-flight job, and a
-// replacement pod finishing the batch. Not recoverStaleJobs (workdir scan on startup).
+// testProcessorGracefulShutdown covers the processor's SIGTERM -> context.Canceled
+// -> re-enqueue path using two different Kubernetes triggers:
+//   - PodDeleteMidJob: kubectl delete pod (standard termination grace period)
+//   - RollingRestartReEnqueue: kubectl rollout restart
+//
+// Both deliver SIGTERM and wait terminationGracePeriodSeconds (60s) before
+// SIGKILL, giving the processor ample time to re-enqueue in-flight jobs.
+// Neither test covers recoverStaleJobs (workdir scan on startup) or true
+// hard-crash (SIGKILL-only) scenarios.
 func testProcessorGracefulShutdown(t *testing.T) {
-	t.Run("PodDeletedMidJob", doTestPodDeletedMidJob)
+	t.Run("PodDeleteMidJob", doTestPodDeleteMidJob)
 	t.Run("RollingRestartReEnqueue", doTestRollingRestartReEnqueue)
 }
 
-// doTestPodDeletedMidJob submits a batch with long-running requests (max_tokens=200
-// on testModel; dev-deploy's default sim-model uses ~50ms TTFT and ~100ms
-// inter-token latency), deletes the processor pod mid-execution, and verifies the
-// batch reaches a terminal state after a replacement pod comes up.
+// doTestPodDeleteMidJob submits a batch with long-running requests
+// (max_tokens=200 on testModel; dev-deploy's default sim-model uses ~50ms TTFT
+// and ~100ms inter-token latency), deletes the processor pod mid-execution, and
+// verifies the batch completes after a replacement pod comes up.
 //
-// Pod deletion usually delivers SIGTERM first; the processor then cancels work and
-// re-enqueues the job (see Processor.handleJobError in job_runner.go for the
-// context.Canceled path). A new pod dequeues and reprocesses the job from scratch
-// (no checkpoint/resume). This is not the same as recoverStaleJobs (workdir scan):
-// that path needs leftover on-disk job state inside the same pod volume.
-func doTestPodDeletedMidJob(t *testing.T) {
+// kubectl delete pod sends SIGTERM and respects the pod's
+// terminationGracePeriodSeconds (60s). The processor catches SIGTERM via
+// interrupt.ContextWithSignal, cancels the polling context, and in-flight
+// workers re-enqueue the job via a detached context (see Processor.handleJobError
+// in job_runner.go). A new pod dequeues and reprocesses the job from scratch
+// (no checkpoint/resume).
+func doTestPodDeleteMidJob(t *testing.T) {
 	t.Helper()
 
 	if !testKubectlAvailable {
-		t.Skip("kubectl not available, skipping processor pod-delete graceful-shutdown test")
+		t.Skip("kubectl not available, skipping processor pod-delete test")
 	}
 
 	var lines []string
@@ -55,22 +62,19 @@ func doTestPodDeletedMidJob(t *testing.T) {
 		lines = append(lines, fmt.Sprintf(
 			`{"custom_id":"pod-del-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
 	}
-	fileID := mustCreateFile(t, fmt.Sprintf("test-pod-delete-graceful-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	fileID := mustCreateFile(t, fmt.Sprintf("test-pod-delete-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)
 
 	// Wait for in_progress so the processor has picked up the job.
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 	time.Sleep(2 * time.Second)
 
-	// Delete the processor pod. The API typically SIGTERMs the container first (even
-	// with --grace-period=0 / --force the window may be short), which triggers the
-	// processor's shutdown path and often re-enqueues the in-flight job — unlike an
-	// immediate SIGKILL-only "hard crash".
+	// Delete the processor pod. Kubelet delivers SIGTERM and waits
+	// terminationGracePeriodSeconds (60s) before SIGKILL.
 	t.Log("deleting processor pod...")
 	out, err := exec.Command("kubectl", "delete", "pod",
 		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
 		"-n", testNamespace,
-		"--grace-period=0", "--force",
 	).CombinedOutput()
 	if err != nil {
 		t.Fatalf("kubectl delete pod failed: %v\n%s", err, out)
@@ -81,24 +85,27 @@ func doTestPodDeletedMidJob(t *testing.T) {
 	waitForReady(t, testProcessorObsURL, 2*time.Minute)
 	t.Log("new processor pod is ready")
 
-	// Expect a terminal status after pod replacement. completed is the usual outcome
-	// when SIGTERM allows re-enqueue and the new pod finishes the job. failed is still
-	// allowed (e.g. re-enqueue failed, SIGKILL raced shutdown, or later processing error).
-	// The key assertion is that the job does NOT stay stuck in in_progress.
+	// The re-enqueue path should succeed reliably with the full grace period.
+	// failed is accepted in waitForBatchStatus to avoid a fatal on unlikely
+	// edge cases (e.g. transient Redis error), but we expect completed.
 	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
 		openai.BatchStatusCompleted, openai.BatchStatusFailed)
 
-	t.Logf("pod delete (graceful shutdown path): batch %s reached %s (completed=%d, failed=%d, total=%d)",
+	t.Logf("pod delete: batch %s reached %s (completed=%d, failed=%d, total=%d)",
 		batchID, finalBatch.Status,
 		finalBatch.RequestCounts.Completed,
 		finalBatch.RequestCounts.Failed,
 		finalBatch.RequestCounts.Total)
+
+	if finalBatch.Status != openai.BatchStatusCompleted {
+		t.Errorf("expected batch to complete after pod delete, got %s", finalBatch.Status)
+	}
 }
 
-// doTestRollingRestartReEnqueue submits a batch with the same slow-request pattern
-// as doTestPodDeletedMidJob, triggers a rolling restart of the processor deployment,
-// and verifies the batch eventually completes. Exercises the SIGTERM ->
-// context.Canceled -> re-enqueue path.
+// doTestRollingRestartReEnqueue submits a batch with the same slow-request
+// pattern as doTestPodDeleteMidJob, triggers a rolling restart of the processor
+// deployment, and verifies the batch eventually completes. Same SIGTERM ->
+// re-enqueue path, different trigger.
 func doTestRollingRestartReEnqueue(t *testing.T) {
 	t.Helper()
 
@@ -136,11 +143,9 @@ func doTestRollingRestartReEnqueue(t *testing.T) {
 	waitForReady(t, testProcessorObsURL, 2*time.Minute)
 	t.Log("processor rollout complete and ready")
 
-	// Graceful shutdown (SIGTERM) triggers context.Canceled in handleJobError,
-	// which re-enqueues the job via detached context. The new pod picks it up
-	// from the queue and completes it. Stricter than PodDeletedMidJob: we expect completed.
-	// failed is accepted in waitForBatchStatus to avoid a fatal on edge cases
-	// (e.g. re-enqueue itself failed), but we assert completed below.
+	// Same re-enqueue path as PodDeleteMidJob. completed is expected; failed
+	// is accepted in waitForBatchStatus to avoid a fatal on unlikely edge
+	// cases, but we assert completed below.
 	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
 		openai.BatchStatusCompleted, openai.BatchStatusFailed)
 


### PR DESCRIPTION
## Why is this PR needed?
The existing e2e suite covered the happy path and basic cancel/expiration but
lacked coverage for several API edge cases and error paths. Several comments
across e2e files were also inaccurate — referencing wrong latency numbers,
claiming behaviors the code doesn't assert, or conflicting with the design
document. The README was outdated (wrong env var names, wrong defaults, missing
variables).

## What does this PR do?
**New e2e test scenarios (12 tests):**
- Cancel: idempotent retry (cancel twice → 200 both times), reject cancel on
  completed batch (→ 400)
- Multi-model: batch with testModel + testModelB, verify both appear in output
- Progress polling: fast+slow request mix, observe completed > 0 while
  in_progress
- Ingestion failures: duplicate custom_id, stream:true → failed
- All-unregistered models: completed with failed == total, error file contains
  model_not_found
- Batch create validation: missing input_file_id, invalid endpoint, nonexistent
  file → 400
- Processor graceful shutdown: pod delete mid-job + rolling restart

**Comment accuracy fixes:**
- Expiration test: "partial results" → all-undispatched, completed==0 scenario
- Cancel test: clarify abortCtx aborts in-flight vs undispatched drain
- Simulator latency: include TTFT (~50ms) in timing references
- AllModelsUnregistered: correct ingestion-vs-execution taxonomy to match
  preprocessor behavior
- waitForIngestionFailure: correct skip reason (validateBatchResults, not
  validateTerminalBatch)
- validateBatchResults: "every custom_id" → "every non-empty custom_id"
- files_test: remove unasserted "storage path" claim
- helm_upgrade_test: "chart default" → "dev-deploy sets maxRetries=3"

**README updates (test/e2e/README.md):**
- TEST_BASE_URL → TEST_APISERVER_URL, http → https
- port-forward description → NodePort
- LOG_VERBOSITY default 4 → 5, S3_SECRET_ACCESS_KEY → minioadmin
- Document all 12 e2e environment variables

**New helpers:**
- `createBatchRaw`: non-fatal batch creation for validation error tests
- `waitForIngestionFailure`: polls for failed status without validateBatchResults

## How was this tested?
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)
- [ ] Manual testing performed

## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues
N/A
