### PR TITLE
chore: add image repo parameters to install script

### DIFF
--- a/examples/deploy-demo/README.md
+++ b/examples/deploy-demo/README.md
@@ -16,19 +16,63 @@ UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-rhoai.sh uninstall
 UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-maas.sh uninstall
 ```
 
-Use that only on **ephemeral or dedicated** demo clusters. See [issue #309](https://github.com/opendatahub-io/batch-gateway/issues/309) for background.
+Use that only on **ephemeral or dedicated** demo clusters. See [issue #309](https://github.com/llm-d-incubation/batch-gateway/issues/309) for background.
 
 ## 1) Overview
 
 | Script | Cluster | Description |
 |--------|---------|-------------|
-| `deploy-k8s.sh` | Kubernetes/OpenShift | Deploys llm-d + Kuadrant + batch-gateway |
 | `deploy-rhoai.sh` | OpenShift | Deploys batch-gateway on top of RHOAI + RHCL |
+| `deploy-k8s.sh` | Kubernetes/OpenShift | Deploys llm-d + Kuadrant + batch-gateway |
 | `deploy-maas.sh` | OpenShift | Deploys batch-gateway on top of MaaS |
 
 **Prerequisites**: You must be logged in to the target cluster before running any script. Use `kubectl config current-context` (or `oc whoami` on OpenShift) to verify.
 
-## 2) deploy-k8s.sh
+## 2) deploy-rhoai.sh
+
+### Components Installed
+
+| Component | Details |
+|-----------|---------|
+| cert-manager operator | OLM-managed |
+| LeaderWorkerSet operator | OLM-managed |
+| OpenShift Gateway | GatewayClass + Gateway (auto-installs Service Mesh) |
+| RHCL | Productized Kuadrant (OLM-managed) |
+| RHOAI | DSCInitialization + DataScienceCluster |
+| Redis | Batch job queue (Bitnami Helm chart) |
+| PostgreSQL | Batch metadata store (Bitnami Helm chart) |
+| batch-gateway | apiserver + processor (Helm chart) |
+
+### Auth & Rate Limits
+
+| Policy | Target | Limit |
+|--------|--------|-------|
+| AuthPolicy (kubernetesTokenReview) | batch-route | — |
+| TokenRateLimitPolicy | Gateway (inference) | 500 tokens/1min per user |
+| RateLimitPolicy | batch-route | 20 req/1min per user |
+
+### Usage
+
+```bash
+bash examples/deploy-demo/deploy-rhoai.sh install
+bash examples/deploy-demo/deploy-rhoai.sh test
+bash examples/deploy-demo/deploy-rhoai.sh uninstall
+UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-rhoai.sh uninstall   # optional: remove RHOAI operators, Kuadrant, cert-manager, etc.
+```
+
+### Install Examples
+
+| Mode | Command |
+|------|---------|
+| Local chart (default) | `bash examples/deploy-demo/deploy-rhoai.sh install` |
+| Specific commit | `BATCH_DEV_VERSION=1f925ff bash examples/deploy-demo/deploy-rhoai.sh install` |
+| Released OCI chart | `BATCH_RELEASE_VERSION=v0.1.0 bash examples/deploy-demo/deploy-rhoai.sh install` |
+| Overwrite with Midstream images | `BATCH_IMAGE_TAG=v0.1.0 BATCH_APISERVER_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-apiserver BATCH_PROCESSOR_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-processor BATCH_GC_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-gc bash examples/deploy-demo/deploy-rhoai.sh install` |
+
+> `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together. See [Environment Variables](#environment-variables) for all available parameters.
+
+
+## 3) deploy-k8s.sh
 
 ### Components Installed
 
@@ -60,38 +104,16 @@ bash examples/deploy-demo/deploy-k8s.sh uninstall
 UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-k8s.sh uninstall   # optional: remove Kuadrant/Istio/cert-manager too
 ```
 
+### Install Examples
 
-## 3) deploy-rhoai.sh
+| Mode | Command |
+|------|---------|
+| Local chart (default) | `bash examples/deploy-demo/deploy-k8s.sh install` |
+| Specific commit | `BATCH_DEV_VERSION=1f925ff bash examples/deploy-demo/deploy-k8s.sh install` |
+| Released OCI chart | `BATCH_RELEASE_VERSION=v0.1.0 bash examples/deploy-demo/deploy-k8s.sh install` |
+| Overwrite with Midstream images | `BATCH_IMAGE_TAG=v0.1.0 BATCH_APISERVER_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-apiserver BATCH_PROCESSOR_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-processor BATCH_GC_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-gc bash examples/deploy-demo/deploy-k8s.sh install` |
 
-### Components Installed
-
-| Component | Details |
-|-----------|---------|
-| cert-manager operator | OLM-managed |
-| LeaderWorkerSet operator | OLM-managed |
-| OpenShift Gateway | GatewayClass + Gateway (auto-installs Service Mesh) |
-| RHCL | Productized Kuadrant (OLM-managed) |
-| RHOAI | DSCInitialization + DataScienceCluster |
-| Redis | Batch job queue (Bitnami Helm chart) |
-| PostgreSQL | Batch metadata store (Bitnami Helm chart) |
-| batch-gateway | apiserver + processor (Helm chart) |
-
-### Auth & Rate Limits
-
-| Policy | Target | Limit |
-|--------|--------|-------|
-| AuthPolicy (kubernetesTokenReview) | batch-route | — |
-| TokenRateLimitPolicy | Gateway (inference) | 500 tokens/1min per user |
-| RateLimitPolicy | batch-route | 20 req/1min per user |
-
-### Usage
-
-```bash
-bash examples/deploy-demo/deploy-rhoai.sh install
-bash examples/deploy-demo/deploy-rhoai.sh test
-bash examples/deploy-demo/deploy-rhoai.sh uninstall
-UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-rhoai.sh uninstall   # optional: remove RHOAI operators, Kuadrant, cert-manager, etc.
-```
+> `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together. See [Environment Variables](#environment-variables) for all available parameters.
 
 
 ## 4) deploy-maas.sh
@@ -125,28 +147,18 @@ bash examples/deploy-demo/deploy-maas.sh uninstall
 UNINSTALL_ALL=1 bash examples/deploy-demo/deploy-maas.sh uninstall
 ```
 
+### Install Examples
+
+| Mode | Command |
+|------|---------|
+| Local chart (default) | `bash examples/deploy-demo/deploy-maas.sh install` |
+| Specific commit | `BATCH_DEV_VERSION=1f925ff bash examples/deploy-demo/deploy-maas.sh install` |
+| Released OCI chart | `BATCH_RELEASE_VERSION=v0.1.0 bash examples/deploy-demo/deploy-maas.sh install` |
+| Overwrite with Midstream images | `BATCH_IMAGE_TAG=v0.1.0 BATCH_APISERVER_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-apiserver BATCH_PROCESSOR_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-processor BATCH_GC_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-gc bash examples/deploy-demo/deploy-maas.sh install` |
+
+> `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together. See [Environment Variables](#environment-variables) for all available parameters.
+
 If you change MaaS test user/password env vars and run `install` again on the **same** cluster, delete the OAuth htpasswd secret first so it is recreated: `oc delete secret htpass-secret -n openshift-config`.
-
-## Installation Modes
-
-**Local chart (default):**
-```bash
-bash examples/deploy-demo/deploy-rhoai.sh install
-```
-
-**Install from a specific commit (chart + image):**
-```bash
-BATCH_DEV_VERSION=1f925ff \
-  bash examples/deploy-demo/deploy-rhoai.sh install
-```
-
-**Install from released OCI Helm chart:**
-```bash
-BATCH_RELEASE_VERSION=v1.0.0 \
-  bash examples/deploy-demo/deploy-rhoai.sh install
-```
-
-> `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together.
 
 ## Environment Variables
 
@@ -155,20 +167,31 @@ BATCH_RELEASE_VERSION=v1.0.0 \
 | `BATCH_HELM_RELEASE` | `batch-gateway` | all | Helm release name |
 | `BATCH_RELEASE_VERSION` | — | all | Install from released OCI chart (e.g. `v1.0.0`). Cannot be used with `BATCH_DEV_VERSION` |
 | `BATCH_DEV_VERSION` | `local` | all | Image tag / commit SHA. `local` uses local chart + `latest` image. Cannot be used with `BATCH_RELEASE_VERSION` |
+| `BATCH_IMAGE_TAG` | — | all | Override image tag for all components. Takes precedence over `BATCH_RELEASE_VERSION` / `BATCH_DEV_VERSION` derived tags |
+| `BATCH_APISERVER_REPO` | — | all | Override apiserver image repository |
+| `BATCH_PROCESSOR_REPO` | — | all | Override processor image repository |
+| `BATCH_GC_REPO` | — | all | Override gc image repository |
 | `BATCH_DB_TYPE` | `postgresql` | all | Database backend: `postgresql` or `redis` |
 | `BATCH_STORAGE_TYPE` | `s3` | all | File storage: `fs` or `s3` |
 | `DEMO_TLS_INSECURE_SKIP_VERIFY` | `1` | all | Disables TLS certificate verification for processor → model gateway and Istio Gateway → batch apiserver (**demo/lab only**, [CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Default `1` since demo scripts use self-signed certs. Set to `0` if you have trusted CA certs. |
 | `BATCH_NAMESPACE` | `batch-api` | all | Namespace for batch-gateway |
 | `LLM_NAMESPACE` | `llm` | all | Namespace for model serving |
+| `GATEWAY_NAME` | `openshift-ai-inference` / `istio-gateway` / `maas-default-gateway` | per-script | Gateway resource name |
+| `GATEWAY_NAMESPACE` | `openshift-ingress` / `istio-ingress` | per-script | Gateway namespace |
+| `OPERATOR_TYPE` | `rhoai` | rhoai | `rhoai` or `odh` |
+| `RHOAI_VERSION` | `3.4` | rhoai | RHOAI operator version |
+| `RHOAI_CHANNEL` | `stable-${RHOAI_VERSION}` | rhoai | RHOAI subscription channel |
+| `MODEL_NAME` | `facebook/opt-125m` | rhoai | Model name for simulator |
+| `MODEL_REPLICAS` | `2` | rhoai | Number of model replicas |
+| `MODEL_URI` | `hf://sshleifer/tiny-gpt2` | rhoai | Model URI for simulator |
+| `SIM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.7.1` | rhoai | Simulator image |
 | `LLMD_VERSION` | `main` | k8s | llm-d git ref to install |
 | `LLMD_RELEASE_POSTFIX` | `llmd` | k8s | Helm release postfix |
 | `GATEWAY_LOCAL_PORT` | `8080` | k8s | Port-forward local port |
 | `MODEL_NAME` | `random` | k8s | Model name for routing |
-| `OPERATOR_TYPE` | `rhoai` | rhoai | `rhoai` or `odh` |
-| `MODEL_NAME` | `facebook/opt-125m` | rhoai | Model name for simulator |
-| `MODEL_REPLICAS` | `2` | rhoai | Number of model replicas |
-| `SIM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:v0.7.1` | rhoai | Simulator image |
+| `KUADRANT_VERSION` | `1.3.1` | k8s | Kuadrant Helm chart version |
 | `MAAS_REF` | `main` | maas | MaaS git ref |
+| `MAAS_MODEL_NAME` | `facebook/opt-125m` | maas | Model name for batch requests |
 | `MAAS_TEST_USER` | `testuser` | maas | Test username |
 | `MAAS_TEST_PASS` | `testpass` | maas | Test password |
 | `MAAS_TEST_GROUP` | `tier-free-users` | maas | Test user group |

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -80,6 +80,20 @@ BATCH_MINIO_RELEASE="${BATCH_MINIO_RELEASE:-minio}"
 MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
 MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
 MINIO_BUCKET="${MINIO_BUCKET:-batch-gateway}"
+# Image overrides. When set, these take precedence over defaults derived from
+# BATCH_RELEASE_VERSION / BATCH_DEV_VERSION. Leave unset to use chart defaults.
+# Example (upstream):
+#   BATCH_IMAGE_TAG=v0.1.0 BATCH_APISERVER_REPO=ghcr.io/llm-d-incubation/batch-gateway-apiserver \
+#   BATCH_PROCESSOR_REPO=ghcr.io/llm-d-incubation/batch-gateway-processor \
+#   BATCH_GC_REPO=ghcr.io/llm-d-incubation/batch-gateway-gc ./deploy-rhoai.sh
+# Example (midstream):
+#   BATCH_IMAGE_TAG=v0.1.0 BATCH_APISERVER_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-apiserver \
+#   BATCH_PROCESSOR_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-processor \
+#   BATCH_GC_REPO=quay.io/redhat-user-workloads/open-data-hub-tenant/temp-batch-gateway-gc ./deploy-rhoai.sh
+BATCH_IMAGE_TAG="${BATCH_IMAGE_TAG:-}"
+BATCH_APISERVER_REPO="${BATCH_APISERVER_REPO:-}"
+BATCH_PROCESSOR_REPO="${BATCH_PROCESSOR_REPO:-}"
+BATCH_GC_REPO="${BATCH_GC_REPO:-}"
 
 # Temp directory cleanup (used by install_batch_gateway)
 _BATCH_TMP_DIR=""
@@ -571,14 +585,14 @@ install_batch_gateway() {
 
     # Print installed versions and verify image tags
     local expected_tag
-    if [ -n "${BATCH_RELEASE_VERSION}" ]; then
+    if [ -n "${BATCH_IMAGE_TAG}" ]; then
+        expected_tag="${BATCH_IMAGE_TAG}"
+    elif [ -n "${BATCH_RELEASE_VERSION}" ]; then
         expected_tag="${BATCH_RELEASE_VERSION}"
+    elif [ "${BATCH_DEV_VERSION}" = "local" ]; then
+        expected_tag="latest"
     else
-        if [ "${BATCH_DEV_VERSION}" = "local" ]; then
-            expected_tag="latest"
-        else
-            expected_tag="${BATCH_DEV_VERSION}"
-        fi
+        expected_tag="${BATCH_DEV_VERSION}"
     fi
     step "Installed batch-gateway components:"
     local mismatch=false
@@ -621,9 +635,20 @@ do_deploy_batch_gateway() {
         --set "global.secretName=${BATCH_APP_SECRET_NAME}"
     )
 
-    # Only override image tags for non-release installs.
-    # Released OCI charts already have correct image tags baked in.
-    if [ -z "${BATCH_RELEASE_VERSION}" ]; then
+    # Image repository overrides (when set via env vars)
+    [ -n "${BATCH_APISERVER_REPO}" ]  && helm_args+=(--set "apiserver.image.repository=${BATCH_APISERVER_REPO}")
+    [ -n "${BATCH_PROCESSOR_REPO}" ]  && helm_args+=(--set "processor.image.repository=${BATCH_PROCESSOR_REPO}")
+    [ -n "${BATCH_GC_REPO}" ]         && helm_args+=(--set "gc.image.repository=${BATCH_GC_REPO}")
+
+    # Image tag: explicit BATCH_IMAGE_TAG takes precedence; otherwise derive from
+    # BATCH_DEV_VERSION for non-release installs (release charts have tags baked in).
+    if [ -n "${BATCH_IMAGE_TAG}" ]; then
+        helm_args+=(
+            --set "apiserver.image.tag=${BATCH_IMAGE_TAG}"
+            --set "processor.image.tag=${BATCH_IMAGE_TAG}"
+            --set "gc.image.tag=${BATCH_IMAGE_TAG}"
+        )
+    elif [ -z "${BATCH_RELEASE_VERSION}" ]; then
         local image_tag="latest"
         [ "${BATCH_DEV_VERSION}" != "local" ] && image_tag="${BATCH_DEV_VERSION}"
         helm_args+=(
@@ -686,7 +711,7 @@ do_deploy_batch_gateway() {
 #   4. sleep 60
 #   5. Batch Authentication   (unauthenticated -> 401, authenticated -> 200)
 #   6. Batch Authorization    (unauthorized batch -> LLM route rejects)
-#   7. Batch Lifecycle        (upload + create + poll -> completed)
+#   7. Batch Lifecycle        (upload + create + poll -> completed + download output)
 #   8. Batch Request Rate Limit (rapid requests -> 429)
 #
 # llm_url:            inference endpoint (e.g. .../v1/chat/completions)
@@ -756,6 +781,7 @@ run_tests() {
         local input_file="/tmp/batch-$$-${RANDOM}.jsonl"
         cat > "${input_file}" <<JSONL
 {"custom_id":"req-1","method":"POST","url":"/v1/chat/completions","body":{"model":"${model}","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}}
+{"custom_id":"req-2","method":"POST","url":"/v1/chat/completions","body":{"model":"${model}","messages":[{"role":"user","content":"Tell me a joke"}],"max_tokens":50}}
 JSONL
         response=$(curl -sk -w "\n%{http_code}" -X POST "${url}/v1/files" \
             -H "${header}" -F "purpose=batch" -F "file=@${input_file}")
@@ -895,6 +921,26 @@ JSONL
         _poll_batch "${batch_url}" "${_BATCH_ID}" "${authorized_header}"
         if [ "$_BATCH_STATUS" = "completed" ]; then
             pass_test "Batch completed successfully"
+
+            next_test "Download output file"
+            local output_file_id
+            output_file_id=$(curl -sk "${batch_url}/v1/batches/${_BATCH_ID}" \
+                -H "${authorized_header}" | jq -r '.output_file_id // empty')
+            if [ -n "$output_file_id" ]; then
+                local output_content
+                output_content=$(curl -sk "${batch_url}/v1/files/${output_file_id}/content" \
+                    -H "${authorized_header}")
+                if [ -n "$output_content" ]; then
+                    pass_test "Output file downloaded (file: ${output_file_id})"
+                    echo "  --- output content ---"
+                    echo "$output_content"
+                    echo "  --- end ---"
+                else
+                    fail_test "Output file is empty (file: ${output_file_id})"
+                fi
+            else
+                fail_test "No output_file_id in completed batch"
+            fi
         else
             fail_test "Batch ended with status=${_BATCH_STATUS} (expected completed)"
         fi


### PR DESCRIPTION
## Why is this PR needed?

Users cannot easily switch between upstream and midstream images without editing deploy scripts.

## What does this PR do?

- Add `BATCH_IMAGE_TAG`, `BATCH_APISERVER_REPO`, `BATCH_PROCESSOR_REPO`, `BATCH_GC_REPO` env vars for image overrides
- Add output file download to Batch Lifecycle test
- Update README with install examples and new env vars

## How was this tested?

- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #342, Related to #339