### PR TITLE
feat: support release tags from release branches

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   verify-tag-on-allowed-branch:
-    name: Verify tag is on main or a release branch
+    name: Verify tag is on main or a release-vX.Y.Z branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure tagged commit is reachable from main or release-*
+      - name: Ensure tagged commit is reachable from main or release-v*.*.*
         run: |
           git fetch origin
           TAG_SHA="${GITHUB_SHA}"
@@ -39,9 +39,9 @@ jobs:
               ok=1
               break
             fi
-          done < <(git branch -r | sed 's/^[ *]*//' | grep -E '^origin/release-' || true)
+          done < <(git branch -r | sed 's/^[ *]*//' | grep -E '^origin/release-v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$' || true)
           if [ "$ok" -ne 1 ]; then
-            echo "::error::Release tags must point to a commit on main or on an origin/release-* branch."
+            echo "::error::Release tags must point to a commit on main or on an origin/release-vX.Y.Z branch (same naming as a version tag)."
             exit 1
           fi
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,8 +14,8 @@ permissions:
   packages: write
 
 jobs:
-  verify-tag-on-main:
-    name: Verify tag is on main
+  verify-tag-on-allowed-branch:
+    name: Verify tag is on main or a release branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,18 +23,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure tagged commit is reachable from main
+      - name: Ensure tagged commit is reachable from main or release-*
         run: |
-          git fetch origin main
+          git fetch origin
           TAG_SHA="${GITHUB_SHA}"
-          if ! git merge-base --is-ancestor "$TAG_SHA" "origin/main"; then
-            echo "::error::Release tags must point to a commit on main (merged into origin/main before tagging)."
+          if git merge-base --is-ancestor "$TAG_SHA" "origin/main" 2>/dev/null; then
+            echo "Tag is reachable from origin/main."
+            exit 0
+          fi
+          ok=0
+          while IFS= read -r ref; do
+            [ -z "$ref" ] && continue
+            if git merge-base --is-ancestor "$TAG_SHA" "$ref" 2>/dev/null; then
+              echo "Tag is reachable from ${ref}."
+              ok=1
+              break
+            fi
+          done < <(git branch -r | sed 's/^[ *]*//' | grep -E '^origin/release-' || true)
+          if [ "$ok" -ne 1 ]; then
+            echo "::error::Release tags must point to a commit on main or on an origin/release-* branch."
             exit 1
           fi
 
   build:
     name: Build binaries
-    needs: verify-tag-on-main
+    needs: verify-tag-on-allowed-branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,27 +23,41 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure tagged commit is reachable from main or release-v*.*.*
+      - name: Ensure tagged commit is reachable from main or release-vX.Y.Z
         run: |
           git fetch origin
+          TAG="${{ github.ref_name }}"
           TAG_SHA="${GITHUB_SHA}"
           if git merge-base --is-ancestor "$TAG_SHA" "origin/main" 2>/dev/null; then
             echo "Tag is reachable from origin/main."
             exit 0
           fi
-          ok=0
+          matched_branch=""
           while IFS= read -r ref; do
             [ -z "$ref" ] && continue
             if git merge-base --is-ancestor "$TAG_SHA" "$ref" 2>/dev/null; then
               echo "Tag is reachable from ${ref}."
-              ok=1
+              matched_branch="$ref"
               break
             fi
           done < <(git branch -r | sed 's/^[ *]*//' | grep -E '^origin/release-v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$' || true)
-          if [ "$ok" -ne 1 ]; then
+          if [ -z "$matched_branch" ]; then
             echo "::error::Release tags must point to a commit on main or on an origin/release-vX.Y.Z branch (same naming as a version tag)."
             exit 1
           fi
+
+          # Validate that the tag version matches the release branch's major.minor.
+          branch_name="${matched_branch#origin/}"
+          branch_ver="${branch_name#release-}"
+          branch_major=$(echo "$branch_ver" | cut -d. -f1 | sed 's/^v//')
+          branch_minor=$(echo "$branch_ver" | cut -d. -f2)
+          tag_major=$(echo "$TAG" | cut -d. -f1 | sed 's/^v//')
+          tag_minor=$(echo "$TAG" | cut -d. -f2)
+          if [ "$tag_major" != "$branch_major" ] || [ "$tag_minor" != "$branch_minor" ]; then
+            echo "::error::Tag ${TAG} has major.minor v${tag_major}.${tag_minor} but branch ${branch_name} expects v${branch_major}.${branch_minor}.*"
+            exit 1
+          fi
+          echo "Tag ${TAG} matches release line v${branch_major}.${branch_minor}.*"
 
   build:
     name: Build binaries

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -111,6 +111,6 @@ jobs:
           generate_release_notes: true
           files: release/*
           draft: false
-          make_latest: true
+          make_latest: legacy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,16 @@ publish-helm-chart:
 	export GITHUB_ACTOR="$(GITHUB_ACTOR)"; \
 	./scripts/publish-helm-chart.sh
 
-## generate-release: Create and push a release tag from main (requires REL_VERSION, e.g. make generate-release REL_VERSION=0.0.1)
+## generate-release: Create and push a release tag (requires REL_VERSION; optional REL_BRANCH=main|release-* , default main)
 generate-release:
 	@if [ -z "$(REL_VERSION)" ]; then \
 	  echo "Error: REL_VERSION is required. Example: make generate-release REL_VERSION=0.0.1"; exit 1; \
 	fi
-	@./scripts/generate-release.sh $(REL_VERSION)
+	@if [ -n "$(REL_BRANCH)" ]; then \
+	  ./scripts/generate-release.sh $(REL_VERSION) $(REL_BRANCH); \
+	else \
+	  ./scripts/generate-release.sh $(REL_VERSION); \
+	fi
 
 ## run-apiserver: Run the apiserver
 run-apiserver: build-apiserver

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ publish-helm-chart:
 	export GITHUB_ACTOR="$(GITHUB_ACTOR)"; \
 	./scripts/publish-helm-chart.sh
 
-## generate-release: Create and push a release tag (requires REL_VERSION; optional REL_BRANCH=main|release-* , default main)
+## generate-release: Create and push a release tag (requires REL_VERSION; optional REL_BRANCH=main|release-vX.Y.Z , default main)
 generate-release:
 	@if [ -z "$(REL_VERSION)" ]; then \
 	  echo "Error: REL_VERSION is required. Example: make generate-release REL_VERSION=0.0.1"; exit 1; \

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -4,27 +4,27 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 ## Overview
 
-- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-*` branch** (reachable from `origin/main` or `origin/release-*`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
+- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-v*.*.*` branch** (same naming shape as a tag: `release-v1.0.0`, optional `-suffix`; reachable from `origin/main` or from such a branch on `origin`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
 - **Docker workflow** (`.github/workflows/ci-release.yaml`): Builds and pushes container images to GHCR. It runs on the following triggers:
   - **Push to `main`**: Images are tagged `latest` and with the commit SHA.
   - **Push of version tag** (`v*.*.*`): Images are tagged with the version (e.g. `v1.0.0`) and with the commit SHA.
 - **Release notes config** (`.github/release.yml`): Defines how PRs are grouped in release notes generated automatically (e.g. Features, Bug fixes, Documentation).
 - **Release template** (`.github/RELEASE_TEMPLATE.md`): Optional template you can copy into a release description (e.g. Docker image names, upgrade notes).
 
-## Tagging policy (main or release branches)
+## Tagging policy (main or release-vX.Y.Z branches)
 
-**The tagged commit must be reachable from `origin/main` or from an `origin/release-*` branch.** The workflow enforces this so release tags are not cut from arbitrary feature branches.
+**The tagged commit must be reachable from `origin/main` or from an `origin/release-v*.*.*` branch** (branch name must match `release-v` plus the same semver-like pattern as a version tag). The workflow enforces this so release tags are not cut from arbitrary feature branches.
 
 - **Normal releases:** merge to `main`, then tag from `main` (default), e.g. `./scripts/generate-release.sh 1.0.0` or `make generate-release REL_VERSION=1.0.0`.
-- **Hotfixes on a release line:** use the corresponding `release-*` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
-- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any `release-*` branch the workflow can see.
+- **Hotfixes on a release line:** use the corresponding `release-vX.Y.Z` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
+- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any allowed `release-v*.*.*` branch the workflow can see.
 
 Pushing `v*.*.*` **always** triggers the workflow if the check passes.
 
 ## Creating a release
 
 1. **Ensure the target branch is in a good state**
-  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-*` branch.
+  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-v*.*.*` branch.
 2. **Create and push a version tag** (semantic version with optional `v` prefix; script normalizes to `v*.*.*`):
 
    From **main** (default):
@@ -86,7 +86,7 @@ The workflow does **not** automatically inject this file into the release body; 
 
 To verify the release workflow without affecting a real version, use the same `generate-release` script with a test tag (e.g. `v0.0.0-test`):
 
-1. **Create a test tag** on `main` or a `release-*` branch (the same reachability rules as a real release apply):
+1. **Create a test tag** on `main` or a `release-v*.*.*` branch (the same reachability rules as a real release apply):
   ```bash
    ./scripts/generate-release.sh v0.0.0-test
    # or from a release branch:

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -4,36 +4,46 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 ## Overview
 
-- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main`**, then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
+- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-*` branch** (reachable from `origin/main` or `origin/release-*`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
 - **Docker workflow** (`.github/workflows/ci-release.yaml`): Builds and pushes container images to GHCR. It runs on the following triggers:
   - **Push to `main`**: Images are tagged `latest` and with the commit SHA.
   - **Push of version tag** (`v*.*.*`): Images are tagged with the version (e.g. `v1.0.0`) and with the commit SHA.
 - **Release notes config** (`.github/release.yml`): Defines how PRs are grouped in release notes generated automatically (e.g. Features, Bug fixes, Documentation).
 - **Release template** (`.github/RELEASE_TEMPLATE.md`): Optional template you can copy into a release description (e.g. Docker image names, upgrade notes).
 
-## Tagging policy (main only)
+## Tagging policy (main or release branches)
 
-**The tagged commit must already be on `main`** (merged via PR). The workflow checks that the tag's commit is an ancestor of `origin/main`.
+**The tagged commit must be reachable from `origin/main` or from an `origin/release-*` branch.** The workflow enforces this so release tags are not cut from arbitrary feature branches.
 
-- **Do:** merge to `main`, then tag that release line (e.g. `git checkout main && git pull && git tag v1.0.0 && git push origin v1.0.0`).
-- **Don't:** push a release tag that points at a commit that only exists on a feature branch.
+- **Normal releases:** merge to `main`, then tag from `main` (default), e.g. `./scripts/generate-release.sh 1.0.0` or `make generate-release REL_VERSION=1.0.0`.
+- **Hotfixes on a release line:** use the corresponding `release-*` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
+- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any `release-*` branch the workflow can see.
 
-Pushing `v*.*.`* **always** triggers the workflow if the check passes; there is no way to "tag only on main" from GitHub's side without this check - so follow the process above.
+Pushing `v*.*.*` **always** triggers the workflow if the check passes.
 
 ## Creating a release
 
-1. **Ensure `main` is in a good state**
-  CI and tests should be passing on `main` before tagging.
-2. **Create and push a version tag** from `main` (semantic version with `v` prefix):
+1. **Ensure the target branch is in a good state**
+  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-*` branch.
+2. **Create and push a version tag** (semantic version with optional `v` prefix; script normalizes to `v*.*.*`):
+
+   From **main** (default):
 
    ```bash
    ./scripts/generate-release.sh 1.0.0
+   ```
+
+   From a **release branch** (e.g. patch after `v0.1.0`):
+
+   ```bash
+   ./scripts/generate-release.sh 0.1.1 release-v0.1.0
    ```
 
    Or using the Makefile (for admins):
 
   ```bash
   make generate-release REL_VERSION=1.0.0
+  make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0
   ```
 
 3. **Let automation run**
@@ -76,10 +86,15 @@ The workflow does **not** automatically inject this file into the release body; 
 
 To verify the release workflow without affecting a real version, use the same `generate-release` script with a test tag (e.g. `v0.0.0-test`):
 
-1. **Create a test tag** on `main` (the requirement that the tag is on main still applies):
+1. **Create a test tag** on `main` or a `release-*` branch (the same reachability rules as a real release apply):
   ```bash
    ./scripts/generate-release.sh v0.0.0-test
+   # or from a release branch:
+   ./scripts/generate-release.sh v0.0.0-test release-v0.0.1
   ```
+
+   Equivalent with Make: `make generate-release REL_VERSION=v0.0.0-test REL_BRANCH=release-v0.0.1`
+
 2. **Check that workflows run** in the **Actions** tab: **Release** and **CI Release** should run for that tag. When they finish, a new release and new image tags will exist.
 3. **Important:** Running a failed workflow again uses the workflow file from the original trigger commit. To run with updated workflow code (e.g. after fixing ci-release.yaml), push the fix and then push the tag again from the new commit so a fresh run is triggered.
 4. **Clean up when done** — see [Manually deleting a release](#manually-deleting-a-release).

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -17,6 +17,7 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 - **Normal releases:** merge to `main`, then tag from `main` (default), e.g. `./scripts/generate-release.sh 1.0.0` or `make generate-release REL_VERSION=1.0.0`.
 - **Hotfixes on a release line:** use the corresponding `release-vX.Y.Z` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
+- **Version must match the release line:** when tagging from a `release-vX.Y.Z` branch, the version tag must share the same major and minor (`vX.Y.*`). For example, `release-v0.1.0` only accepts tags like `v0.1.1` or `v0.1.2-rc1`; a tag like `v0.3.0` will be rejected by the script.
 - **Don't:** push a release tag that points only at a commit that is not on `main` and not on any allowed `release-v*.*.*` branch the workflow can see.
 
 Pushing `v*.*.*` **always** triggers the workflow if the check passes.

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -4,7 +4,7 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 ## Overview
 
-- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-v*.*.*` branch** (same naming shape as a tag: `release-v1.0.0`, optional `-suffix`; reachable from `origin/main` or from such a branch on `origin`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
+- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-vX.Y.Z` branch** (e.g. `release-v1.0.0`; reachable from `origin/main` or from such a branch on `origin`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, uploads those assets, and marks the release as **Latest**.
 - **Docker workflow** (`.github/workflows/ci-release.yaml`): Builds and pushes container images to GHCR. It runs on the following triggers:
   - **Push to `main`**: Images are tagged `latest` and with the commit SHA.
   - **Push of version tag** (`v*.*.*`): Images are tagged with the version (e.g. `v1.0.0`) and with the commit SHA.
@@ -13,19 +13,19 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 ## Tagging policy (main or release-vX.Y.Z branches)
 
-**The tagged commit must be reachable from `origin/main` or from an `origin/release-v*.*.*` branch** (branch name must match `release-v` plus the same semver-like pattern as a version tag). The workflow enforces this so release tags are not cut from arbitrary feature branches.
+**The tagged commit must be reachable from `origin/main` or from an `origin/release-vX.Y.Z` branch** (branch name must match `release-v` plus the same semver-like pattern as a version tag). The workflow enforces this so release tags are not cut from arbitrary feature branches.
 
 - **Normal releases:** merge to `main`, then tag from `main` (default), e.g. `./scripts/generate-release.sh 1.0.0` or `make generate-release REL_VERSION=1.0.0`.
 - **Hotfixes on a release line:** use the corresponding `release-vX.Y.Z` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
-- **Version must match the release line:** when tagging from a `release-vX.Y.Z` branch, the version tag must share the same major and minor (`vX.Y.*`). For example, `release-v0.1.0` only accepts tags like `v0.1.1` or `v0.1.2-rc1`; a tag like `v0.3.0` will be rejected by the script.
-- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any allowed `release-v*.*.*` branch the workflow can see.
+- **Version must match the release line:** when tagging from a `release-vX.Y.Z` branch, the version tag must share the same major and minor (`vX.Y.*`). For example, `release-v0.1.0` only accepts tags like `v0.1.1` or `v0.1.2-rc1`; a tag like `v0.3.0` will be rejected. This is enforced both by `generate-release.sh` locally and by the `create-release.yml` workflow in CI.
+- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any allowed `release-vX.Y.Z` branch the workflow can see.
 
 Pushing `v*.*.*` **always** triggers the workflow if the check passes.
 
 ## Creating a release
 
 1. **Ensure the target branch is in a good state**
-  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-v*.*.*` branch.
+  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-vX.Y.Z` branch.
 2. **Create and push a version tag** (semantic version with optional `v` prefix; script normalizes to `v*.*.*`):
 
    From **main** (default):
@@ -87,7 +87,7 @@ The workflow does **not** automatically inject this file into the release body; 
 
 To verify the release workflow without affecting a real version, use the same `generate-release` script with a test tag (e.g. `v0.0.0-test`):
 
-1. **Create a test tag** on `main` or a `release-v*.*.*` branch (the same reachability rules as a real release apply):
+1. **Create a test tag** on `main` or a `release-vX.Y.Z` branch (the same reachability rules as a real release apply):
   ```bash
    ./scripts/generate-release.sh v0.0.0-test
    # or from a release branch:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@
 
 | Script                  | Description                                                                                                                                               |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate-release.sh`   | Creates and pushes a `v*.*.*` tag from `main`, which triggers the GitHub release workflows. See [managing releases](../docs/guides/managing-releases.md). |
+| `generate-release.sh`   | Creates and pushes a `v*.*.*` tag from `main` (default) or a `release-v*.*.*` branch (same naming shape as a tag), which triggers the GitHub release workflows. See [managing releases](../docs/guides/managing-releases.md). |
 | `publish-helm-chart.sh` | Packages the helm chart for a tag and pushes it to `oci://ghcr.io/llm-d-incubation/charts` (invoked as `make publish-helm-chart` in release CI).          |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@
 
 | Script                  | Description                                                                                                                                               |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate-release.sh`   | Creates and pushes a `v*.*.*` tag from `main` (default) or a `release-v*.*.*` branch (same naming shape as a tag), which triggers the GitHub release workflows. See [managing releases](../docs/guides/managing-releases.md). |
+| `generate-release.sh`   | Creates and pushes a `v*.*.*` tag from `main` (default) or a `release-vX.Y.Z` branch, which triggers the GitHub release workflows. See [managing releases](../docs/guides/managing-releases.md). |
 | `publish-helm-chart.sh` | Packages the helm chart for a tag and pushes it to `oci://ghcr.io/llm-d-incubation/charts` (invoked as `make publish-helm-chart` in release CI).          |

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -1,35 +1,48 @@
 #!/bin/bash
-# Generates a release by creating and pushing a version tag from main.
+# Generates a release by creating and pushing a version tag from main or a release-* branch.
 # This triggers the create-release and ci-release workflows.
 #
-# Usage: ./scripts/generate-release.sh <version>
+# Usage: ./scripts/generate-release.sh <version> [branch]
+#   branch defaults to main; must be main or release-* (e.g. release-v0.1.0 for hotfixes).
+#
 # Example: ./scripts/generate-release.sh 1.0.0
+#          ./scripts/generate-release.sh 0.1.1 release-v0.1.0
 #          ./scripts/generate-release.sh v1.0.0
-#          ./scripts/generate-release.sh v0.0.0-test   # for testing the workflow
+#          ./scripts/generate-release.sh v0.0.0-test              # test tag from main
+#          ./scripts/generate-release.sh v0.0.0-test release-v0.0.1   # test tag from a release branch
 #
 # The version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test). The 'v' prefix is added if omitted.
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <version>"
+    echo "Usage: $0 <version> [branch]"
     echo ""
-    echo "Creates and pushes a release tag from main. Triggers create-release and ci-release workflows."
+    echo "Creates and pushes a release tag from the given branch (default: main)."
+    echo "Branch must be main or release-*. Triggers create-release and ci-release workflows."
     echo ""
     echo "Examples:"
-    echo "  $0 1.0.0         # tags as v1.0.0"
-    echo "  $0 v1.0.0        # tags as v1.0.0"
-    echo "  $0 v0.0.0-test   # tags as v0.0.0-test (for testing the release workflow)"
+    echo "  $0 1.0.0                    # tags v1.0.0 from main"
+    echo "  $0 0.1.1 release-v0.1.0     # hotfix tag from release branch"
+    echo "  $0 v1.0.0                   # tags as v1.0.0 from main"
+    echo "  $0 v0.0.0-test              # test tag from main"
+    echo "  $0 v0.0.0-test release-v0.0.1   # test tag from a release branch"
     echo ""
-    echo "The tagged commit must already be on main (merge your changes first)."
+    echo "The tagged commit must already be on the branch you select (merge or push there first)."
     exit 1
 }
 
-if [ $# -lt 1 ]; then
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
     usage
 fi
 
 VERSION="$1"
+BRANCH="${2:-main}"
+
+if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release- ]]; then
+    echo "Error: branch must be 'main' or match 'release-*' (got: ${BRANCH})" >&2
+    exit 1
+fi
 # Add 'v' prefix if not present
 if [[ ! "$VERSION" =~ ^v ]]; then
     VERSION="v${VERSION}"
@@ -45,10 +58,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${REPO_ROOT}"
 
-echo "Generating release ${VERSION}..."
-echo "  - Checking out main and pulling latest"
-git checkout main
-git pull origin main
+echo "Generating release ${VERSION} from branch ${BRANCH}..."
+echo "  - Checking out ${BRANCH} and pulling latest"
+git checkout "${BRANCH}"
+git pull origin "${BRANCH}"
 
 echo "  - Creating tag ${VERSION}"
 git tag "${VERSION}"

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Generates a release by creating and pushing a version tag from main or a release-* branch.
+# Generates a release by creating and pushing a version tag from main or a release-v*.*.* branch.
 # This triggers the create-release and ci-release workflows.
 #
 # Usage: ./scripts/generate-release.sh <version> [branch]
-#   branch defaults to main; must be main or release-* (e.g. release-v0.1.0 for hotfixes).
+#   branch defaults to main; must be main or release-vX.Y.Z (same form as a version tag, e.g. release-v0.1.0).
 #
 # Example: ./scripts/generate-release.sh 1.0.0
 #          ./scripts/generate-release.sh 0.1.1 release-v0.1.0
@@ -19,7 +19,7 @@ usage() {
     echo "Usage: $0 <version> [branch]"
     echo ""
     echo "Creates and pushes a release tag from the given branch (default: main)."
-    echo "Branch must be main or release-*. Triggers create-release and ci-release workflows."
+    echo "Branch must be main or release-vX.Y.Z (same form as a tag, e.g. release-v0.1.0). Triggers create-release and ci-release workflows."
     echo ""
     echo "Examples:"
     echo "  $0 1.0.0                    # tags v1.0.0 from main"
@@ -39,8 +39,11 @@ fi
 VERSION="$1"
 BRANCH="${2:-main}"
 
-if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release- ]]; then
-    echo "Error: branch must be 'main' or match 'release-*' (got: ${BRANCH})" >&2
+# Semver-like tag body: vX.Y.Z or vX.Y.Z-suffix (release branches are release-<same>, e.g. release-v0.1.0)
+_SEMVER_V='v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?'
+
+if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release-${_SEMVER_V}$ ]]; then
+    echo "Error: branch must be 'main' or 'release-vX.Y.Z' matching the tag pattern (e.g. release-v0.1.0) (got: ${BRANCH})" >&2
     exit 1
 fi
 # Add 'v' prefix if not present
@@ -49,7 +52,7 @@ if [[ ! "$VERSION" =~ ^v ]]; then
 fi
 
 # Validate semver-like format (v*.*.* or v*.*.*-suffix for test tags)
-if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+if [[ ! "$VERSION" =~ ^${_SEMVER_V}$ ]]; then
     echo "Error: version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test)" >&2
     exit 1
 fi

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Generates a release by creating and pushing a version tag from main or a release-v*.*.* branch.
+# Generates a release by creating and pushing a version tag from main or a release-vX.Y.Z branch.
 # This triggers the create-release and ci-release workflows.
 #
 # Usage: ./scripts/generate-release.sh <version> [branch]

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -12,6 +12,7 @@
 #          ./scripts/generate-release.sh v0.0.0-test release-v0.0.1   # test tag from a release branch
 #
 # The version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test). The 'v' prefix is added if omitted.
+# When tagging from release-vX.Y.Z, the version must be vX.Y.*.
 
 set -euo pipefail
 
@@ -55,6 +56,20 @@ fi
 if [[ ! "$VERSION" =~ ^${_SEMVER_V}$ ]]; then
     echo "Error: version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test)" >&2
     exit 1
+fi
+
+# If tagging from release-vX.Y.Z, ensure the tag stays on that release line (vX.Y.*).
+if [[ "$BRANCH" =~ ^release-v([0-9]+)\.([0-9]+)\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+    BRANCH_MAJOR="${BASH_REMATCH[1]}"
+    BRANCH_MINOR="${BASH_REMATCH[2]}"
+    if [[ "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+        VERSION_MAJOR="${BASH_REMATCH[1]}"
+        VERSION_MINOR="${BASH_REMATCH[2]}"
+        if [[ "$VERSION_MAJOR" != "$BRANCH_MAJOR" || "$VERSION_MINOR" != "$BRANCH_MINOR" ]]; then
+            echo "Error: version ${VERSION} is not valid for branch ${BRANCH}. Expected v${BRANCH_MAJOR}.${BRANCH_MINOR}.* for this release branch." >&2
+            exit 1
+        fi
+    fi
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Why is this PR needed?

This PR addresses the release-branch support requested in issue #347.
Before this change, release tagging was effectively tied to main, which affected the hotfix workflow where tags should be cut from release branches. We also needed guardrails so release tags can only come from approved branch histories, not arbitrary feature branches.

## What does this PR do?

This PR updates release-tagging flow to support both main and release branches, with strict validation:

1. Updates `scripts/generate-release.sh` to accept an optional branch argument (default main), validate branch naming, checkout/pull that branch, then create/push the tag.
2. Extends `Makefile` generate-release target to pass optional `REL_BRANCH` (while keeping existing default behaviour).
3. Updates `.github/workflows/create-release.yml` verification job to allow tags whose commit is reachable from origin/main or an allowed `origin/release-v*.*.*` branch.
4. Updates release docs in `docs/guides/managing-releases.md` with the branch based tagging workflow and examples.
5. Updates `scripts/README.md` description for `generate-release.sh` to reflect branch aware release tagging.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Related to #347
