### PR TITLE
fix: auto-label workflow failing on fork PRs

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,7 +1,7 @@
 name: Add default labels to PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## Summary

- The `auto-label-pr` workflow uses `pull_request`, which gives a read-only `GITHUB_TOKEN` for fork PRs, causing a 403 when adding labels
- Switch to `pull_request_target`, which runs in the base repo context with write access
- Safe because the workflow only adds a label — it does not check out or execute any PR code

**All fork PRs have been failing** since the workflow was introduced (e.g. [run 24213705747](https://github.com/llm-d-incubation/batch-gateway/actions/runs/24213705747)). Labels on fork PRs were being added manually.

## Test plan

- [ ] Open a test PR from a fork and verify the `ai-assisted` label is added automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)