### PR TITLE
fix: increase waitForReady timeout in helm upgrade e2e test

### DIFF
--- a/test/e2e/helm_upgrade_test.go
+++ b/test/e2e/helm_upgrade_test.go
@@ -109,7 +109,7 @@ func testHelmUpgrade(t *testing.T) {
 		t.Logf("ConfigMap max_retries changed from %d to %d (model_gateways[%s])", originalMaxRetries, got, testModel)
 
 		waitForRollout(t, fmt.Sprintf("%s-processor", testHelmRelease))
-		waitForReady(t, testProcessorObsURL, 60*time.Second)
+		waitForReady(t, testProcessorObsURL, 180*time.Second)
 		t.Log("processor healthy after helm upgrade")
 	})
 
@@ -124,7 +124,7 @@ func testHelmUpgrade(t *testing.T) {
 		}
 
 		waitForRollout(t, fmt.Sprintf("%s-processor", testHelmRelease))
-		waitForReady(t, testProcessorObsURL, 60*time.Second)
+		waitForReady(t, testProcessorObsURL, 180*time.Second)
 		t.Log("original values restored successfully")
 	})
 }


### PR DESCRIPTION
## Summary

- The `HelmUpgrade/RestoreOriginalValues` e2e test fails on CI with `connection reset by peer` after 60 seconds — the processor pod rolls out successfully but the metrics server isn't accepting connections through the NodePort chain within the timeout
- This passes locally (faster hardware) but fails on GitHub Actions runners (2-core, 7GB RAM Kind cluster)
- Increase `waitForReady` timeout from 60s to 180s in both helm upgrade subtests, matching the `kubectl rollout` timeout used elsewhere

**Root cause:** After the second helm upgrade (restore), the pod takes longer to fully initialize on a resource-constrained runner. `kubectl rollout status` reports success when the pod passes K8s readiness probes, but the NodePort routing + metrics server startup has an additional delay.

## Test plan

- [x] Re-run the integration tests workflow and verify `HelmUpgrade/RestoreOriginalValues` passes

Fixes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)