### PR TITLE
fix(security): restrict GW listerner to only required namespace

### DIFF
--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -343,7 +343,10 @@ spec:
     port: 80
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
   - name: https
     protocol: HTTPS
     port: 443
@@ -353,7 +356,10 @@ spec:
       - name: ${GATEWAY_NAME}-tls
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
 EOF
 
 # wait for gateway instance is ready
@@ -362,6 +368,8 @@ kubectl wait --for=condition=Programmed --timeout=300s \
 ```
 
 > **Note**: The Gateway uses a self-signed certificate from cert-manager (not OpenShift router certs). Access via `kubectl port-forward` with `-k` (insecure) flag on curl.
+
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"`. This is applied automatically in the batch-gateway installation step below.
 
 </details>
 
@@ -605,6 +613,7 @@ kubectl wait tokenratelimitpolicy/inference-token-limit \
 ```bash
 BATCH_NS=batch-api
 kubectl create namespace "${BATCH_NS}" 2>/dev/null || true
+kubectl label namespace "${BATCH_NS}" batch-gateway.llm-d.ai/apiserver-route=true
 
 # Install Redis
 helm install redis oci://registry-1.docker.io/bitnamicharts/redis \

--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -346,7 +346,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
   - name: https
     protocol: HTTPS
     port: 443
@@ -359,7 +359,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
 EOF
 
 # wait for gateway instance is ready
@@ -369,7 +369,7 @@ kubectl wait --for=condition=Programmed --timeout=300s \
 
 > **Note**: The Gateway uses a self-signed certificate from cert-manager (not OpenShift router certs). Access via `kubectl port-forward` with `-k` (insecure) flag on curl.
 
-> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"`. This is applied automatically in the batch-gateway installation step below.
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only namespaces labeled with `llm-d.ai/gateway-route: "true"` can attach HTTPRoutes. This must be applied to the batch and LLM namespaces before creating their HTTPRoutes CRs.
 
 </details>
 
@@ -457,6 +457,12 @@ replicaset.apps/ms-llmd-llm-d-modelservice-prefill-7d7b78699f   1         1     
 
 <details>
 <summary>Create HTTPRoute for LLM inference</summary>
+
+Label the LLM namespace so the Gateway's namespace selector allows HTTPRoute attachment:
+
+```bash
+kubectl label namespace ${LLM_NS} llm-d.ai/gateway-route=true
+```
 
 The llm-route is manually created with URL rewrite rules that map `/{namespace}/{model}/v1/*` to the InferencePool backend.
 
@@ -613,7 +619,7 @@ kubectl wait tokenratelimitpolicy/inference-token-limit \
 ```bash
 BATCH_NS=batch-api
 kubectl create namespace "${BATCH_NS}" 2>/dev/null || true
-kubectl label namespace "${BATCH_NS}" batch-gateway.llm-d.ai/apiserver-route=true
+kubectl label namespace "${BATCH_NS}" llm-d.ai/gateway-route=true
 
 # Install Redis
 helm install redis oci://registry-1.docker.io/bitnamicharts/redis \

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -275,7 +275,10 @@ spec:
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
   - name: https
     hostname: "${HOSTNAME}"
     port: 443
@@ -286,7 +289,10 @@ spec:
       - name: router-certs-default
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
 EOF
 
 # Wait for the Envoy proxy deployment to become ready
@@ -295,6 +301,8 @@ oc rollout status deployment/openshift-ai-inference-openshift-default -n openshi
 ```
 
 > **Note**: The Gateway uses the OpenShift default router certificate (`router-certs-default`). The hostname must match the cluster's wildcard DNS for external access.
+
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"` This is applied automatically in the batch-gateway installation step below.
 
 </details>
 
@@ -641,6 +649,7 @@ Deploy batch-gateway with the model gateway URL from the LLMInferenceService sta
 ```bash
 BATCH_NS=batch-api
 oc create namespace "${BATCH_NS}" 2>/dev/null || true
+oc label namespace "${BATCH_NS}" batch-gateway.llm-d.ai/apiserver-route=true
 
 # Install Redis
 helm install redis oci://registry-1.docker.io/bitnamicharts/redis \

--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -278,7 +278,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
   - name: https
     hostname: "${HOSTNAME}"
     port: 443
@@ -292,7 +292,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
 EOF
 
 # Wait for the Envoy proxy deployment to become ready
@@ -302,7 +302,7 @@ oc rollout status deployment/openshift-ai-inference-openshift-default -n openshi
 
 > **Note**: The Gateway uses the OpenShift default router certificate (`router-certs-default`). The hostname must match the cluster's wildcard DNS for external access.
 
-> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"` This is applied automatically in the batch-gateway installation step below.
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only namespaces labeled with `llm-d.ai/gateway-route: "true"` can attach HTTPRoutes. This must be applied to the batch and LLM namespaces before creating their HTTPRoutes.
 
 </details>
 
@@ -504,6 +504,8 @@ MODEL_NAME="facebook/opt-125m"
 ISVC_NAME=$(echo "${MODEL_NAME}" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
 
 oc create namespace "${LLM_NS}" 2>/dev/null || true
+# Label namespace for gateway access (required by Gateway namespace selector)
+oc label namespace "${LLM_NS}" llm-d.ai/gateway-route=true
 
 oc apply -f - <<EOF
 apiVersion: serving.kserve.io/v1alpha1
@@ -649,7 +651,7 @@ Deploy batch-gateway with the model gateway URL from the LLMInferenceService sta
 ```bash
 BATCH_NS=batch-api
 oc create namespace "${BATCH_NS}" 2>/dev/null || true
-oc label namespace "${BATCH_NS}" batch-gateway.llm-d.ai/apiserver-route=true
+oc label namespace "${BATCH_NS}" llm-d.ai/gateway-route=true
 
 # Install Redis
 helm install redis oci://registry-1.docker.io/bitnamicharts/redis \

--- a/docs/guides/kuadrant-integration.md
+++ b/docs/guides/kuadrant-integration.md
@@ -112,9 +112,14 @@ spec:
     port: 80
     allowedRoutes:
       namespaces:
-        from: All   # Accept HTTPRoutes from all namespaces
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
 EOF
 ```
+
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"` — this is applied in the batch HTTPRoute step below.
 
 ### 2.6 Install Model Servers (vLLM)
 
@@ -357,6 +362,10 @@ EOF
 Follow the [guide](../../README.md) to install Batch Inference Service
 
 ### 2.10 Create Batch HTTPRoute
+
+```bash
+kubectl label namespace batch-api batch-gateway.llm-d.ai/apiserver-route=true
+```
 
 Create HTTPRoute to route batch requests to batch inference service.
 

--- a/docs/guides/kuadrant-integration.md
+++ b/docs/guides/kuadrant-integration.md
@@ -115,11 +115,11 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
 EOF
 ```
 
-> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only the namespace where the batch-gateway apiserver is deployed needs the label `batch-gateway.llm-d.ai/apiserver-route: "true"` — this is applied in the batch HTTPRoute step below.
+> **Security**: The Gateway uses `allowedRoutes.namespaces.from: Selector` to restrict HTTPRoute attachment. Only namespaces labeled with `llm-d.ai/gateway-route: "true"` can attach HTTPRoutes. This must be applied to the batch and LLM namespaces before creating their HTTPRoutes.
 
 ### 2.6 Install Model Servers (vLLM)
 
@@ -251,6 +251,12 @@ helm install gold-model \
 
 ### 2.8 Create LLM HTTPRoute
 
+Label the LLM namespace so the Gateway's namespace selector allows HTTPRoute attachment:
+
+```bash
+kubectl label namespace llm llm-d.ai/gateway-route=true
+```
+
 Create HTTPRoute to route LLM inference requests to InferencePools.
 
 ```bash
@@ -363,8 +369,10 @@ Follow the [guide](../../README.md) to install Batch Inference Service
 
 ### 2.10 Create Batch HTTPRoute
 
+Label the batch namespace so the Gateway's namespace selector allows HTTPRoute attachment:
+
 ```bash
-kubectl label namespace batch-api batch-gateway.llm-d.ai/apiserver-route=true
+kubectl label namespace batch-api llm-d.ai/gateway-route=true
 ```
 
 Create HTTPRoute to route batch requests to batch inference service.

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -620,7 +620,7 @@ install_batch_gateway() {
 # (e.g. modelGateways, passThroughHeaders).
 do_deploy_batch_gateway() {
     kubectl get namespace "${BATCH_NAMESPACE}" &>/dev/null || kubectl create namespace "${BATCH_NAMESPACE}"
-    kubectl label namespace "${BATCH_NAMESPACE}" batch-gateway.llm-d.ai/apiserver-route=true --overwrite
+    kubectl label namespace "${BATCH_NAMESPACE}" llm-d.ai/gateway-route=true --overwrite
 
     install_batch_redis
     install_batch_postgresql

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -620,6 +620,7 @@ install_batch_gateway() {
 # (e.g. modelGateways, passThroughHeaders).
 do_deploy_batch_gateway() {
     kubectl get namespace "${BATCH_NAMESPACE}" &>/dev/null || kubectl create namespace "${BATCH_NAMESPACE}"
+    kubectl label namespace "${BATCH_NAMESPACE}" batch-gateway.llm-d.ai/apiserver-route=true --overwrite
 
     install_batch_redis
     install_batch_postgresql

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -108,7 +108,10 @@ spec:
     port: 80
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
   - name: https
     protocol: HTTPS
     port: 443
@@ -118,7 +121,10 @@ spec:
       - name: ${GATEWAY_NAME}-tls
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
 EOF
 
     wait_for_deployment "${GATEWAY_NAME}-istio" "${GATEWAY_NAMESPACE}" 300s

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -111,7 +111,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
   - name: https
     protocol: HTTPS
     port: 443
@@ -124,7 +124,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
 EOF
 
     wait_for_deployment "${GATEWAY_NAME}-istio" "${GATEWAY_NAMESPACE}" 300s
@@ -534,6 +534,10 @@ cmd_install() {
             kubectl create namespace "${ns}"
             log "Created namespace '${ns}'."
         fi
+    done
+
+    for ns in "${BATCH_NAMESPACE}" "${LLM_NAMESPACE}"; do
+        kubectl label namespace "${ns}" llm-d.ai/gateway-route=true --overwrite
     done
 
     install_cert_manager

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -178,7 +178,10 @@ spec:
     protocol: HTTP
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
   - name: https
     hostname: "${hostname}"
     port: 443
@@ -189,7 +192,10 @@ spec:
       - name: router-certs-default
     allowedRoutes:
       namespaces:
-        from: All
+        from: Selector
+        selector:
+          matchLabels:
+            batch-gateway.llm-d.ai/apiserver-route: "true"
 EOF
     fi
 

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -181,7 +181,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
   - name: https
     hostname: "${hostname}"
     port: 443
@@ -195,7 +195,7 @@ spec:
         from: Selector
         selector:
           matchLabels:
-            batch-gateway.llm-d.ai/apiserver-route: "true"
+            llm-d.ai/gateway-route: "true"
 EOF
     fi
 
@@ -469,6 +469,7 @@ deploy_llm_inference_service() {
     step "Deploying LLMInferenceService '${isvc_name}' (simulator) in namespace '${LLM_NAMESPACE}'..."
 
     kubectl get namespace "${LLM_NAMESPACE}" &>/dev/null || kubectl create namespace "${LLM_NAMESPACE}"
+    kubectl label namespace "${LLM_NAMESPACE}" llm-d.ai/gateway-route=true --overwrite
 
     if kubectl get llminferenceservice "${isvc_name}" -n "${LLM_NAMESPACE}" &>/dev/null; then
         log "LLMInferenceService '${isvc_name}' already exists. Skipping."

--- a/pkg/clients/inference/inference_client_integration_test.go
+++ b/pkg/clients/inference/inference_client_integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 /*
 Copyright 2026 The llm-d Authors

--- a/pkg/clients/inference/inference_client_test.go
+++ b/pkg/clients/inference/inference_client_test.go
@@ -1,5 +1,4 @@
 //go:build !integration
-// +build !integration
 
 /*
 Copyright 2026 The llm-d Authors


### PR DESCRIPTION
## Why is this PR needed?

<!-- Explain the motivation: feature request, bug fix, performance improvement, etc. -->

- to prevenet any namespace in the cluster could attach an HTTPRoute to this GW. This is a security risk, a rogue namespace could attach routes and intercept or inject  traffic. 
- similar practice in https://github.com/opendatahub-io/opendatahub-operator/pull/2807

## What does this PR do?
- replace from: All to use selector on the namespace where api-server deployment is
- fix lint when run `"make ci"`
<!-- Describe the changes and their purpose -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
