### PR TITLE
doc: validate operator channel and verify batch-route authn-only policy

### DIFF
--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -881,8 +881,9 @@ JSONL
 
     # ── 4. Batch Authn ──────────────────────────────────
     test_group_header "Batch Authn"
-    assert_http 401 "Unauthenticated batch request -> 401" "${batch_url}/v1/batches"
+    assert_http 401 "No credentials batch request -> 401" "${batch_url}/v1/batches"
     assert_http 200 "Authenticated batch request -> 200" -H "${authorized_header}" "${batch_url}/v1/batches"
+    assert_http 200 "Unauthorized but authenticated batch request -> 200 (no authz on batch-route)" -H "${unauthorized_header}" "${batch_url}/v1/batches"
 
     # ── 5. Batch Authz (LLM route enforces) ──────────────
     test_group_header "Batch Authz (LLM route enforces)"

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -357,6 +357,17 @@ install_rhoai_operator() {
         -n "${namespace}" &>/dev/null 2>&1; then
         log "${OPERATOR_TYPE} operator already installed. Skipping."
     else
+        # Validate channel exists in catalog
+        local available_channels
+        available_channels=$(kubectl get packagemanifest "${operator_name}" \
+            -n openshift-marketplace -o jsonpath='{.status.channels[*].name}' 2>/dev/null || echo "")
+        if [ -z "${available_channels}" ]; then
+            die "PackageManifest '${operator_name}' not found in catalog. Is the catalog source available?"
+        fi
+        if ! echo " ${available_channels} " | grep -q " ${channel} "; then
+            die "Channel '${channel}' not found for '${operator_name}'. Available: ${available_channels}"
+        fi
+
         kubectl create namespace "${namespace}" 2>/dev/null || true
 
         kubectl apply -f - <<EOF


### PR DESCRIPTION
## Why is this PR needed?

Made some enhancement for documents

## What does this PR do?

- check operator channel existence before creating RHOAI operator subscription to fail fast with a clear error message
- Add test case verifying batch-route allows unauthorized-but-authenticated requests

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
