### PR TITLE
doc: remove unnecessary gateway.refs in LLMInferenceService

### DIFF
--- a/docs/guides/deploy-rhoai.md
+++ b/docs/guides/deploy-rhoai.md
@@ -523,10 +523,6 @@ spec:
   replicas: 2
   router:
     route: {}
-    gateway:
-      refs:
-        - name: openshift-ai-inference
-          namespace: openshift-ingress
     scheduler: {}
   template:
     containers:

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -28,8 +28,9 @@ TLS_ISSUER_NAME="${TLS_ISSUER_NAME:-selfsigned-issuer}"
 # Demo uninstall safety: default uninstall removes batch-gateway-scoped
 # resources and the named Gateway only. Set UNINSTALL_ALL=1 to also tear down Kuadrant,
 # Istio, cert-manager, operators, cluster CRDs, and other shared platform pieces.
+UNINSTALL_ALL="${UNINSTALL_ALL:-0}"
 is_demo_uninstall_all() {
-    case "${UNINSTALL_ALL:-0}" in
+    case "${UNINSTALL_ALL}" in
         1|true|yes|TRUE|YES) return 0 ;;
         *) return 1 ;;
     esac

--- a/examples/deploy-demo/deploy-rhoai.sh
+++ b/examples/deploy-demo/deploy-rhoai.sh
@@ -159,6 +159,8 @@ EOF
     log "Cluster domain: ${domain}, Gateway hostname: ${hostname}"
 
     # Gateway CR
+    # KServe does NOT create the Gateway CR itself — it only creates HTTPRoutes
+    # that reference this Gateway. The Gateway must be pre-provisioned.
     if kubectl get gateway ${GATEWAY_NAME} -n "${GATEWAY_NAMESPACE}" &>/dev/null; then
         log "Gateway already exists. Skipping."
     else
@@ -505,10 +507,12 @@ spec:
   replicas: ${MODEL_REPLICAS}
   router:
     route: {}
-    gateway:
-      refs:
-        - name: ${GATEWAY_NAME}
-          namespace: ${GATEWAY_NAMESPACE}
+    #gateway:
+    #  refs:
+    #    - name: ${GATEWAY_NAME}
+    #      namespace: ${GATEWAY_NAMESPACE}
+    # No gateway.refs needed: KServe uses the default gateway configured in
+    # inferenceservice-config ConfigMap (kserveIngressGateway: openshift-ingress/openshift-ai-inference).
     scheduler: {}
   template:
     containers:
@@ -560,6 +564,12 @@ spec:
             cpu: 500m
             memory: 512Mi
 EOF
+
+    step "Waiting for LLMInferenceService '${isvc_name}' pods to start"
+    for deploy in ${isvc_name}-kserve \
+                  ${isvc_name}-kserve-router-scheduler; do
+        wait_for_deployment "$deploy" "${LLM_NAMESPACE}" 180s
+    done
 
     step "Waiting for LLMInferenceService '${isvc_name}' to be ready..."
     local i=0


### PR DESCRIPTION
## Why is this PR needed?

`spec.router.gateway.refs` in LLMInferenceService is unnecessary when using the default gateway. KServe resolves the gateway from `inferenceservice-config` ConfigMap (`kserveIngressGateway: openshift-ingress/openshift-ai-inference`), so explicit refs are redundant and misleading.


## What does this PR do?

- Remove `spec.router.gateway.refs` from LLMInferenceService CR in deploy script and docs


## How was this tested?

- [x] Full install + 13/13 tests passed on clean OpenShift cluster (RHOAI beta channel)
- [x] Verified LLMInferenceService finds gateway without `gateway.refs`
- [x] Verified clean uninstall/reinstall cycle

## Related Issues

Fixes #357