### PR TITLE
feat: rename DEV_VERSION to IMAGE_TAG and add SKIP_BUILD option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /usr/bin/env bash
 TARGETARCH ?= $(shell go env GOARCH)
 
 # Variables
-DEV_VERSION ?= 0.0.1
+IMAGE_TAG ?= 0.0.1
 APISERVER_BINARY=batch-gateway-apiserver
 PROCESSOR_BINARY=batch-gateway-processor
 GC_BINARY=batch-gateway-gc
@@ -20,11 +20,11 @@ RELEASE_BINARIES := apiserver:$(CMD_APISERVER) processor:$(CMD_PROCESSOR) gc:$(C
 BINARIES_DIR ?= dist/binaries
 RELEASE_DIR ?= release
 APISERVER_IMAGE_TAG_BASE ?= ghcr.io/llm-d-incubation/$(APISERVER_BINARY)
-APISERVER_IMG = $(APISERVER_IMAGE_TAG_BASE):$(DEV_VERSION)
+APISERVER_IMG = $(APISERVER_IMAGE_TAG_BASE):$(IMAGE_TAG)
 PROCESSOR_IMAGE_TAG_BASE ?= ghcr.io/llm-d-incubation/$(PROCESSOR_BINARY)
-PROCESSOR_IMG = $(PROCESSOR_IMAGE_TAG_BASE):$(DEV_VERSION)
+PROCESSOR_IMG = $(PROCESSOR_IMAGE_TAG_BASE):$(IMAGE_TAG)
 GC_IMAGE_TAG_BASE ?= ghcr.io/llm-d-incubation/$(GC_BINARY)
-GC_IMG = $(GC_IMAGE_TAG_BASE):$(DEV_VERSION)
+GC_IMG = $(GC_IMAGE_TAG_BASE):$(IMAGE_TAG)
 GO=go
 GOFLAGS=
 LDFLAGS=-ldflags "-s -w"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Deploy to a local Kind cluster for development:
 ```bash
 # Creates cluster, builds images, and deploys with Helm
 make dev-deploy
+
+# Or deploy a specific release version from GHCR
+IMAGE_TAG=v0.1.0 SKIP_BUILD=true make dev-deploy
 ```
 
 For detailed instructions, see [Development Guide](docs/guides/development.md).

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -55,7 +55,7 @@ This produces:
 To use a different tag:
 
 ```bash
-DEV_VERSION=dev make image-build
+IMAGE_TAG=dev make image-build
 ```
 
 ## 3. Load Images to Kind

--- a/examples/poc/README.md
+++ b/examples/poc/README.md
@@ -19,6 +19,12 @@ This directory contains demo files for testing the Batch Gateway system.
    make dev-deploy
    ```
 
+   To deploy a specific release version from GHCR instead of building locally:
+
+   ```bash
+   IMAGE_TAG=v0.1.0 SKIP_BUILD=true make dev-deploy
+   ```
+
    This will start:
    - API Server at <https://localhost:8000>
    - Processor at <http://localhost:9090>

--- a/examples/poc/curl_demo.md
+++ b/examples/poc/curl_demo.md
@@ -8,6 +8,9 @@ Fast-track demo using curl commands.
 # Deploy the batch gateway
 make dev-deploy
 
+# Or deploy a specific release version from GHCR
+IMAGE_TAG=v0.1.0 SKIP_BUILD=true make dev-deploy
+
 # Navigate to the demo directory
 cd test/poc
 ```

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -10,7 +10,8 @@ source "${SCRIPT_DIR}/dev-common.sh"
 # ── Deployment-Specific Configuration ────────────────────────────────────────
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-batch-gateway-dev}"
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-mirror.gcr.io}"
-DEV_VERSION="${DEV_VERSION:-0.0.1}"
+IMAGE_TAG="${IMAGE_TAG:-0.0.1}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
 POSTGRESQL_PASSWORD="${POSTGRESQL_PASSWORD:-postgres}"
 INFERENCE_API_KEY="${INFERENCE_API_KEY:-dummy-api-key}"
 S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY:-minioadmin}"
@@ -33,9 +34,9 @@ JAEGER_NODE_PORT="${JAEGER_NODE_PORT:-30086}"
 PROMETHEUS_NODE_PORT="${PROMETHEUS_NODE_PORT:-30091}"
 GRAFANA_NODE_PORT="${GRAFANA_NODE_PORT:-30030}"
 MINIO_NODE_PORT="${MINIO_NODE_PORT:-30009}"
-APISERVER_IMG="${APISERVER_IMG:-ghcr.io/llm-d-incubation/batch-gateway-apiserver:${DEV_VERSION}}"
-PROCESSOR_IMG="${PROCESSOR_IMG:-ghcr.io/llm-d-incubation/batch-gateway-processor:${DEV_VERSION}}"
-GC_IMG="${GC_IMG:-ghcr.io/llm-d-incubation/batch-gateway-gc:${DEV_VERSION}}"
+APISERVER_IMG="${APISERVER_IMG:-ghcr.io/llm-d-incubation/batch-gateway-apiserver:${IMAGE_TAG}}"
+PROCESSOR_IMG="${PROCESSOR_IMG:-ghcr.io/llm-d-incubation/batch-gateway-processor:${IMAGE_TAG}}"
+GC_IMG="${GC_IMG:-ghcr.io/llm-d-incubation/batch-gateway-gc:${IMAGE_TAG}}"
 # USE_KIND=true  → use kind; create cluster if it doesn't exist (default)
 # USE_KIND=false → use existing kubeconfig context (OpenShift / Kubernetes)
 USE_KIND="${USE_KIND:-true}"
@@ -241,9 +242,17 @@ build_images() {
     local target_arch
     target_arch="$(get_target_arch)"
 
-    step "Building container images (TARGETARCH=${target_arch}, version=${DEV_VERSION})..."
+    step "Building container images (TARGETARCH=${target_arch}, version=${IMAGE_TAG})..."
     cd "${REPO_ROOT}"
-    CONTAINER_TOOL="${CONTAINER_TOOL}" TARGETARCH="${target_arch}" DEV_VERSION="${DEV_VERSION}" make image-build
+    CONTAINER_TOOL="${CONTAINER_TOOL}" TARGETARCH="${target_arch}" IMAGE_TAG="${IMAGE_TAG}" make image-build
+}
+
+pull_images() {
+    step "Pulling images from GHCR..."
+    "${CONTAINER_TOOL}" pull "${APISERVER_IMG}"
+    "${CONTAINER_TOOL}" pull "${PROCESSOR_IMG}"
+    "${CONTAINER_TOOL}" pull "${GC_IMG}"
+    log "Images pulled successfully."
 }
 
 load_images() {
@@ -810,7 +819,7 @@ EOF
 # ── Batch Gateway ─────────────────────────────────────────────────────────────
 
 install_batch_gateway() {
-    step "Installing batch-gateway via Helm (version=${DEV_VERSION})..."
+    step "Installing batch-gateway via Helm (version=${IMAGE_TAG})..."
     cd "${REPO_ROOT}"
 
     local vllm_sim_url="http://${VLLM_SIM_NAME}.${NAMESPACE}.svc.cluster.local:8000"
@@ -818,9 +827,9 @@ install_batch_gateway() {
 
     local helm_args=(
         --set apiserver.image.pullPolicy=IfNotPresent
-        --set "apiserver.image.tag=${DEV_VERSION}"
+        --set "apiserver.image.tag=${IMAGE_TAG}"
         --set processor.image.pullPolicy=IfNotPresent
-        --set "processor.image.tag=${DEV_VERSION}"
+        --set "processor.image.tag=${IMAGE_TAG}"
         --set "global.fileClient.type=${FILE_CLIENT_TYPE}"
         --set "global.secretName=${APP_SECRET_NAME}"
         --set "processor.config.modelGateways.${VLLM_SIM_MODEL}.url=${vllm_sim_url}"
@@ -848,7 +857,7 @@ install_batch_gateway() {
         --set "processor.resources.requests.memory=256Mi"
         --set "gc.enabled=true"
         --set "gc.image.pullPolicy=IfNotPresent"
-        --set "gc.image.tag=${DEV_VERSION}"
+        --set "gc.image.tag=${IMAGE_TAG}"
         --set "gc.config.interval=5s"
         --namespace "${NAMESPACE}"
     )
@@ -1132,7 +1141,11 @@ main() {
     echo ""
 
     check_prerequisites
-    build_images
+    if [ "${SKIP_BUILD}" = "true" ]; then
+        pull_images
+    else
+        build_images
+    fi
     ensure_cluster
     install_redis
     install_postgresql

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -29,7 +29,8 @@ This script:
 | `KIND_CLUSTER_NAME`   | `batch-gateway-dev`                        | Kind cluster name (created if needed)              |
 | `HELM_RELEASE`        | `batch-gateway`                            | Helm release name                                  |
 | `NAMESPACE`           | `default`                                  | Kubernetes namespace                               |
-| `DEV_VERSION`         | `0.0.1`                                    | Image tag to build and deploy                      |
+| `IMAGE_TAG`           | `0.0.1`                                    | Image tag to build and deploy                      |
+| `SKIP_BUILD`          | `false`                                    | Pull images from GHCR instead of building locally  |
 | `LOCAL_PORT`          | `8000`                                     | Local port for the apiserver                       |
 | `LOG_VERBOSITY`       | `5`                                        | klog verbosity for apiserver and processor         |
 | `POSTGRESQL_RELEASE`  | `postgresql`                               | Helm release name for PostgreSQL                   |


### PR DESCRIPTION
## Summary

- Rename `DEV_VERSION` to `IMAGE_TAG` across Makefile, `dev-deploy.sh`, and docs. The old name was misleading when pointing at a release tag (e.g. `v0.1.0`).
- Add `SKIP_BUILD` option to `dev-deploy.sh`. When set to `true`, images are pulled from GHCR instead of building locally, enabling dev-deploy with pre-built release images.

### Usage

```bash
# Default behavior (unchanged): build locally with tag 0.0.1
make dev-deploy

# Build locally with a custom tag
IMAGE_TAG=dev make dev-deploy

# Pull v0.1.0 release images from GHCR instead of building
IMAGE_TAG=v0.1.0 SKIP_BUILD=true make dev-deploy
```

### Files changed

| File | Change |
|------|--------|
| `Makefile` | `DEV_VERSION` → `IMAGE_TAG` |
| `scripts/dev-deploy.sh` | `DEV_VERSION` → `IMAGE_TAG`, add `SKIP_BUILD` + `pull_images()` |
| `test/e2e/README.md` | Update env var table |
| `docs/guides/development.md` | Update example command |

## Test plan

- [x] `make dev-deploy` works with default settings (existing behavior)
- [x] `IMAGE_TAG=v0.1.0 SKIP_BUILD=true make dev-deploy` pulls and deploys GHCR images
- [x] `IMAGE_TAG=custom make dev-deploy` builds locally with custom tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)