### PR TITLE
feat: use different retry backoff by HTTP status code

### DIFF
--- a/pkg/clients/http/http_client.go
+++ b/pkg/clients/http/http_client.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
+	cbackoff "github.com/cenkalti/backoff/v5"
 	"github.com/go-logr/logr"
 	"github.com/go-resty/resty/v2"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
@@ -36,6 +38,11 @@ import (
 const (
 	HeaderNameReqID       string = "X-Request-ID"
 	HeaderNameContentType string = "Content-Type"
+
+	// rateLimitBackoffMultiplier scales the initial backoff for 429 responses.
+	// A 429 means the server explicitly asks the client to slow down, so we
+	// back off harder than for transient 5xx errors.
+	rateLimitBackoffMultiplier = 3
 )
 
 // HTTPClient implements HTTP client with retry, TLS, and observability support
@@ -131,9 +138,9 @@ func NewHTTPClient(config Config, logger logr.Logger) (*HTTPClient, error) {
 	// Configure retry only if enabled
 	if config.MaxRetries > 0 {
 		client.SetRetryCount(config.MaxRetries).
-			SetRetryWaitTime(config.InitialBackoff). // Min wait time between retries
-			SetRetryMaxWaitTime(config.MaxBackoff)   // Max wait time between retries
-		// Resty automatically applies exponential backoff with jitter
+			SetRetryWaitTime(config.InitialBackoff).                                   // Min wait time between retries
+			SetRetryMaxWaitTime(config.MaxBackoff).                                    // Max wait time between retries
+			SetRetryAfter(newRetryAfterFunc(config.InitialBackoff, config.MaxBackoff)) // Status-code-aware backoff
 
 		// Retry condition: retry on server errors, rate limits, and network errors
 		client.AddRetryCondition(func(r *resty.Response, err error) bool {
@@ -265,6 +272,85 @@ func MapStatusCodeToCategory(statusCode int) ErrorCategory {
 		}
 		return ErrCategoryUnknown
 	}
+}
+
+// newRetryAfterFunc returns a resty RetryAfterFunc that differentiates retry
+// delays by HTTP status code:
+//   - 429 with Retry-After header: use the server-specified delay (0 retries as fast as InitialBackoff allows)
+//   - 429 without Retry-After: use a longer backoff (rateLimitBackoffMultiplier × initialBackoff)
+//   - 502/503/504: transient failures, faster retry targeting ~maxBackoff/2 (jitter may exceed)
+//   - other 5xx: standard exponential backoff
+func newRetryAfterFunc(initialBackoff, maxBackoff time.Duration) func(*resty.Client, *resty.Response) (time.Duration, error) {
+	return func(_ *resty.Client, resp *resty.Response) (time.Duration, error) {
+		if resp == nil {
+			return computeBackoff(1, initialBackoff, maxBackoff), nil
+		}
+
+		switch resp.StatusCode() {
+		case http.StatusTooManyRequests: // 429
+			// Honor server's Retry-After header if present and parseable.
+			// Resty treats returned 0 as "use default algorithm", so we use
+			// 1ns for Retry-After: 0 — resty clamps it to InitialBackoff.
+			if ra := resp.Header().Get("Retry-After"); ra != "" {
+				if d, ok := parseRetryAfter(ra); ok {
+					if d == 0 {
+						d = 1 * time.Nanosecond
+					}
+					return d, nil
+				}
+			}
+			// No usable header — use longer backoff
+			return computeBackoff(resp.Request.Attempt, rateLimitBackoffMultiplier*initialBackoff, maxBackoff), nil
+
+		case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout: // 502, 503, 504
+			// Transient failures — retry faster
+			return computeBackoff(resp.Request.Attempt, initialBackoff, maxBackoff/2), nil
+
+		default:
+			return computeBackoff(resp.Request.Attempt, initialBackoff, maxBackoff), nil
+		}
+	}
+}
+
+// computeBackoff uses cenkalti/backoff to calculate exponential backoff with
+// jitter for the given attempt number.
+func computeBackoff(attempt int, base, max time.Duration) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	b := &cbackoff.ExponentialBackOff{
+		InitialInterval:     base,
+		MaxInterval:         max,
+		Multiplier:          2,
+		RandomizationFactor: 0.5,
+	}
+	b.Reset()
+	var d time.Duration
+	for range attempt {
+		d = b.NextBackOff()
+	}
+	return d
+}
+
+// parseRetryAfter parses a Retry-After header value, which can be either
+// a number of seconds (e.g. "120") or an HTTP-date (e.g. "Thu, 01 Dec 1994 16:00:00 GMT").
+// Returns the parsed duration and true if successful, or (0, false) if unparseable.
+// A value of 0 seconds is valid and means "retry as soon as possible" (subject to
+// resty's InitialBackoff floor).
+func parseRetryAfter(value string) (time.Duration, bool) {
+	// Try integer seconds first
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second, true
+	}
+	// Try HTTP-date format
+	if t, err := time.Parse(http.TimeFormat, value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
 }
 
 // BuildTLSConfig constructs a custom TLS configuration based on provided options

--- a/pkg/clients/http/http_client_test.go
+++ b/pkg/clients/http/http_client_test.go
@@ -460,6 +460,229 @@ func TestPost_NoRetryOn400(t *testing.T) {
 	}
 }
 
+// TestRetryAfter_429WithRetryAfterHeader tests that 429 responses with Retry-After header
+// are retried after the server-specified delay.
+func TestRetryAfter_429WithRetryAfterHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		retryAfter   string
+		minElapsed   time.Duration
+		maxElapsed   time.Duration
+		assertTiming bool
+	}{
+		{
+			name:         "seconds format",
+			retryAfter:   "0",
+			maxElapsed:   80 * time.Millisecond,
+			assertTiming: true,
+		},
+		{
+			name:         "HTTP-date format",
+			retryAfter:   time.Now().Add(120 * time.Millisecond).UTC().Format(http.TimeFormat),
+			assertTiming: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attemptCount atomic.Int32
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count := attemptCount.Add(1)
+				if count < 2 {
+					w.Header().Set("Retry-After", tt.retryAfter)
+					w.WriteHeader(http.StatusTooManyRequests)
+					_, _ = w.Write([]byte(`{"error": {"message": "rate limited"}}`))
+				} else {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"result": "success"}`))
+				}
+			}))
+			defer server.Close()
+
+			client, err := NewHTTPClient(Config{
+				BaseURL:        server.URL,
+				MaxRetries:     3,
+				InitialBackoff: 10 * time.Millisecond,
+				MaxBackoff:     100 * time.Millisecond,
+			}, testLogger(t))
+			if err != nil {
+				t.Fatalf("NewHTTPClient failed: %v", err)
+			}
+
+			start := time.Now()
+			_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "test-retry-after")
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Fatalf("Post failed: %v", err)
+			}
+
+			if statusCode != http.StatusOK {
+				t.Errorf("Expected status 200, got %d", statusCode)
+			}
+
+			if attemptCount.Load() != 2 {
+				t.Errorf("Expected 2 attempts, got %d", attemptCount.Load())
+			}
+			if tt.assertTiming {
+				if tt.minElapsed > 0 && elapsed < tt.minElapsed {
+					t.Errorf("Expected elapsed >= %v, got %v", tt.minElapsed, elapsed)
+				}
+				if tt.maxElapsed > 0 && elapsed > tt.maxElapsed {
+					t.Errorf("Expected elapsed <= %v, got %v", tt.maxElapsed, elapsed)
+				}
+			}
+		})
+	}
+}
+
+// TestRetryAfter_429WithoutHeader tests that 429 responses without Retry-After header
+// still retry with the 429-specific longer backoff.
+func TestRetryAfter_429WithoutHeader(t *testing.T) {
+	var attemptCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := attemptCount.Add(1)
+		if count < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error": {"message": "rate limited"}}`))
+		} else {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result": "success"}`))
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPClient(Config{
+		BaseURL:        server.URL,
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+	}, testLogger(t))
+	if err != nil {
+		t.Fatalf("NewHTTPClient failed: %v", err)
+	}
+
+	_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "test-429-no-header")
+	if err != nil {
+		t.Fatalf("Post failed: %v", err)
+	}
+
+	if statusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", statusCode)
+	}
+
+	if attemptCount.Load() != 2 {
+		t.Errorf("Expected 2 attempts, got %d", attemptCount.Load())
+	}
+}
+
+// TestRetryAfter_5xxUsesFasterBackoff tests that 502/503/504 responses use a
+// faster retry with maxBackoff/2 cap (transient failures).
+func TestRetryAfter_5xxUsesFasterBackoff(t *testing.T) {
+	runScenario := func(t *testing.T, firstFailureStatus int) time.Duration {
+		t.Helper()
+		var attemptCount atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			count := attemptCount.Add(1)
+			if count <= 3 {
+				w.WriteHeader(firstFailureStatus)
+				_, _ = w.Write([]byte(`{"error": {"message": "transient failure"}}`))
+			} else {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"result": "success"}`))
+			}
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     4,
+			InitialBackoff: 20 * time.Millisecond,
+			MaxBackoff:     80 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatalf("NewHTTPClient failed: %v", err)
+		}
+
+		start := time.Now()
+		_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "test-5xx")
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("Post failed: %v", err)
+		}
+		if statusCode != http.StatusOK {
+			t.Fatalf("Expected status 200, got %d", statusCode)
+		}
+		if attemptCount.Load() != 4 {
+			t.Fatalf("Expected 4 attempts, got %d", attemptCount.Load())
+		}
+		return elapsed
+	}
+
+	const samples = 5
+	var elapsed503Samples []time.Duration
+	var elapsed500Samples []time.Duration
+	for range samples {
+		elapsed503Samples = append(elapsed503Samples, runScenario(t, http.StatusServiceUnavailable))
+		elapsed500Samples = append(elapsed500Samples, runScenario(t, http.StatusInternalServerError))
+	}
+
+	median := func(values []time.Duration) time.Duration {
+		ordered := append([]time.Duration(nil), values...)
+		for i := 0; i < len(ordered); i++ {
+			for j := i + 1; j < len(ordered); j++ {
+				if ordered[j] < ordered[i] {
+					ordered[i], ordered[j] = ordered[j], ordered[i]
+				}
+			}
+		}
+		return ordered[len(ordered)/2]
+	}
+
+	median503 := median(elapsed503Samples)
+	median500 := median(elapsed500Samples)
+	if median503 >= median500 {
+		t.Errorf("Expected 503 median retry time (%v) < 500 median retry time (%v)", median503, median500)
+	}
+}
+
+// TestParseRetryAfter tests the Retry-After header parsing function.
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantOK   bool
+		wantZero bool // if wantOK, whether the duration should be zero
+	}{
+		{name: "integer seconds", value: "120", wantOK: true, wantZero: false},
+		{name: "zero seconds", value: "0", wantOK: true, wantZero: true},
+		{name: "HTTP-date future", value: time.Now().Add(10 * time.Second).UTC().Format(http.TimeFormat), wantOK: true, wantZero: false},
+		{name: "HTTP-date past", value: time.Now().Add(-10 * time.Second).UTC().Format(http.TimeFormat), wantOK: true, wantZero: true},
+		{name: "invalid value", value: "abc", wantOK: false},
+		{name: "empty string", value: "", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := parseRetryAfter(tt.value)
+			if ok != tt.wantOK {
+				t.Fatalf("parseRetryAfter(%q): ok = %v, want %v", tt.value, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if tt.wantZero && d != 0 {
+				t.Errorf("Expected zero duration, got %v", d)
+			}
+			if !tt.wantZero && d <= 0 {
+				t.Errorf("Expected positive duration, got %v", d)
+			}
+		})
+	}
+}
+
 // TestHandleErrorResponse_OpenAIFormat tests parsing OpenAI-style error response
 func TestHandleErrorResponse_OpenAIFormat(t *testing.T) {
 	body := []byte(`{"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}}`)


### PR DESCRIPTION
## Why is this PR needed?

The inference HTTP client currently uses the same exponential backoff for all retryable errors. This is suboptimal: a 429 (rate limit) means the server explicitly asks the client to slow down, while a 502/503/504 is typically a transient infrastructure issue that resolves quickly. 

## What does this PR do?

Adds a status-code-aware `RetryAfterFunc` to the resty client that differentiates retry delays by HTTP status:

- **429 with `Retry-After` header**: honors the server-specified delay
- **429 without header**: uses 3× longer initial backoff than default
- **502/503/504**: retries faster with `maxBackoff/2` ceiling
- **Other 5xx**: standard exponential backoff

Uses `cenkalti/backoff/v5` for exponential backoff computation with jitter. No changes to Config, retry conditions, or upper-layer callers.

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues
