### PR TITLE
docs: update dispatcher formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The system is designed to facilitate efficient processing of batch workloads in 
      - Priority queue, event channels, and status updates: `Redis` or `Valkey`.
      - File storage: `S3`, `filesystem`.
 
-4. **Batch Dispatcher**
+4. **Batch Dispatcher** (also called **Async Processor**, implemented in [llm-d-incubation/llm-d-async](https://github.com/llm-d-incubation/llm-d-async))
    - Implements intelligent flow control to balance batch and interactive workloads.
    - Monitors downstream inference system metrics (e.g. queue depth, latency, utilization).
    - Dynamically adjusts dispatch flow of batch requests based on downstream system load, to minimize interference with interactive requests while meeting batch jobs SLOs.

--- a/docs/design/batch-dispatcher.md
+++ b/docs/design/batch-dispatcher.md
@@ -5,10 +5,12 @@ Related:
 - [\[PUBLIC\] EPP Flow Controller for Priority, Fairness, and Queuing](https://docs.google.com/document/d/1VZL7opFWuwgWquvgiOzLlXAJ633qZ9U-A0ZixGjBgaI/edit?tab=t.0#heading=h.hfyow92z2d0t)
 - [\[PUBLIC\] Improved Flow Control Request Management](https://docs.google.com/document/d/1JxzJc8gNv2wKK5-a8ohb0btn78ymVKw9XMIb4-S-ncA/edit?tab=t.0#heading=h.rutawybt03nl)
 - [https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/)
+- [Async Processor: Dispatch Gates](https://github.com/llm-d-incubation/llm-d-async/blob/main/README.md#dispatch-gates) (llm-d-async)
+- [Dispatch Budget](https://github.com/llm-d-incubation/llm-d-async/blob/main/docs/dispatch-budget.md) (llm-d-async)
 
 ## Summary
 
-This document proposes the introduction of a **Batch Dispatcher** to extend the existing "online batch processing agent" architecture (see [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj)). While the **Inference Gateway (IGW)** acts as the primary component for scheduling and flow control, the Batch Dispatcher serves as a system-load aware gatekeeper. It ensures that batch workloads (low-priority and sheddable) are pulled from message queues and forwarded to the IGW only when the inference pool has sufficient capacity. This prevents low-priority traffic from flooding the system and competing with realtime requests.
+This document details the design of a **Batch Dispatcher** (sometimes also referred to as the [**Async Processor**](https://github.com/llm-d-incubation/llm-d-async)) to extend the existing "online batch processing agent" architecture (see [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj)). While the **Inference Gateway (IGW)** acts as the primary component for scheduling and flow control, the Batch Dispatcher serves as a system-load aware gatekeeper. It ensures that batch workloads (low-priority and sheddable) are pulled from message queues and forwarded to the IGW only when the inference pool has sufficient capacity. This prevents low-priority traffic from flooding the system and competing with realtime requests.
 
 ## Problem statement
 
@@ -41,82 +43,18 @@ Because there is one InferencePool and one EPP per (base) model (see [InferenceP
 #### **Key Components**
 
 * **Batch Processing Agent:** The component described in [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj)
-* **Batch Dispatcher:** A component that reads flow-control metrics, determines a "Dispatch Budget", and forwards sheddable traffic to the Inference Gateway (it could be realized as a standalone container, possibly an EPP pod sidecar; or it can be thought of as part of the **Batch Processing Agent**)
+* **Batch Dispatcher:** A component that reads flow-control metrics, determines a "Dispatch Budget", and forwards sheddable traffic to the Inference Gateway
 * **Message Queue:** A persistent store (e.g., Redis, Pub/Sub, Kafka) that holds asynchronous requests. The queue is a priority queue, sorted according to some policy (e.g. an SLO, tenancy, etc: out of scope here)
-* **Metrics Store:** Provides real-time data on **Inference Pool usage**.
+* **Metrics Store:** Provides real-time data on **Inference Pool usage**. Such data drives the **Batch Dispatcher** logic
 * **Inference Gateway (IGW):** L7 Proxy \+ Endpoint Picker (EPP) \+ any other accessory service, it handles the final routing to model servers.
 
-## Detailed Approach
+## Deployment Model and Lifecycle
 
-The **Batch Dispatcher** pulls requests from the Message Queue, reads metrics from a **Metrics Store** and decides whether to forward them to the IGW: when the metrics are within a certain interval the "gates" are open, and a certain number of requests may go through. Otherwise, the Batch Dispatcher waits until the metrics return within the acceptable range.
+The dispatcher corresponds to the **batch processing agent** described [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj), effectively implementing a "strategy" to pull and forward requests from Message Queue to the IGW.
 
-### Dispatch Budget
-
-In addition to forwarding the requests, we also propose a simple aggregated metric that we call a "**Dispatch Budget"**, to determine **the number of concurrent batch requests** allowed to enter the IGW at a given time.
-
-Using the following definitions:
-
-* $\mathrm{cur}_\mathrm{SYS}$: a measure of currently used system resources
-  * at the time of writing: number of requests
-  * in the future: number of bytes, number of tokens etc
-
-* $\mathrm{max}_\mathrm{SYS}$: a measure of available resources
-  * at the time of writing: total number of possible requests
-  * in the future: total number of bytes, total number of tokens etc
-
-* $\mathrm{cur}_\mathrm{EPP}$: a measure of currently used EPP resources
-  * e.g.: number of requests in the EPP internal queues
-  * possibly: number of bytes, number of tokens etc; as long as consistent with
-    $\mathrm{cur}\_\mathrm{SYS}$ and $\mathrm{max}_\mathrm{SYS}$
-
-  *Note:* given the variability in size of the requests, $\mathrm{max}_\mathrm{SYS}$ is currently meant to be a statically-configured parameter. However this could be turned into readable metrics as well
-
-We define the following formulas:
-
-* **Saturation**: a measure of "fullness" of the system, slightly reformulated from the metric described in [\[PUBLIC\] Improved Flow Control Request Management](https://docs.google.com/document/d/1JxzJc8gNv2wKK5-a8ohb0btn78ymVKw9XMIb4-S-ncA/edit?tab=t.0)
-  $\mathrm{F}\_\mathrm{SYS} = \frac{\mathrm{cur}\_\mathrm{SYS}}{\mathrm{max}\_\mathrm{SYS}}$
-* **Virtual Load** of the EPP: a measure of **fullness** as F, but relative to the internal queues of the EPP
-  $\mathrm{F}\_\mathrm{EPP} = \frac{\mathrm{cur}\_\mathrm{EPP}}{\mathrm{max}\_\mathrm{SYS}}$
-* A configurable **Reserved Baseline** (e.g., *B \= 0.05*) reserved for unexpected bursts in high-priority realtime traffic.
-
-Then, **Dispatch Budget** is a combined view of pool **Saturation,** **EPP Virtual Load**, and the **Reserved Baseline**. Because the denominator for   $\mathrm{F}\_\mathrm{SYS}$ and $\mathrm{F}\_\mathrm{EPP}$ is always $\mathrm{max}\_\mathrm{SYS}$, then we can write:
-
-$D = 1 -(\mathrm{F}\_\mathrm{SYS}+\mathrm{F}\_\mathrm{EPP}+B)$
-
-
-For a given Dispatch Budget, the expected remaining capacity of the system is just
-
-$\mathrm{max}_\mathrm{SYS}\times D$
-#### Example
-
-$\mathrm{F}\_\mathrm{SYS} = 0.5,   \quad    \mathrm{F}\_\mathrm{EPP} = 0.1, \quad     B=0.05$
-
-- Dispatch Budget \= *1 \- (0.5 \+ 0.1 \+ 0.05) \= 0.35*
-- $\mathrm{max}\_\mathrm{SYS} = 50$ requests
-- Dispatchable Requests \= *floor(50 \* 0.35) \= 17* requests in parallel
-
-### Request Lifecycle and Flow Control
-
-The **Batch Dispatcher** monitors the metrics and computes a **Dispatch Budget**.
-
-* When the Dispatch Budget *D* is **within a given range** \[0,u\], where **1** indicates **100%** of system capacity, and u**\<1,** then the Batch Dispatcher may forward ($\mathrm{max}\_\mathrm{SYS} \times D$) requests at once.
-* When $D>u$, then the Batch Dispatcher should stop forwarding requests until again $D\leq u$
-
-#### Failure Modes
-
-* **Queue Consumer Failures:** If the Batch Dispatcher pod crashes, the messages remain in the persistent Message Queue (Redis/PubSub), ensuring no data loss.
-* **IGW Backpressure:** If the IGW returns an HTTP error indicating overload (e.g. HTTP 429\) despite the computed budget, then the **saturation is assumed to be close to 1**, and therefore a **dispatch budget close to 0\.** The Batch Dispatcher will not retry until a subsequent update from the metrics store will bring it back within the acceptable limits.
-  * This might happen if a sudden spike of traffic enters the gateway and the metrics did not update on-time.
-* **Unreadable Metrics:** In case of unreadable metrics, the Batch Processor cannot take informed decisions, and therefore will assume a **dispatch budget of 0\.**
-
-### Deployment Model
-
-We propose two alternative strategies for deployment
-
-1. **Self-Contained Deployment:** A component in the **batch processing agent** described [\[Public Doc\] Serving Online Batch via Inference Gateway](https://docs.google.com/document/d/1notkq9s0qOmWmUNonZ8CfI-5jtGtHA4PGMI-xz8sGRE/edit?tab=t.0#heading=h.i76kzr3j3swj), effectively implementing a "strategy" to pull and forward requests from Message Queue to the IGW.
-2. **EPP Extension/Sidecar:** The scheduler lives within the same Pod as the EPP. This allows the scheduler to potentially access shared memory or local IPC for fast updates on model server saturation, bypassing metrics scraping delays.
-
-For the first iteration, we propose to implement **1**.
+Currently, the dispatcher is meant to be deployed stand-alone, with its own lifecycle. The dispatcher
+can read from multiple queues and dispatch to multiple inference pools. It can be also configured to dispatch
+to a single pool; in this case, you would configure one dispatcher for each pool.
 
 ## Open Questions & Thinking Points
 


### PR DESCRIPTION
Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>

## Why is this PR needed?

update docs, following up to https://github.com/llm-d-incubation/llm-d-async/pull/106 and @yizhaodev suggestions

## What does this PR do?

we update the docs with an alternative version of the formula of the dispatch budget, where instead we multiply F_SYS by F_EPP 

> $\mathrm{F}\_\mathrm{SYS}$ and $\mathrm{F}\_\mathrm{EPP}$ measure **independent capacity dimensions**; the inference backend and the gateway layer respectively. Their denominators may differ (e.g., the saturation detector normalizes by the dynamic pool capacity, while the EPP load normalizes by a configured constant). Because they are not fractions of the same pool, we compute their product:
> 
> $$D = (1 - \mathrm{F}\_\mathrm{SYS}) \times (1 - \mathrm{F}\_\mathrm{EPP}) \times (1 - B)$$ 
> 

## How was this tested?

the new proposal is better informed about the EPP codebase (GAIE), llm-d-async, and the shape of the available metrics

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

https://github.com/llm-d-incubation/llm-d-async/pull/106