### PR TITLE
refactor(worker): replace cancel flag with context hierarchy and harden error handling

### DIFF
--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -18,12 +18,14 @@ package worker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
+	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
 )
 
 func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams) {
@@ -43,8 +45,12 @@ func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams)
 			if event.Type == db.BatchEventCancel {
 				logger.V(logging.INFO).Info("watchCancel: cancel event received")
 
-				params.cancelRequested.Store(true)
-				params.abortInferFn()
+				// userCancelFn marks userCancelCtx as cancelled (user-cancel signal).
+				// requestAbortFn stops the dispatch loop immediately via requestAbortCtx.
+				params.userCancelFn()
+				if params.requestAbortFn != nil {
+					params.requestAbortFn()
+				}
 
 				// We don't update the DB status to 'cancelling' here because
 				// the API server already wrote 'cancelling' before sending this event.
@@ -54,31 +60,44 @@ func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams)
 }
 
 // handleCancelled finalizes a user-cancelled job.
-// When called after executeJob (execution), requestCounts and jobInfo are non-nil and partial
-// results are uploaded. When called before executeJob (ingestion), both are nil and only
-// cleanup + status transition is performed.
+// When called after executeJob (execution), requestCounts is non-nil and partial results are
+// uploaded. When called before executeJob (ingestion), requestCounts is nil — only cleanup
+// and status transition are performed. jobInfo is always non-nil on the normal runJob path
+// (it is populated before the job goroutine is launched).
+//
+// Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.
 func (p *Processor) handleCancelled(ctx context.Context, params *jobExecutionParams) error {
+	ioCtx, ioSpan := uotel.DetachedContext(ctx, "handle-cancelled")
+	ioCtx, ioCancel := context.WithTimeout(ioCtx, finalizationTimeout)
+	defer ioCancel()
+	defer ioSpan.End()
+
 	logger := logr.FromContextOrDiscard(ctx)
 
 	var outputFileID, errorFileID string
 	if params.requestCounts != nil && params.jobInfo != nil {
 		logger.V(logging.INFO).Info("Job cancelled mid-execution, uploading partial results")
-		outputFileID, errorFileID = p.uploadPartialResults(ctx, params.jobInfo, params.jobItem)
+		outputFileID, errorFileID = p.uploadPartialResults(ioCtx, params.jobInfo, params.jobItem)
 	}
 
-	p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
-
-	if err := params.updater.UpdateCancelledStatus(ctx, params.jobItem, params.requestCounts, outputFileID, errorFileID); err != nil {
-		logger.Error(err, "Failed to update status to cancelled")
-		return err
+	if err := params.updater.UpdateCancelledStatus(ioCtx, params.jobItem, params.requestCounts, outputFileID, errorFileID); err != nil {
+		logger.Error(err, "Failed to update cancelled status, falling back to failed with file IDs preserved")
+		if failErr := params.updater.UpdateFailedStatus(ioCtx, params.jobItem, params.requestCounts, outputFileID, errorFileID); failErr != nil {
+			return fmt.Errorf("failed to update job status to cancelled (%w) and fallback to failed also failed: %w", err, failErr)
+		}
+		// Cleanup after fallback succeeded so startup recovery doesn't re-process.
+		p.cleanupJobArtifacts(ioCtx, params.jobItem.ID, params.jobItem.TenantID)
+		return fmt.Errorf("cancelled status write failed: %w", errFinalizeFailedOver)
 	}
+
+	// Cleanup after terminal status write: if the write failed above, the local
+	// files survive for startup recovery to re-upload.
+	p.cleanupJobArtifacts(ioCtx, params.jobItem.ID, params.jobItem.TenantID)
 
 	setRequestCountAttrs(ctx, params.requestCounts)
 
 	recordE2ELatency(params.jobInfo, metrics.E2EStatusCancelled)
 
-	// requestCounts is non-nil only after executeJob populates it, so it
-	// reliably distinguishes execution-phase cancellation from queue-phase.
 	if params.requestCounts != nil {
 		metrics.RecordCancellation(metrics.CancelPhaseInProgress)
 	} else {

--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -45,12 +45,9 @@ func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams)
 			if event.Type == db.BatchEventCancel {
 				logger.V(logging.INFO).Info("watchCancel: cancel event received")
 
-				// userCancelFn marks userCancelCtx as cancelled (user-cancel signal).
-				// requestAbortFn stops the dispatch loop immediately via requestAbortCtx.
+				// userCancelFn marks userCancelCtx as cancelled. requestAbortCtx is
+				// automatically cancelled via context.AfterFunc wired in runJob.
 				params.userCancelFn()
-				if params.requestAbortFn != nil {
-					params.requestAbortFn()
-				}
 
 				// We don't update the DB status to 'cancelling' here because
 				// the API server already wrote 'cancelling' before sending this event.
@@ -81,8 +78,10 @@ func (p *Processor) handleCancelled(ctx context.Context, params *jobExecutionPar
 	}
 
 	if err := params.updater.UpdateCancelledStatus(ioCtx, params.jobItem, params.requestCounts, outputFileID, errorFileID); err != nil {
+		ioSpan.RecordError(err)
 		logger.Error(err, "Failed to update cancelled status, falling back to failed with file IDs preserved")
 		if failErr := params.updater.UpdateFailedStatus(ioCtx, params.jobItem, params.requestCounts, outputFileID, errorFileID); failErr != nil {
+			ioSpan.RecordError(failErr)
 			return fmt.Errorf("failed to update job status to cancelled (%w) and fallback to failed also failed: %w", err, failErr)
 		}
 		// Cleanup after fallback succeeded so startup recovery doesn't re-process.

--- a/internal/processor/worker/errors.go
+++ b/internal/processor/worker/errors.go
@@ -18,10 +18,30 @@ package worker
 
 import "errors"
 
-// Sentinel errors returned by executeJob to signal non-fatal terminal conditions.
-// These are checked by runJob / handleJobError to route to the appropriate handler.
-// Exported for test access; not referenced outside the processor package.
+// Sentinel errors used for routing within the processor worker.
+
 var (
-	ErrCancelled = errors.New("batch job cancelled") // user-initiated cancel
-	ErrExpired   = errors.New("batch SLO expired")   // SLO deadline reached during execution
+	// errCancelled signals a user-initiated batch job cancellation.
+	// Returned by preprocessor and executor when userCancelCtx is cancelled.
+	errCancelled = errors.New("batch job cancelled")
+
+	// errExpired signals that the batch SLO deadline was reached during execution.
+	// Returned by executor when the SLO context expires.
+	errExpired = errors.New("batch SLO expired")
+
+	// errRequestInputRead signals a fatal failure reading a request entry from the
+	// plan input file. Unlike per-request errors (which are embedded in output),
+	// this prevents the entire model from processing further.
+	errRequestInputRead = errors.New("failed to read request from input file")
+
+	// errShutdown signals that the processor is shutting down (SIGTERM).
+	// The job is re-enqueued so another worker can pick it up.
+	errShutdown = errors.New("processor shutting down")
+
+	// errFinalizeFailedOver signals that a terminal status transition (completed,
+	// cancelled) or an upload failed, but the fallback to failed status with
+	// surviving file IDs succeeded. The caller must NOT call handleFailed again,
+	// as that would overwrite file IDs with empty strings and orphan
+	// already-uploaded files.
+	errFinalizeFailedOver = errors.New("finalization fell back to failed")
 )

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -153,26 +154,26 @@ func (ep *executionProgress) counts() *openai.BatchRequestCounts {
 }
 
 // executeJob performs execution: reads plan files per model, sends inference
-// requests concurrently (one goroutine per model), and writes results to
+// requests concurrently (one goroutine per model, multiple requests per model), and writes results to
 // output.jsonl (successes) and error.jsonl (failures). Returns request counts for finalization.
 //
-// On success, returns (counts, nil). On interruption or error, undispatched requests are
-// drained to the error file with the appropriate code, writers are flushed, and partial counts
-// are returned alongside the sentinel/cause error:
-//   - SLO expired:    (counts, ErrExpired)    — drain as batch_expired
-//   - User cancel:    (counts, ErrCancelled)  — drain as batch_cancelled
-//   - System error:   (counts, firstErr)      — drain as batch_failed
-//   - Pod shutdown:   (nil, ctx.Err())        — no flush, caller re-enqueues
-
-// abortCtx is cancelled when the user requests batch cancellation. Cancelling it aborts all
-// in-flight inference HTTP requests immediately, freeing downstream resources (GPU slots, EPP
-// capacity). abortCtx is derived from sloCtx in the caller so the SLO deadline is also respected.
+// On success, returns (counts, nil). On interruption or error, output and error writers are
+// always flushed (buffered data written to the underlying files) before returning, and partial
+// counts are returned alongside the sentinel/cause error:
+//   - SLO expired:    (counts, errExpired)   — undispatched drained as batch_expired
+//   - User cancel:    (counts, errCancelled) — undispatched drained as batch_cancelled
+//   - System error:   (counts, firstErr)     — undispatched drained as batch_failed
+//   - Pod shutdown:   (counts, errShutdown)  — caller re-enqueues; counts reflect work done
+//     before SIGTERM, flush preserves partial output for startup recovery
 //
-// Dispatch abort relies solely on context cancellation (checkAbortCondition checks ctx.Err()).
-// The cancelRequested flag is NOT polled to stop dispatch; it is only consulted in the
-// error-handling path to distinguish the cancellation reason (user cancel vs SLO vs pod shutdown)
-// and to drain undispatched entries with the correct error code.
-func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
+// requestAbortCtx controls the dispatch loop and all in-flight inference calls: cancelling it
+// stops dispatch and aborts in-flight requests. It is derived from sloCtx in the caller (in runJob)
+// so SLO expiry and SIGTERM propagate automatically. watchCancel also calls requestAbortFn directly
+// for user-initiated cancellation.
+// userCancelCtx is a user-cancel-only signal derived from context.Background; it does not inherit
+// SLO expiry or SIGTERM. Its sole purpose is to let the drain phase distinguish user cancel from
+// SLO expiry.
+func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Starting execution: executing job")
 
@@ -193,7 +194,7 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 	if sloCtx.Err() == context.DeadlineExceeded {
 		logger.V(logging.INFO).Info("SLO already expired at execution start, skipping dispatch",
 			"total", modelMap.LineCount)
-		return &openai.BatchRequestCounts{Total: modelMap.LineCount, Failed: modelMap.RejectedCount}, ErrExpired
+		return &openai.BatchRequestCounts{Total: modelMap.LineCount, Failed: modelMap.RejectedCount}, errExpired
 	}
 
 	inputFilePath, err := p.jobInputFilePath(params.jobInfo.JobID, params.jobInfo.TenantID)
@@ -237,12 +238,8 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 		return nil, err
 	}
 
-	// one goroutine per model; concurrency within each model is bounded
-	// by globalSem (processor-wide concurrency limit) and perModelMaxConcurrency (per-model concurrency limit).
-	// execCtx is derived from abortCtx (which itself is derived from sloCtx) so both the SLO
-	// deadline and user-initiated cancellation propagate to all dispatch loops and inference calls.
-	execCtx, execCancel := context.WithCancel(abortCtx)
-	defer execCancel()
+	// requestAbortCtx and requestAbortFn are set in runJob before watchCancel starts,
+	// eliminating the race window where a cancel event could arrive before the fn is assigned.
 
 	progress := &executionProgress{
 		total:   modelMap.LineCount,
@@ -263,23 +260,35 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 		logger.V(logging.DEBUG).Info("pass-through headers attached to job", "headerNames", headerNames)
 	}
 
+	// User-initiated cancellation stops dispatch via two independent cancel calls:
+	// watchCancel calls userCancelFn() to mark userCancelCtx (user-cancel signal),
+	// and requestAbortFn() to cancel requestAbortCtx (stops dispatch loop).
+	// These are independent — userCancelCtx does NOT propagate to requestAbortCtx.
+	// processModel's drain phase checks sloCtx.Err() vs userCancelCtx.Err() to choose
+	// the right error code (errExpired vs errCancelled).
 	for safeModelID, modelID := range modelMap.SafeToModel {
-		// Ordering guarantee: processModel returns → execCancel → errCh send.
+		// Ordering guarantee: processModel returns → requestAbortFn → errCh send.
 		// This ensures the first real error reaches errCh before any context.Canceled
-		// from other models whose contexts were cancelled by execCancel.
+		// from other models whose contexts were cancelled by requestAbortFn.
 		go func(safeModelID, modelID string) {
 			err := p.processModel(
-				execCtx,
+				requestAbortCtx,
+				ctx,
 				sloCtx,
+				userCancelCtx,
 				inputFile,
 				plansDir, safeModelID, modelID,
 				writers,
-				params.cancelRequested,
 				progress,
 				passThroughHeaders,
 			)
+			// Cancel requestAbortCtx for all sibling models when this model fails.
+			// In production, params.requestAbortFn is always set by runJob before
+			// executeJob is called. Guard against nil for direct-call test paths.
 			if err != nil {
-				execCancel()
+				if fn := params.requestAbortFn; fn != nil {
+					fn()
+				}
 			}
 			errCh <- err
 		}(safeModelID, modelID)
@@ -297,37 +306,30 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 	progress.flush(ctx)
 
 	if firstErr != nil {
-		// prefer parent-context / user-cancel errors for correct routing in handleJobError
-		if ctx.Err() != nil {
-			return nil, ctx.Err() // parent-context error (e.g. pod shutdown)
+		// Flush partial results to disk before routing the error.
+		// Required for all non-nil firstErr paths: errExpired, errCancelled, system errors
+		// (callers upload from disk), and SIGTERM (startup recovery reads from disk on restart).
+		if err := writers.output.Flush(); err != nil {
+			logger.Error(err, "Failed to flush output file on error path (partial results may be truncated)")
 		}
-		if params.cancelRequested.Load() {
-			_ = writers.output.Flush()
-			_ = writers.errors.Flush()
-			counts := progress.counts()
-			logger.V(logging.INFO).Info("Execution cancelled, returning partial counts",
-				"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
-			return counts, ErrCancelled
+		if err := writers.errors.Flush(); err != nil {
+			logger.Error(err, "Failed to flush error file on error path (partial results may be truncated)")
 		}
-		// SLO deadline exceeded: sloCtx deadline fired during execution.
-		// processModel already drained undispatched entries to error file; flush and return partial counts.
-		// Use sloCtx.Err() rather than execCtx.Err(): execCtx may have been cancelled by a goroutine
-		// via execCancel() before the sloCtx deadline propagated, setting execCtx.Err() = Canceled.
-		if sloCtx.Err() == context.DeadlineExceeded {
-			// best-effort: flush the output and error files
-			_ = writers.output.Flush()
-			_ = writers.errors.Flush()
-			counts := progress.counts()
+		// processModel already drained undispatched entries and returned a sentinel (errExpired or
+		// errCancelled) or the underlying system error. All terminal handlers now use detached
+		// contexts, so we preserve processModel's decision even when SIGTERM is concurrent.
+		counts := progress.counts()
+		switch {
+		case errors.Is(firstErr, errExpired):
 			logger.V(logging.INFO).Info("Execution SLO expired, returning partial counts",
 				"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
-			return counts, ErrExpired
+		case errors.Is(firstErr, errCancelled):
+			logger.V(logging.INFO).Info("Execution cancelled, returning partial counts",
+				"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
+		default:
+			logger.V(logging.INFO).Info("Execution system error, returning partial counts",
+				"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
 		}
-		// System error from model goroutines — flush partial results.
-		_ = writers.output.Flush()
-		_ = writers.errors.Flush()
-		counts := progress.counts()
-		logger.V(logging.INFO).Info("Execution system error, returning partial counts",
-			"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
 		return counts, firstErr
 	}
 
@@ -342,10 +344,17 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 	logger.V(logging.INFO).Info("Execution completed",
 		"total", counts.Total, "completed", counts.Completed, "failed", counts.Failed)
 
-	// Cancel may have arrived after all requests were dispatched and completed normally
-	// (i.e. context cancellation never interrupted dispatch). Honour the cancellation.
-	if params.cancelRequested.Load() {
-		return counts, ErrCancelled
+	// A terminal signal may have arrived after all requests completed normally.
+	// SLO expiry and user cancel affect the job's terminal status even when all
+	// requests finished — e.g. "completed but past SLO" vs "completed".
+	// SIGTERM is NOT checked here: all output is already flushed to disk and counts
+	// are final, so the caller should proceed to finalizeJob (which uses a detached
+	// context) rather than re-enqueueing a fully-complete job.
+	switch {
+	case errors.Is(sloCtx.Err(), context.DeadlineExceeded):
+		return counts, errExpired
+	case userCancelCtx.Err() != nil:
+		return counts, errCancelled
 	}
 
 	return counts, nil
@@ -360,16 +369,17 @@ func (p *Processor) executeJob(ctx, sloCtx, abortCtx context.Context, params *jo
 //
 // Error strategy in this function: when a goroutine encounters a fatal error, modelErr is captured
 // via errOnce but the context is NOT cancelled within this function. Context cancellation is
-// propagated at the executeJob level (execCancel), which stops dispatch across all models.
+// propagated at the executeJob level (requestAbortFn), which stops dispatch across all models.
 // Already-dispatched goroutines may finish with errors or cancellation rather than successful
-// completion, depending on when execCancel fires.
+// completion, depending on when requestAbortFn fires.
 func (p *Processor) processModel(
 	ctx context.Context,
+	mainCtx context.Context,
 	sloCtx context.Context,
+	userCancelCtx context.Context,
 	inputFile *os.File,
 	plansDir, safeModelID, modelID string,
 	writers *outputWriters,
-	cancelRequested *atomic.Bool,
 	progress *executionProgress,
 	passThroughHeaders map[string]string,
 ) error {
@@ -379,15 +389,13 @@ func (p *Processor) processModel(
 	planPath := filepath.Join(plansDir, safeModelID+".plan")
 	entries, err := readPlanEntries(planPath)
 	if err != nil {
-		return fmt.Errorf("failed to read plan for model %s: %w", modelID, err)
+		return fmt.Errorf("model setup failed: read plan for model %s: %w", modelID, err)
 	}
 
 	logger.V(logging.INFO).Info("Processing requests for a model", "numEntries", len(entries))
 
-	modelSem, err := semaphore.New(p.cfg.PerModelMaxConcurrency, p.guardCallback)
-	if err != nil {
-		return fmt.Errorf("failed to create model semaphore: %w", err)
-	}
+	// PerModelMaxConcurrency > 0 is enforced by config validation; this cannot fail.
+	modelSem, _ := semaphore.New(p.cfg.PerModelMaxConcurrency, p.guardCallback)
 
 	var (
 		wg              sync.WaitGroup
@@ -398,8 +406,10 @@ func (p *Processor) processModel(
 
 dispatch:
 	for i, entry := range entries {
-		if err := checkAbortCondition(ctx); err != nil {
-			errOnce.Do(func() { modelErr = err })
+		if ctx.Err() != nil {
+			// Context cancelled (SLO expiry, SIGTERM, or user cancel via requestAbortFn).
+			// Do not set modelErr here; the drain switch determines the correct sentinel
+			// by inspecting sloCtx, userCancelCtx, and ctx independently.
 			break
 		}
 
@@ -423,17 +433,21 @@ dispatch:
 
 			result, execErr := p.executeOneRequest(ctx, sloCtx, inputFile, entry, modelID, passThroughHeaders)
 			if execErr != nil {
+				// Fatal read failure: the input file is unreadable at this offset
+				// (e.g. disk corruption). We do not know the CustomID, so we cannot
+				// write a batch_failed entry to the error file. This means
+				// completed + failed < total for this job, but the job status is
+				// set to failed, which already signals that output files are incomplete.
 				logger.Error(execErr, "Fatal error executing request", "offset", entry.Offset)
 				errOnce.Do(func() { modelErr = execErr })
 				return
 			}
 
-			// If cancel was requested while this request was in-flight,
+			// If user-initiated cancel arrived while this request was in-flight,
 			// overwrite the result as batch_cancelled and write to the error file
 			// so that output lines + error lines == total requests.
-			// Note: abortCtx is already cancelled at this point, so the HTTP
-			// request was aborted and this goroutine returns almost immediately.
-			if cancelRequested.Load() {
+			// SLO expiry does not overwrite in-flight results — only user cancel does.
+			if sloCtx.Err() == nil && userCancelCtx.Err() != nil {
 				result.Response = nil
 				result.Error = &outputError{
 					Code:    batch_types.ErrCodeBatchCancelled,
@@ -443,14 +457,14 @@ dispatch:
 
 				lineBytes, marshalErr := json.Marshal(result)
 				if marshalErr != nil {
-					logger.Error(marshalErr, "Failed to marshal cancelled output line", "offset", entry.Offset)
-					errOnce.Do(func() { modelErr = fmt.Errorf("failed to marshal cancelled line: %w", marshalErr) })
+					errOnce.Do(func() {
+						modelErr = fmt.Errorf("marshal cancelled output line at offset %d: %w", entry.Offset, marshalErr)
+					})
 					return
 				}
 				lineBytes = append(lineBytes, '\n')
 				if writeErr := writers.write(lineBytes, true); writeErr != nil {
-					logger.Error(writeErr, "Failed to write cancelled line", "offset", entry.Offset)
-					errOnce.Do(func() { modelErr = fmt.Errorf("failed to write cancelled line: %w", writeErr) })
+					errOnce.Do(func() { modelErr = fmt.Errorf("write cancelled output line at offset %d: %w", entry.Offset, writeErr) })
 				}
 				return
 			}
@@ -459,8 +473,7 @@ dispatch:
 
 			lineBytes, marshalErr := json.Marshal(result)
 			if marshalErr != nil {
-				logger.Error(marshalErr, "Failed to marshal output line", "offset", entry.Offset)
-				errOnce.Do(func() { modelErr = fmt.Errorf("failed to marshal output line: %w", marshalErr) })
+				errOnce.Do(func() { modelErr = fmt.Errorf("marshal output line at offset %d: %w", entry.Offset, marshalErr) })
 				return
 			}
 			lineBytes = append(lineBytes, '\n')
@@ -474,57 +487,72 @@ dispatch:
 				if isError {
 					kind = "error"
 				}
-				logger.Error(writeErr, "Failed to write line", "kind", kind, "offset", entry.Offset)
-				errOnce.Do(func() { modelErr = fmt.Errorf("failed to write %s line: %w", kind, writeErr) })
+				errOnce.Do(func() { modelErr = fmt.Errorf("write %s line at offset %d: %w", kind, entry.Offset, writeErr) })
 			}
 		}(entry)
 	}
 
 	wg.Wait()
 
-	// Drain undispatched entries to the error file based on the termination reason.
-	// Priority: SLO expiry > user cancel > system error.
-	// Use sloCtx.Err() rather than ctx.Err(): ctx (execCtx) may report Canceled if execCancel()
+	// Drain undispatched entries to the error file based on the termination reason, and return the
+	// appropriate sentinel so executeJob can route without re-examining context state.
+	// Priority: SLO expiry > user cancel > system error > pod shutdown.
+	// Use sloCtx.Err() rather than ctx.Err(): ctx (requestAbortCtx) may report Canceled if requestAbortFn()
 	// was called by another goroutine before the sloCtx deadline propagated.
-	// (Same rationale as the sloCtx check in executeJob.)
+	undispatched := entries[dispatchedCount:]
+	var returnErr error
 	switch {
-	case sloCtx.Err() == context.DeadlineExceeded && !cancelRequested.Load():
+	case errors.Is(sloCtx.Err(), context.DeadlineExceeded):
 		// SLO deadline fired during dispatch — record remaining requests as expired.
-		undispatched := entries[dispatchedCount:]
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("SLO expired: draining undispatched entries", "count", len(undispatched))
 			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchExpired,
 				"This request could not be executed before the completion window expired.")
 		}
+		returnErr = errExpired
 
-	case cancelRequested.Load():
+	case userCancelCtx.Err() != nil:
 		// User-initiated cancel — record remaining requests as cancelled.
-		undispatched := entries[dispatchedCount:]
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("Cancelled: draining undispatched entries", "count", len(undispatched))
 			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchCancelled,
 				"This request was not executed because the batch was cancelled.")
 		}
+		returnErr = errCancelled
 
 	case modelErr != nil:
 		// System error in a model goroutine — record remaining requests as failed.
-		undispatched := entries[dispatchedCount:]
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("Fatal error: draining undispatched entries", "count", len(undispatched))
 			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchFailed,
 				"This request was not executed because the batch encountered a system error.")
 		}
+		returnErr = modelErr
+
+	default:
+		if mainCtx.Err() != nil && len(undispatched) > 0 {
+			// Pod shutdown (SIGTERM): main processor context is cancelled.
+			// Do not drain here — startup recovery or the re-enqueued worker
+			// will process these entries from scratch.
+			returnErr = errShutdown
+		} else if ctx.Err() != nil && len(undispatched) > 0 {
+			// Sibling model abort: requestAbortCtx was cancelled by another
+			// model's error (requestAbortFn), but this is not SLO/cancel/SIGTERM.
+			// Drain undispatched entries as batch_failed so that
+			// completed + failed == total holds for the job.
+			logger.V(logging.INFO).Info("Sibling abort: draining undispatched entries", "count", len(undispatched))
+			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
+				batch_types.ErrCodeBatchFailed,
+				"This request was not executed because the batch encountered a system error.")
+		}
 	}
 
-	if modelErr == nil && ctx.Err() != nil {
-		modelErr = ctx.Err()
-	}
-
-	logger.V(logging.INFO).Info("Finished processing model", "numEntries", len(entries), "hasError", modelErr != nil)
-	return modelErr
+	siblingAbort := returnErr == nil && ctx.Err() != nil
+	logger.V(logging.INFO).Info("Finished processing model", "numEntries", len(entries), "hasError", returnErr != nil, "siblingAbort", siblingAbort)
+	return returnErr
 }
 
 // drainUnprocessedRequests records undispatched requests in the error file when a job terminates
@@ -644,7 +672,7 @@ func (p *Processor) executeOneRequest(
 	// read the request line from input.jsonl at the given offset and length
 	buf := make([]byte, entry.Length)
 	if _, err := inputFile.ReadAt(buf, entry.Offset); err != nil {
-		return nil, fmt.Errorf("failed to read plan entry input at offset %d: %w", entry.Offset, err)
+		return nil, fmt.Errorf("%w at offset %d: %w", errRequestInputRead, entry.Offset, err)
 	}
 
 	// trim the newline character from the request line

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -377,7 +377,7 @@ func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx conte
 // Already-dispatched goroutines may finish with errors or cancellation rather than successful
 // completion, depending on when requestAbortFn fires.
 func (p *Processor) processModel(
-	ctx context.Context,
+	requestAbortCtx context.Context,
 	mainCtx context.Context,
 	sloCtx context.Context,
 	userCancelCtx context.Context,
@@ -387,8 +387,8 @@ func (p *Processor) processModel(
 	progress *executionProgress,
 	passThroughHeaders map[string]string,
 ) error {
-	logger := logr.FromContextOrDiscard(ctx).WithValues("model", modelID)
-	ctx = logr.NewContext(ctx, logger)
+	logger := logr.FromContextOrDiscard(requestAbortCtx).WithValues("model", modelID)
+	requestAbortCtx = logr.NewContext(requestAbortCtx, logger)
 
 	planPath := filepath.Join(plansDir, safeModelID+".plan")
 	entries, err := readPlanEntries(planPath)
@@ -410,20 +410,20 @@ func (p *Processor) processModel(
 
 dispatch:
 	for i, entry := range entries {
-		if ctx.Err() != nil {
+		if requestAbortCtx.Err() != nil {
 			// Context cancelled (SLO expiry, SIGTERM, or user cancel via requestAbortFn).
 			// Do not set modelErr here; the drain switch determines the correct sentinel
-			// by inspecting sloCtx, userCancelCtx, and ctx independently.
+			// by inspecting sloCtx, userCancelCtx, and requestAbortCtx independently.
 			break
 		}
 
 		// Acquire semaphores in order: local (per-model) before global (shared).
 		// This order prevents starving other models — blocking on global only wastes a local slot.
-		if err := modelSem.Acquire(ctx); err != nil {
+		if err := modelSem.Acquire(requestAbortCtx); err != nil {
 			break dispatch
 		}
 
-		if err := p.globalSem.Acquire(ctx); err != nil {
+		if err := p.globalSem.Acquire(requestAbortCtx); err != nil {
 			modelSem.Release()
 			break dispatch
 		}
@@ -435,7 +435,7 @@ dispatch:
 			defer modelSem.Release()
 			defer p.globalSem.Release()
 
-			result, execErr := p.executeOneRequest(ctx, sloCtx, inputFile, entry, modelID, passThroughHeaders)
+			result, execErr := p.executeOneRequest(requestAbortCtx, sloCtx, inputFile, entry, modelID, passThroughHeaders)
 			if execErr != nil {
 				// Fatal read failure: the input file is unreadable at this offset
 				// (e.g. disk corruption). We do not know the CustomID, so we cannot
@@ -457,7 +457,7 @@ dispatch:
 					Code:    batch_types.ErrCodeBatchCancelled,
 					Message: "This request was cancelled while in progress.",
 				}
-				progress.record(ctx, false)
+				progress.record(requestAbortCtx, false)
 
 				lineBytes, marshalErr := json.Marshal(result)
 				if marshalErr != nil {
@@ -473,7 +473,7 @@ dispatch:
 				return
 			}
 
-			progress.record(ctx, result.isSuccess())
+			progress.record(requestAbortCtx, result.isSuccess())
 
 			lineBytes, marshalErr := json.Marshal(result)
 			if marshalErr != nil {
@@ -501,8 +501,8 @@ dispatch:
 	// Drain undispatched entries to the error file based on the termination reason, and return the
 	// appropriate sentinel so executeJob can route without re-examining context state.
 	// Priority: SLO expiry > user cancel > system error > pod shutdown.
-	// Use sloCtx.Err() rather than ctx.Err(): ctx (requestAbortCtx) may report Canceled if requestAbortFn()
-	// was called by another goroutine before the sloCtx deadline propagated.
+	// Use sloCtx.Err() rather than requestAbortCtx.Err(): requestAbortCtx may report Canceled if
+	// requestAbortFn() was called by another goroutine before the sloCtx deadline propagated.
 	undispatched := entries[dispatchedCount:]
 	var returnErr error
 	switch {
@@ -510,7 +510,7 @@ dispatch:
 		// SLO deadline fired during dispatch — record remaining requests as expired.
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("SLO expired: draining undispatched entries", "count", len(undispatched))
-			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
+			p.drainUnprocessedRequests(requestAbortCtx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchExpired,
 				"This request could not be executed before the completion window expired.")
 		}
@@ -520,7 +520,7 @@ dispatch:
 		// User-initiated cancel — record remaining requests as cancelled.
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("Cancelled: draining undispatched entries", "count", len(undispatched))
-			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
+			p.drainUnprocessedRequests(requestAbortCtx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchCancelled,
 				"This request was not executed because the batch was cancelled.")
 		}
@@ -530,7 +530,7 @@ dispatch:
 		// System error in a model goroutine — record remaining requests as failed.
 		if len(undispatched) > 0 {
 			logger.V(logging.INFO).Info("Fatal error: draining undispatched entries", "count", len(undispatched))
-			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
+			p.drainUnprocessedRequests(requestAbortCtx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchFailed,
 				"This request was not executed because the batch encountered a system error.")
 		}
@@ -542,19 +542,19 @@ dispatch:
 			// Do not drain here — startup recovery or the re-enqueued worker
 			// will process these entries from scratch.
 			returnErr = errShutdown
-		} else if ctx.Err() != nil && len(undispatched) > 0 {
+		} else if requestAbortCtx.Err() != nil && len(undispatched) > 0 {
 			// Sibling model abort: requestAbortCtx was cancelled by another
 			// model's error (requestAbortFn), but this is not SLO/cancel/SIGTERM.
 			// Drain undispatched entries as batch_failed so that
 			// completed + failed == total holds for the job.
 			logger.V(logging.INFO).Info("Sibling abort: draining undispatched entries", "count", len(undispatched))
-			p.drainUnprocessedRequests(ctx, inputFile, undispatched, writers, progress,
+			p.drainUnprocessedRequests(requestAbortCtx, inputFile, undispatched, writers, progress,
 				batch_types.ErrCodeBatchFailed,
 				"This request was not executed because the batch encountered a system error.")
 		}
 	}
 
-	siblingAbort := returnErr == nil && ctx.Err() != nil
+	siblingAbort := returnErr == nil && requestAbortCtx.Err() != nil
 	logger.V(logging.INFO).Info("Finished processing model", "numEntries", len(entries), "hasError", returnErr != nil, "siblingAbort", siblingAbort)
 	return returnErr
 }

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -282,9 +282,13 @@ func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx conte
 				progress,
 				passThroughHeaders,
 			)
-			// Cancel requestAbortCtx for all sibling models when this model fails.
-			// In production, params.requestAbortFn is always set by runJob before
-			// executeJob is called. Guard against nil for direct-call test paths.
+			// Abort all sibling models when any model hits a fatal I/O error
+			// (e.g. output file write failure). modelErr is only set for local
+			// I/O failures — not inference errors, which are recorded normally
+			// in the error file. Since all models share the same output writers,
+			// a write failure in one model means the shared file is unusable
+			// and continuing other models would produce corrupt output.
+			// Guard against nil requestAbortFn for direct-call test paths.
 			if err != nil {
 				if fn := params.requestAbortFn; fn != nil {
 					fn()

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2027,7 +2027,7 @@ func TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired(t *te
 }
 
 // =====================================================================
-// Tests: handleCancelled / handleFailedWithPartial / handleFailed
+// Tests: handleCancelled / handleFailed
 // with partial output
 // =====================================================================
 
@@ -2169,7 +2169,7 @@ func TestHandleCancelled_CancelledWriteFails_FallsBackToFailed(t *testing.T) {
 	}
 }
 
-func TestHandleFailedWithPartial_Execution_UploadsPartialOutput(t *testing.T) {
+func TestHandleFailed_Execution_UploadsPartialOutput(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -2191,8 +2191,8 @@ func TestHandleFailedWithPartial_Execution_UploadsPartialOutput(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 10, Completed: 7, Failed: 3}
 
 	ctx := testLoggerCtx(t)
-	if err := env.p.handleFailedWithPartial(ctx, env.updater, dbJob, jobInfo, counts); err != nil {
-		t.Fatalf("handleFailedWithPartial: %v", err)
+	if err := env.p.handleFailed(ctx, env.updater, dbJob, counts, jobInfo); err != nil {
+		t.Fatalf("handleFailed: %v", err)
 	}
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -588,7 +588,6 @@ func TestProcessModel_Success(t *testing.T) {
 
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	cancelReq := &atomic.Bool{}
 
 	progress := &executionProgress{
 		total:   int64(len(requests)),
@@ -600,7 +599,7 @@ func TestProcessModel_Success(t *testing.T) {
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.processModel(ctx, ctx, inputFile, plansDir, "m1", "m1", writers, cancelReq, progress, nil)
+	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
 	if err != nil {
 		t.Fatalf("processModel error: %v", err)
 	}
@@ -624,10 +623,8 @@ func TestProcessModel_Success(t *testing.T) {
 	}
 }
 
-// TestProcessModel_CancelStopsDispatch verifies that when the context is cancelled
-// and cancelRequested is set (matching the real watchCancel flow), processModel stops
-// dispatch via context cancellation and drains undispatched entries as batch_cancelled
-// using the cancelRequested flag to determine the drain reason.
+// TestProcessModel_CancelStopsDispatch verifies that when userCancelCtx is cancelled,
+// processModel stops dispatch and drains undispatched entries as batch_cancelled.
 func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -645,8 +642,6 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	cancelReq := &atomic.Bool{}
-	cancelReq.Store(true)
 
 	progress := &executionProgress{
 		total:   1,
@@ -658,17 +653,20 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	errWriter := bufio.NewWriter(&errBuf)
 	writers := &outputWriters{output: writer, errors: errWriter}
 
-	// Cancel context to simulate the real flow: watchCancel cancels abortCtx (which
-	// propagates to execCtx passed to processModel) AND sets cancelRequested.
-	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	// Cancel ctx to simulate requestAbortCtx being cancelled (by watchCancel calling requestAbortFn).
+	// Separately pass ctx as userCancelCtx so drain chooses errCancelled, not errShutdown.
+	// mainCtx (baseCtx) is not cancelled — errShutdown should NOT fire.
+	// sloCtx is background — drain should choose userCancelCtx path (errCancelled), not SLO.
+	baseCtx := testLoggerCtx(t)
+	ctx, cancel := context.WithCancel(baseCtx)
 	cancel()
 
-	err := env.p.processModel(ctx, ctx, inputFile, plansDir, "m1", "m1", writers, cancelReq, progress, nil)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected context.Canceled, got: %v", err)
+	err := env.p.processModel(ctx, baseCtx, context.Background(), ctx, inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got: %v", err)
 	}
 
-	// Verify that undispatched entry was drained as batch_cancelled (reason from cancelRequested).
+	// Verify that undispatched entry was drained as batch_cancelled.
 	if flushErr := errWriter.Flush(); flushErr != nil {
 		t.Fatalf("flush error writer: %v", flushErr)
 	}
@@ -685,23 +683,22 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	}
 }
 
-// TestProcessModel_CancelWritesInFlightToErrorFile verifies that when cancelRequested
-// is set while an inference request is in-flight, the completed result is overwritten
-// as batch_cancelled and written to the error file (not silently dropped).
+// TestProcessModel_CancelWritesInFlightToErrorFile verifies that when userCancelCtx is
+// cancelled after inference returns (but before the goroutine writes the result), the
+// completed response is overwritten as batch_cancelled and written to the error file.
+// This tests the "late cancel overwrite" path — the cancel arrives between Generate()
+// returning and the result being written. processModel must return errCancelled.
 func TestProcessModel_CancelWritesInFlightToErrorFile(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 	cfg.GlobalConcurrency = 10
 	cfg.PerModelMaxConcurrency = 10
 
-	cancelReq := &atomic.Bool{}
+	userCancelCtx, abortFn := context.WithCancel(context.Background())
 
 	mock := &mockInferenceClient{
 		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			// Simulate cancel arriving while the request is in-flight:
-			// set the flag after inference "completes" but before the
-			// goroutine checks cancelRequested.
-			cancelReq.Store(true)
+			abortFn()
 			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
 		},
 	}
@@ -729,7 +726,10 @@ func TestProcessModel_CancelWritesInFlightToErrorFile(t *testing.T) {
 	}
 
 	ctx := testLoggerCtx(t)
-	_ = env.p.processModel(ctx, ctx, inputFile, plansDir, "m1", "m1", writers, cancelReq, progress, nil)
+	modelErr := env.p.processModel(ctx, ctx, ctx, userCancelCtx, inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	if !errors.Is(modelErr, errCancelled) {
+		t.Fatalf("expected errCancelled from processModel, got: %v", modelErr)
+	}
 
 	if flushErr := outWriter.Flush(); flushErr != nil {
 		t.Fatalf("flush output: %v", flushErr)
@@ -797,7 +797,6 @@ func TestProcessModel_InferenceFatalError(t *testing.T) {
 
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	cancelReq := &atomic.Bool{}
 
 	progress := &executionProgress{
 		total:   int64(len(requests)),
@@ -809,7 +808,7 @@ func TestProcessModel_InferenceFatalError(t *testing.T) {
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.processModel(ctx, ctx, inputFile, plansDir, "m1", "m1", writers, cancelReq, progress, nil)
+	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
 	if err == nil {
 		t.Fatalf("expected error from closed input file")
 	}
@@ -845,7 +844,6 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	cancelReq := &atomic.Bool{}
 
 	progress := &executionProgress{
 		total:   int64(len(requests)),
@@ -860,7 +858,7 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- env.p.processModel(ctx, ctx, inputFile, plansDir, "m1", "m1", writers, cancelReq, progress, nil)
+		done <- env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
 	}()
 
 	<-started
@@ -870,6 +868,51 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 	err := <-done
 	if err == nil {
 		t.Fatalf("expected error on context cancellation")
+	}
+}
+
+// TestProcessModel_SiblingAbort_ReturnsNil verifies that when requestAbortCtx is cancelled
+// by a sibling model error (via requestAbortFn), processModel returns nil rather than errShutdown.
+//
+// P1c regression: Before the fix, the drain-switch default checked ctx.Err() (which is
+// requestAbortCtx), so a sibling abort looked like a pod shutdown and returned errShutdown.
+// executeJob would then route the job to re-enqueue instead of failed-with-partial, breaking
+// retry safety for batches with partial results. After the fix, the default checks mainCtx
+// (the main processor context), which is only cancelled on SIGTERM.
+func TestProcessModel_SiblingAbort_ReturnsNil(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	requests := []batch_types.Request{
+		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{}, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	plansDir, _ := env.p.jobPlansDir(jobInfo.JobID, jobInfo.TenantID)
+
+	var buf bytes.Buffer
+	writers := &outputWriters{output: bufio.NewWriter(&buf), errors: bufio.NewWriter(&buf)}
+
+	progress := &executionProgress{
+		total:   1,
+		updater: env.updater,
+		jobID:   jobInfo.JobID,
+	}
+
+	// mainCtx is not cancelled — only requestAbortCtx is, simulating a sibling model calling
+	// requestAbortFn() on error. SLO and user-cancel signals are both absent.
+	mainCtx := testLoggerCtx(t)
+	requestAbortCtx, requestAbortFn := context.WithCancel(mainCtx)
+	requestAbortFn() // simulate sibling model calling requestAbortFn
+
+	err := env.p.processModel(requestAbortCtx, mainCtx, mainCtx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	// requestAbortCtx cancelled, but no SLO / user-cancel / SIGTERM → nil, not errShutdown
+	if err != nil {
+		t.Fatalf("expected nil when only requestAbortCtx is cancelled (sibling abort), got: %v", err)
 	}
 }
 
@@ -887,13 +930,11 @@ func TestExecuteJob_SingleModel(t *testing.T) {
 		{CustomID: "r2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
@@ -913,6 +954,31 @@ func TestExecuteJob_SingleModel(t *testing.T) {
 	outputLines := bytes.Split(bytes.TrimSpace(outBytes), []byte{'\n'})
 	if len(outputLines) != 2 {
 		t.Fatalf("output lines = %d, want 2", len(outputLines))
+	}
+
+	// Verify each custom_id appears exactly once — guards against duplicates.
+	seenIDs := make(map[string]int)
+	for _, line := range outputLines {
+		var entry outputLine
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal output line: %v", err)
+		}
+		seenIDs[entry.CustomID]++
+	}
+	for _, wantID := range []string{"r1", "r2"} {
+		if seenIDs[wantID] != 1 {
+			t.Errorf("custom_id %q appeared %d times, want 1", wantID, seenIDs[wantID])
+		}
+	}
+
+	// Error file should be empty (all requests succeeded).
+	errorPath, _ := env.p.jobErrorFilePath(jobInfo.JobID, jobInfo.TenantID)
+	errBytes, err := os.ReadFile(errorPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read error file: %v", err)
+	}
+	if len(bytes.TrimSpace(errBytes)) > 0 {
+		t.Fatalf("expected empty error file, got: %s", errBytes)
 	}
 }
 
@@ -935,13 +1001,11 @@ func TestExecuteJob_MultipleModels(t *testing.T) {
 		{CustomID: "d", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m2"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1", "m2": "m2"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
@@ -951,6 +1015,30 @@ func TestExecuteJob_MultipleModels(t *testing.T) {
 	}
 	if int(callCount.Load()) != 4 {
 		t.Fatalf("inference calls = %d, want 4", callCount.Load())
+	}
+
+	// Verify each custom_id appears exactly once and all 4 are present.
+	outputPath, _ := env.p.jobOutputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	outBytes, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	outputLines := bytes.Split(bytes.TrimSpace(outBytes), []byte{'\n'})
+	if len(outputLines) != 4 {
+		t.Fatalf("output lines = %d, want 4", len(outputLines))
+	}
+	seenIDs := make(map[string]int)
+	for _, line := range outputLines {
+		var entry outputLine
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("unmarshal output line: %v", err)
+		}
+		seenIDs[entry.CustomID]++
+	}
+	for _, wantID := range []string{"a", "b", "c", "d"} {
+		if seenIDs[wantID] != 1 {
+			t.Errorf("custom_id %q appeared %d times, want 1", wantID, seenIDs[wantID])
+		}
 	}
 }
 
@@ -969,66 +1057,42 @@ func TestExecuteJob_ContextCancelled(t *testing.T) {
 		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx, cancel := context.WithCancel(testLoggerCtx(t))
 	cancel()
 
-	_, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	_, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
 	if err == nil {
 		t.Fatalf("expected error on cancelled context")
 	}
+	// All four contexts are the same cancelled context. sloCtx.Err() == context.Canceled
+	// (not DeadlineExceeded), so the SLO branch is skipped. userCancelCtx.Err() != nil,
+	// so the drain switch routes to errCancelled.
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got: %v", err)
+	}
 }
 
-// TestExecuteJob_UserCancelFlag verifies that when abortCtx is cancelled and cancelRequested
-// is set (matching the real watchCancel flow), executeJob returns ErrCancelled. Context
-// cancellation stops dispatch; cancelRequested is used in the error-handling path to
-// return the correct sentinel error.
+// TestExecuteJob_UserCancelFlag verifies that when only userCancelCtx is cancelled
+// (ctx, sloCtx, and requestAbortCtx all remain alive), executeJob returns errCancelled.
+// This enforces the separation contract: userCancelCtx is an independent signal derived
+// from context.Background() in production. requestAbortCtx must NOT be cancelled here —
+// the dispatch loop runs to completion, the mock returns a normal response, and the
+// post-execution switch detects userCancelCtx.Err() to produce errCancelled.
+// If requestAbortCtx were also cancelled, the test would pass even if the two contexts
+// were conflated, hiding regressions.
 func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
-	requests := []batch_types.Request{
-		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
-	}
-	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{}, requests, map[string]string{"m1": "m1"})
+	userCancelCtx, cancelFn := context.WithCancel(context.Background())
 
-	cancelReq := &atomic.Bool{}
-	cancelReq.Store(true)
-
-	ctx := testLoggerCtx(t)
-	abortCtx, abortFn := context.WithCancel(ctx)
-	abortFn()
-
-	_, err := env.p.executeJob(ctx, ctx, abortCtx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
-	})
-	if !errors.Is(err, ErrCancelled) {
-		t.Fatalf("expected ErrCancelled, got: %v", err)
-	}
-}
-
-// TestExecuteJob_CancelFlagSetAfterAllRequestsComplete verifies that if the cancel flag is set
-// after all requests have already been dispatched and completed successfully (i.e. context
-// cancellation never interrupted dispatch), executeJob still returns ErrCancelled rather than
-// nil, preventing the job from being finalized as "completed".
-func TestExecuteJob_CancelFlagSetAfterAllRequestsComplete(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.WorkDir = t.TempDir()
-
-	cancelReq := &atomic.Bool{}
-
-	// The mock sets cancelRequested=true only after the inference call returns, simulating
-	// the race where the cancel event arrives while (or just after) the last request completes.
 	mock := &mockInferenceClient{
 		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			cancelReq.Store(true)
+			cancelFn()
 			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
 		},
 	}
@@ -1039,19 +1103,101 @@ func TestExecuteJob_CancelFlagSetAfterAllRequestsComplete(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx(t)
-	_, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+
+	counts, err := env.p.executeJob(ctx, ctx, userCancelCtx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
-	if !errors.Is(err, ErrCancelled) {
-		t.Fatalf("expected ErrCancelled when cancel flag set after all requests complete, got: %v", err)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got: %v", err)
+	}
+	if counts == nil || counts.Total != 1 {
+		t.Fatalf("expected counts with Total=1, got %+v", counts)
+	}
+	if counts.Failed != 1 {
+		t.Fatalf("expected Failed=1 (cancel overwrites completed response as batch_cancelled), got %+v", counts)
 	}
 }
 
-// TestExecuteJob_AbortCtxCancel_AbortsInflightRequests verifies that cancelling abortCtx
-// aborts in-flight inference requests. The mock blocks until it sees context cancellation,
-// simulating a long-running inference call that should be interrupted.
+// TestExecuteJob_CancelAfterAllRequestsComplete verifies that if userCancelCtx is cancelled
+// after all requests have already been dispatched and completed successfully (i.e. context
+// cancellation never interrupted dispatch), executeJob still returns errCancelled rather than
+// nil, preventing the job from being finalized as "completed".
+func TestExecuteJob_CancelAfterAllRequestsComplete(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	userCancelCtx, abortFn := context.WithCancel(context.Background())
+
+	// The mock cancels userCancelCtx after the inference call returns, simulating
+	// the race where the cancel event arrives while (or just after) the last request completes.
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			abortFn()
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	ctx := testLoggerCtx(t)
+	_, err := env.p.executeJob(ctx, ctx, userCancelCtx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
+	})
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled when cancel arrives after all requests complete, got: %v", err)
+	}
+}
+
+// TestExecuteJob_SIGTERMAfterAllComplete verifies that when all requests finish successfully
+// and SIGTERM arrives before executeJob returns, the function returns nil (not errShutdown).
+// This ensures the caller proceeds to finalizeJob (which uses a detached context) rather than
+// re-enqueueing a fully-complete job.
+func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	// ctx (processor/main context) is cancelled after the inference call returns,
+	// simulating SIGTERM arriving just after the last request completes.
+	mainCtx, mainCancel := context.WithCancel(testLoggerCtx(t))
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			mainCancel()
+			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	userCancelCtx := context.Background()
+	counts, err := env.p.executeJob(mainCtx, mainCtx, userCancelCtx, mainCtx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error when SIGTERM arrives after all requests complete, got: %v", err)
+	}
+	if counts == nil {
+		t.Fatal("expected non-nil counts")
+	}
+	if counts.Total != 1 || counts.Completed != 1 {
+		t.Fatalf("counts = {Total:%d, Completed:%d, Failed:%d}, want {1,1,0}",
+			counts.Total, counts.Completed, counts.Failed)
+	}
+}
+
+// TestExecuteJob_AbortCtxCancel_AbortsInflightRequests verifies that a user cancel aborts
+// in-flight inference requests. The test calls both userCancelFn() (user-cancel signal) and
+// requestAbortFn() (stops dispatch), mirroring watchCancel's production behavior. The mock
+// blocks until requestAbortCtx cancellation propagates to its ctx argument. executeJob must
+// return errCancelled with the in-flight request counted as failed.
 func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -1075,32 +1221,37 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	cancelReq := &atomic.Bool{}
 	ctx := testLoggerCtx(t)
-	abortCtx, abortInferFn := context.WithCancel(ctx)
+	// userCancelCtx must be background-derived (user-cancel-only signal, no parent propagation).
+	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
+	// requestAbortCtx is pre-set in params before the goroutine starts, matching the production
+	// flow where runJob sets requestAbortFn before starting watchCancel.
+	requestAbortCtx, requestAbortFn := context.WithCancel(ctx)
 
+	params := &jobExecutionParams{
+		updater:        env.updater,
+		jobInfo:        jobInfo,
+		requestAbortFn: requestAbortFn,
+	}
 	type result struct {
 		counts *openai.BatchRequestCounts
 		err    error
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, ctx, abortCtx, &jobExecutionParams{
-			updater:         env.updater,
-			jobInfo:         jobInfo,
-			cancelRequested: cancelReq,
-		})
+		counts, err := env.p.executeJob(ctx, ctx, userCancelCtx, requestAbortCtx, params)
 		resCh <- result{counts, err}
 	}()
 
 	<-inferStarted
-	cancelReq.Store(true)
-	abortInferFn()
+	// Simulate watchCancel: set userCancelCtx (user-cancel signal) and stop dispatch via requestAbortFn.
+	userCancelFn()
+	requestAbortFn()
 
 	select {
 	case res := <-resCh:
-		if !errors.Is(res.err, ErrCancelled) {
-			t.Fatalf("expected ErrCancelled, got: %v", res.err)
+		if !errors.Is(res.err, errCancelled) {
+			t.Fatalf("expected errCancelled, got: %v", res.err)
 		}
 		if res.counts == nil {
 			t.Fatal("expected non-nil counts")
@@ -1115,12 +1266,12 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 			t.Errorf("Failed = %d, want 1 (aborted request counted as failed)", res.counts.Failed)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("executeJob did not return within 5s after abortCtx cancellation")
+		t.Fatal("executeJob did not return within 5s after userCancelCtx cancellation")
 	}
 }
 
 // TestExecuteJob_SLOExpiredBeforeDispatch verifies that when the SLO deadline has already
-// passed before execution begins, executeJob returns ErrExpired immediately with the total
+// passed before execution begins, executeJob returns errExpired immediately with the total
 // request count and no output/error files are written (early-exit fast path).
 func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 	cfg := config.NewConfig()
@@ -1132,20 +1283,18 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 		{CustomID: "r3", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{}, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
 	// SLO deadline already in the past: early check fires before any files are opened.
 	sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer cancel()
 
-	counts, err := env.p.executeJob(ctx, sloCtx, sloCtx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	counts, err := env.p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
-	if !errors.Is(err, ErrExpired) {
-		t.Fatalf("expected ErrExpired, got: %v", err)
+	if !errors.Is(err, errExpired) {
+		t.Fatalf("expected errExpired, got: %v", err)
 	}
 	if counts == nil {
 		t.Fatal("expected non-nil counts")
@@ -1176,14 +1325,16 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 // TestExecuteJob_SLOExpiredDuringDispatch verifies that when the SLO deadline fires while
 // requests are being dispatched, completed requests are preserved in the output file,
 // undispatched requests are drained to the error file as batch_expired, and executeJob
-// returns ErrExpired with accurate partial counts.
+// returns errExpired with accurate partial counts.
 //
-// This exercises the full context-cancellation chain for SLO expiry:
+// Context hierarchy for SLO expiry:
 //
-//	sloCtx (WithDeadline) → abortCtx (WithCancel) → execCtx (WithCancel)
-//	         DeadlineExceeded       Canceled                Canceled
+//	processorCtx → sloCtx (WithDeadline) → requestAbortCtx (WithCancel)
+//	                        DeadlineExceeded        Canceled (propagated)
 //
-// checkAbortCondition sees Canceled on execCtx to stop dispatch;
+//	userCancelCtx (WithCancel, derived from context.Background — NOT in the chain above)
+//
+// requestAbortCtx sees Canceled to stop dispatch;
 // processModel's drain switch checks sloCtx.Err() == DeadlineExceeded to select batch_expired.
 func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 	cfg := config.NewConfig()
@@ -1208,7 +1359,6 @@ func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 		{CustomID: "r3", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
 	// Use context.WithDeadline so sloCtx.Err() returns DeadlineExceeded (matching real code).
@@ -1221,18 +1371,17 @@ func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, sloCtx, sloCtx, &jobExecutionParams{
-			updater:         env.updater,
-			jobInfo:         jobInfo,
-			cancelRequested: cancelReq,
+		counts, err := env.p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+			updater: env.updater,
+			jobInfo: jobInfo,
 		})
 		resCh <- result{counts, err}
 	}()
 
 	select {
 	case res := <-resCh:
-		if !errors.Is(res.err, ErrExpired) {
-			t.Fatalf("expected ErrExpired, got: %v", res.err)
+		if !errors.Is(res.err, errExpired) {
+			t.Fatalf("expected errExpired, got: %v", res.err)
 		}
 		if res.counts == nil {
 			t.Fatal("expected non-nil counts")
@@ -1297,8 +1446,7 @@ func TestFinalizeJob_Success(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
 	ctx := testLoggerCtx(t)
-	var cancelRequested atomic.Bool
-	err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts, &cancelRequested)
+	err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts)
 	if err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
@@ -1319,6 +1467,9 @@ func TestFinalizeJob_Success(t *testing.T) {
 	}
 }
 
+// TestFinalizeJob_UploadFailure verifies that when all uploads fail, finalizeJob marks the
+// job as failed (not completed) and returns errFinalizeFailedOver. The job must not be
+// marked completed with missing artifacts — that would violate the batch contract.
 func TestFinalizeJob_UploadFailure(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -1343,10 +1494,21 @@ func TestFinalizeJob_UploadFailure(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1}
 
 	ctx := testLoggerCtx(t)
-	var cancelRequested atomic.Bool
-	err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts, &cancelRequested)
-	if err == nil {
-		t.Fatalf("expected error from upload failure")
+	err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts)
+	if !errors.Is(err, errFinalizeFailedOver) {
+		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
+	}
+
+	items, _, _, getErr := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed (upload failure must not produce completed)", got.Status)
 	}
 }
 
@@ -1375,13 +1537,11 @@ func TestExecuteJob_SeparatesSuccessAndErrors(t *testing.T) {
 		{CustomID: "r2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
@@ -1457,13 +1617,11 @@ func TestExecuteJob_HTTPErrorGoesToOutputFile(t *testing.T) {
 		{CustomID: "r3", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
-	cancelReq := &atomic.Bool{}
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         env.updater,
-		jobInfo:         jobInfo,
-		cancelRequested: cancelReq,
+	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: env.updater,
+		jobInfo: jobInfo,
 	})
 	if err != nil {
 		t.Fatalf("executeJob error: %v", err)
@@ -1567,8 +1725,7 @@ func TestFinalizeJob_EmptyOutputFile_OutputFileIDOmitted(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 0, Failed: 1}
 
 	ctx := testLoggerCtx(t)
-	var cancelRequested atomic.Bool
-	if err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts, &cancelRequested); err != nil {
+	if err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts); err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
 
@@ -1618,8 +1775,7 @@ func TestFinalizeJob_EmptyErrorFile_ErrorFileIDOmitted(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
 	ctx := testLoggerCtx(t)
-	var cancelRequested atomic.Bool
-	if err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts, &cancelRequested); err != nil {
+	if err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts); err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
 
@@ -1643,7 +1799,7 @@ func TestFinalizeJob_EmptyErrorFile_ErrorFileIDOmitted(t *testing.T) {
 // Tests: handleJobError (routing branches)
 // =====================================================================
 
-func TestHandleJobError_ErrCancelled(t *testing.T) {
+func TestHandleJobError_errCancelled(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -1662,7 +1818,7 @@ func TestHandleJobError_ErrCancelled(t *testing.T) {
 		updater: env.updater,
 		jobItem: dbJob,
 		jobInfo: ji,
-	}, ErrCancelled)
+	}, errCancelled)
 
 	after := gatherHistogramSampleCount(t, "batch_job_e2e_latency_seconds", map[string]string{"status": "cancelled"})
 	if delta := after - before; delta != 1 {
@@ -1682,7 +1838,7 @@ func TestHandleJobError_ErrCancelled(t *testing.T) {
 	}
 }
 
-func TestHandleJobError_ContextCanceled_ReEnqueues(t *testing.T) {
+func TestHandleJobError_Shutdown_ReEnqueues(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -1703,7 +1859,7 @@ func TestHandleJobError_ContextCanceled_ReEnqueues(t *testing.T) {
 		jobItem: dbJob,
 		task:    task,
 		jobInfo: ji,
-	}, context.Canceled)
+	}, errShutdown)
 
 	afterFailed := gatherHistogramSampleCount(t, "batch_job_e2e_latency_seconds", map[string]string{"status": "failed"})
 	if delta := afterFailed - beforeFailed; delta != 0 {
@@ -1719,32 +1875,7 @@ func TestHandleJobError_ContextCanceled_ReEnqueues(t *testing.T) {
 	}
 }
 
-func TestHandleJobError_DeadlineExceeded_ReEnqueues(t *testing.T) {
-	cfg := config.NewConfig()
-	cfg.WorkDir = t.TempDir()
-
-	env := newTestProcessorEnv(t, cfg, &mockInferenceClient{})
-
-	dbJob := seedDBJob(t, env.dbClient, "job-deadline")
-	task := &db.BatchJobPriority{ID: "job-deadline"}
-
-	ctx := testLoggerCtx(t)
-	env.p.handleJobError(ctx, &jobExecutionParams{
-		updater: env.updater,
-		jobItem: dbJob,
-		task:    task,
-	}, context.DeadlineExceeded)
-
-	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
-	if err != nil {
-		t.Fatalf("PQDequeue: %v", err)
-	}
-	if len(tasks) == 0 {
-		t.Fatalf("expected re-enqueued task, got none")
-	}
-}
-
-func TestHandleJobError_ContextCanceled_NilTask(t *testing.T) {
+func TestHandleJobError_Shutdown_NilTask(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -1757,7 +1888,7 @@ func TestHandleJobError_ContextCanceled_NilTask(t *testing.T) {
 	env.p.handleJobError(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobItem: dbJob,
-	}, context.Canceled)
+	}, errShutdown)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-ctx-nil"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1808,6 +1939,90 @@ func TestHandleJobError_Default_MarksFailed(t *testing.T) {
 	}
 	if got.Status != openai.BatchStatusFailed {
 		t.Fatalf("status = %s, want %s", got.Status, openai.BatchStatusFailed)
+	}
+}
+
+// TestHandleJobError_ExpiredWithCancelledCtx_StillTransitionsExpired verifies that
+// handleExpired completes the DB status write even when the parent context is already
+// cancelled (e.g. SIGTERM arrived concurrently with SLO expiry). handleExpired must use
+// a detached context for the UpdateExpiredStatus call so that SIGTERM does not abort
+// the DB write after file uploads succeed.
+func TestHandleJobError_ExpiredWithCancelledCtx_StillTransitionsExpired(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	env := newTestProcessorEnv(t, cfg, &mockInferenceClient{})
+
+	jobID := "job-expired-sigterm"
+	dbJob := seedDBJob(t, env.dbClient, jobID)
+	ji := &batch_types.JobInfo{
+		JobID:    jobID,
+		TenantID: dbJob.TenantID,
+		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{CreatedAt: time.Now().Add(-10 * time.Second).Unix()}},
+	}
+	counts := &openai.BatchRequestCounts{Total: 10, Completed: 5, Failed: 5}
+
+	// Simulate SIGTERM: parent ctx is already cancelled.
+	cancelledCtx, cancel := context.WithCancel(testLoggerCtx(t))
+	cancel()
+
+	env.p.handleJobError(cancelledCtx, &jobExecutionParams{
+		updater:       env.updater,
+		jobItem:       dbJob,
+		jobInfo:       ji,
+		requestCounts: counts,
+	}, errExpired)
+
+	items, _, _, err := env.dbClient.DBGet(context.Background(), &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if got.Status != openai.BatchStatusExpired {
+		t.Fatalf("status = %s, want expired (detached context must survive SIGTERM)", got.Status)
+	}
+	if got.RequestCounts.Total != 10 || got.RequestCounts.Completed != 5 {
+		t.Fatalf("request_counts = %+v, want {10,5,5}", got.RequestCounts)
+	}
+}
+
+// TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired verifies that
+// handleJobError routes errExpired with nil requestCounts (SLO expired during preprocessing,
+// before executeJob ran) to handleExpired, which tolerates nil counts and transitions the
+// job to expired status.
+func TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	env := newTestProcessorEnv(t, cfg, &mockInferenceClient{})
+
+	dbJob := seedDBJob(t, env.dbClient, "job-expired-ingestion")
+	ji := &batch_types.JobInfo{
+		JobID:    "job-expired-ingestion",
+		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{CreatedAt: time.Now().Add(-10 * time.Second).Unix()}},
+	}
+
+	ctx := testLoggerCtx(t)
+	env.p.handleJobError(ctx, &jobExecutionParams{
+		updater:       env.updater,
+		jobItem:       dbJob,
+		jobInfo:       ji,
+		requestCounts: nil, // nil: SLO expired before executeJob ran
+	}, errExpired)
+
+	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-expired-ingestion"}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if got.Status != openai.BatchStatusExpired {
+		t.Fatalf("status = %s, want %s", got.Status, openai.BatchStatusExpired)
 	}
 }
 
@@ -1877,6 +2092,80 @@ func TestHandleCancelled_Execution_UploadsPartialOutput(t *testing.T) {
 	}
 	if got.ErrorFileID == nil {
 		t.Fatal("expected error_file_id to be set")
+	}
+}
+
+// TestHandleCancelled_CancelledWriteFails_FallsBackToFailed verifies that when
+// UpdateCancelledStatus fails inside handleCancelled, the fallback writes "failed"
+// status with file IDs preserved. This mirrors the failover pattern in finalizeJob.
+func TestHandleCancelled_CancelledWriteFails_FallsBackToFailed(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	innerDB := newMockBatchDBClient()
+	failDB := &failOnStatusDB{
+		inner:      innerDB,
+		failStatus: openai.BatchStatusCancelled,
+		failErr:    errors.New("injected: cancelled write failed"),
+	}
+	statusClient := mockdb.NewMockBatchStatusClient()
+
+	jobID := "job-cancel-failover"
+	tenantID := "tenant__tenantA"
+
+	dbJob := seedDBJob(t, innerDB, jobID)
+	dbJob.TenantID = tenantID
+
+	clients := &clientset.Clientset{
+		BatchDB:   failDB,
+		FileDB:    newMockFileDBClient(),
+		File:      mockfiles.NewMockBatchFilesClient(),
+		Status:    statusClient,
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		Inference: inference.NewSingleClientResolver(&mockInferenceClient{}),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, failDB)
+	updater := NewStatusUpdater(failDB, statusClient, 86400)
+
+	createPartialOutputFiles(t, p, jobID, tenantID)
+
+	jobInfo := &batch_types.JobInfo{
+		JobID:    jobID,
+		TenantID: tenantID,
+		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{CreatedAt: time.Now().Add(-10 * time.Second).Unix()}},
+	}
+	counts := &openai.BatchRequestCounts{Total: 5, Completed: 3, Failed: 2}
+
+	ctx := testLoggerCtx(t)
+	err := p.handleCancelled(ctx, &jobExecutionParams{
+		updater:       updater,
+		jobItem:       dbJob,
+		jobInfo:       jobInfo,
+		requestCounts: counts,
+	})
+
+	if !errors.Is(err, errFinalizeFailedOver) {
+		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
+	}
+
+	items, _, _, getErr := innerDB.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if unmarshalErr := json.Unmarshal(items[0].Status, &got); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed", got.Status)
+	}
+	if got.OutputFileID == nil {
+		t.Fatal("output_file_id must be preserved in fallback, got nil")
+	}
+	if got.RequestCounts.Total != 5 || got.RequestCounts.Completed != 3 || got.RequestCounts.Failed != 2 {
+		t.Fatalf("request_counts = %+v, want {5,3,2}", got.RequestCounts)
 	}
 }
 
@@ -1977,6 +2266,38 @@ func TestHandleFailed_Finalization_RecordsCountsOnly(t *testing.T) {
 	}
 }
 
+// TestHandleFailed_CancelledCtx_StillWritesDB verifies that handleFailed completes
+// the DB status write even when the parent context is already cancelled.
+func TestHandleFailed_CancelledCtx_StillWritesDB(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	env := newTestProcessorEnv(t, cfg, &mockInferenceClient{})
+
+	jobID := "job-failed-sigterm"
+	dbJob := seedDBJob(t, env.dbClient, jobID)
+	counts := &openai.BatchRequestCounts{Total: 3, Completed: 1, Failed: 2}
+
+	cancelledCtx, cancel := context.WithCancel(testLoggerCtx(t))
+	cancel()
+
+	if err := env.p.handleFailed(cancelledCtx, env.updater, dbJob, counts, nil); err != nil {
+		t.Fatalf("handleFailed with cancelled ctx: %v", err)
+	}
+
+	items, _, _, err := env.dbClient.DBGet(context.Background(), &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed (detached context must survive cancelled parent)", got.Status)
+	}
+}
+
 // =====================================================================
 // Tests: uploadPartialResults — empty / missing files
 // =====================================================================
@@ -2057,6 +2378,71 @@ func TestUploadPartialResults_MissingFiles(t *testing.T) {
 	}
 	if errorFileID != "" {
 		t.Fatalf("errorFileID = %q, want empty (error file does not exist)", errorFileID)
+	}
+}
+
+// TestUploadPartialResults_OneUploadFails_OtherSurvives verifies that when one of the two
+// parallel uploads fails, the other file ID is still returned. uploadPartialResults is
+// best-effort: one-side failure must not lose the other side's reference.
+func TestUploadPartialResults_OneUploadFails_OtherSurvives(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	dbClient := newMockBatchDBClient()
+	statusClient := mockdb.NewMockBatchStatusClient()
+	filesClient := &failOnNthCallClient{
+		failN:   1,
+		failErr: errors.New("injected: one-side upload failure"),
+	}
+
+	clients := &clientset.Clientset{
+		BatchDB:   dbClient,
+		FileDB:    newMockFileDBClient(),
+		File:      filesClient,
+		Status:    statusClient,
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Inference: inference.NewSingleClientResolver(&fakeInferenceClient{}),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, dbClient)
+
+	jobID := "partial-one-side"
+	tenantID := "tenant__tenantA"
+
+	jobDir, err := p.jobRootDir(jobID, tenantID)
+	if err != nil {
+		t.Fatalf("jobRootDir: %v", err)
+	}
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath, _ := p.jobOutputFilePath(jobID, tenantID)
+	if err := os.WriteFile(outputPath, []byte(`{"custom_id":"r1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile output: %v", err)
+	}
+	errorPath, _ := p.jobErrorFilePath(jobID, tenantID)
+	if err := os.WriteFile(errorPath, []byte(`{"custom_id":"e1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	dbJob := seedDBJob(t, dbClient, jobID)
+
+	ctx := testLoggerCtx(t)
+	outputFileID, errorFileID := p.uploadPartialResults(ctx, jobInfo, dbJob)
+
+	// Exactly one of the two uploads failed (the first call to Store).
+	// The other must have succeeded and returned a non-empty file ID.
+	nonEmpty := 0
+	if outputFileID != "" {
+		nonEmpty++
+	}
+	if errorFileID != "" {
+		nonEmpty++
+	}
+	if nonEmpty != 1 {
+		t.Fatalf("expected exactly 1 surviving file ID (one upload failed), got output=%q error=%q",
+			outputFileID, errorFileID)
 	}
 }
 

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -22,19 +22,17 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
-	"go.opentelemetry.io/otel/attribute"
-	"golang.org/x/sync/errgroup"
-
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/converter"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
 	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/util/logging"
 	uotel "github.com/llm-d-incubation/batch-gateway/internal/util/otel"
@@ -81,65 +79,106 @@ func (p *Processor) uploadFileAndStoreFileRecord(
 	return fileID, nil
 }
 
+// finalizationTimeout bounds how long finalizeJob waits for file uploads and DB
+// writes before giving up. Storage and DB clients have their own timeouts, but
+// this provides an explicit application-level bound — same pattern as
+// panicRecoveryTimeout. Declared as var (not const) so tests can shorten it.
+var finalizationTimeout = 5 * time.Minute
+
 // finalizeJob performs finalization: uploads output and error files to shared storage,
 // creates file records in the database, and updates job status to completed.
 func (p *Processor) finalizeJob(
 	ctx context.Context,
+	userCancelCtx context.Context,
 	updater *StatusUpdater,
 	dbJob *db.BatchItem,
 	jobInfo *batch_types.JobInfo,
 	requestCounts *openai.BatchRequestCounts,
-	cancelRequested *atomic.Bool,
 ) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Starting finalization: finalizing job")
 
+	// ioCtx is detached from ctx so that SIGTERM cannot abort file uploads or the
+	// final status write. DetachedContext preserves a span link back to the parent
+	// process-batch trace while severing cancellation propagation.
+	// finalizationTimeout provides an explicit upper bound so that an unreachable
+	// storage/DB cannot block the worker token indefinitely.
+	ioCtx, ioSpan := uotel.DetachedContext(ctx, "finalize")
+	ioCtx, ioCancel := context.WithTimeout(ioCtx, finalizationTimeout)
+	defer ioCancel()
+	defer ioSpan.End()
+
 	// in_progress → finalizing
 	// Written before file uploads so the API server can reject cancel requests once
 	// finalization has begun, narrowing the cancel-vs-complete race window.
-	if err := updater.UpdatePersistentStatus(ctx, dbJob, openai.BatchStatusFinalizing, requestCounts, nil); err != nil {
+	if err := updater.UpdatePersistentStatus(ioCtx, dbJob, openai.BatchStatusFinalizing, requestCounts, nil); err != nil {
 		return fmt.Errorf("failed to update job status to finalizing: %w", err)
 	}
 
 	// Per the OpenAI batch spec, output_file_id and error_file_id are both optional:
 	// output_file_id is omitted when all requests failed; error_file_id is omitted when no
 	// requests failed. We skip uploading and recording empty files accordingly.
-	// The two uploads are independent (different local files, different S3 keys,
-	// different DB records), so we run them concurrently.
+	//
+	// The two uploads are fully independent (different local files, different S3 keys,
+	// different DB records). A failure in one must not discard the other's file ID —
+	// otherwise a transient error-file upload failure would orphan an already-uploaded
+	// output file. Both uploads run to completion; if any fails, the job is marked
+	// failed with surviving file IDs preserved.
 	var outputFileID, errorFileID string
-	grp, gCtx := errgroup.WithContext(ctx)
-	grp.Go(func() error {
-		var err error
-		outputFileID, err = p.uploadFileAndStoreFileRecord(gCtx, jobInfo, dbJob, metrics.FileTypeOutput)
-		return err
-	})
-	grp.Go(func() error {
-		var err error
-		errorFileID, err = p.uploadFileAndStoreFileRecord(gCtx, jobInfo, dbJob, metrics.FileTypeError)
-		return err
-	})
-	if err := grp.Wait(); err != nil {
-		return err
+	var outputUploadErr, errorUploadErr error
+	var uploadWG sync.WaitGroup
+	uploadWG.Add(2)
+	go func() {
+		defer uploadWG.Done()
+		outputFileID, outputUploadErr = p.uploadFileAndStoreFileRecord(ioCtx, jobInfo, dbJob, metrics.FileTypeOutput)
+	}()
+	go func() {
+		defer uploadWG.Done()
+		errorFileID, errorUploadErr = p.uploadFileAndStoreFileRecord(ioCtx, jobInfo, dbJob, metrics.FileTypeError)
+	}()
+	uploadWG.Wait()
+
+	if outputUploadErr != nil {
+		logger.Error(outputUploadErr, "Failed to upload output file during finalization")
+	}
+	if errorUploadErr != nil {
+		logger.Error(errorUploadErr, "Failed to upload error file during finalization")
 	}
 
-	// Best-effort cancel check: if a cancel event arrived during file uploads,
-	// finalize as cancelled instead of completed. This covers the narrow window
-	// between executeJob's last cancelRequested check and this point.
-	// A residual TOCTOU race remains (cancel arriving between this check and the
-	// completed write below), but at this stage all requests have already completed
-	// and output files are uploaded — the user receives the same results either way.
-	if cancelRequested != nil && cancelRequested.Load() {
+	// If any upload failed, the job cannot be marked completed or cancelled — that would
+	// expose a partial-artifact terminal state to the user. Instead, write failed status
+	// with whatever file IDs survived so the successfully-uploaded artifact remains
+	// reachable via the API.
+	if outputUploadErr != nil || errorUploadErr != nil {
+		if failErr := updater.UpdateFailedStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); failErr != nil {
+			return fmt.Errorf("upload failed and fallback status write also failed: %w", failErr)
+		}
+		return fmt.Errorf("upload failure during finalization: %w", errFinalizeFailedOver)
+	}
+
+	// Best-effort: honour a user cancel that arrived during finalization.
+	// userCancelCtx is background-derived so it only fires for explicit user cancellation;
+	// SLO expiry and SIGTERM do not propagate here.
+	if userCancelCtx.Err() != nil {
 		logger.V(logging.INFO).Info("Cancel requested during finalization; finalizing as cancelled")
-		if err := updater.UpdateCancelledStatus(ctx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
-			return fmt.Errorf("failed to update job status to cancelled: %w", err)
+		if err := updater.UpdateCancelledStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
+			logger.Error(err, "Failed to update cancelled status, falling back to failed with file IDs preserved")
+			if failErr := updater.UpdateFailedStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); failErr != nil {
+				return fmt.Errorf("failed to update job status to cancelled (%w) and fallback to failed also failed: %w", err, failErr)
+			}
+			return fmt.Errorf("cancelled status write failed: %w", errFinalizeFailedOver)
 		}
 		setRequestCountAttrs(ctx, requestCounts)
-		return ErrCancelled
+		return errCancelled
 	}
 
 	// finalizing → completed
-	if err := updater.UpdateCompletedStatus(ctx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
-		return fmt.Errorf("failed to update job status to completed: %w", err)
+	if err := updater.UpdateCompletedStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
+		logger.Error(err, "Failed to update job status to completed, falling back to failed with file IDs preserved")
+		if failErr := updater.UpdateFailedStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); failErr != nil {
+			return fmt.Errorf("failed to update job status to completed (%w) and fallback to failed also failed: %w", err, failErr)
+		}
+		return fmt.Errorf("completed status write failed: %w", errFinalizeFailedOver)
 	}
 
 	setRequestCountAttrs(ctx, requestCounts)

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -313,12 +312,12 @@ func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 	}
 
 	// Simulate that the worker observed the cancel request before writing the final status.
-	var cancelRequested atomic.Bool
-	cancelRequested.Store(true)
+	cancelledCtx, cancelFn := context.WithCancel(ctx)
+	cancelFn()
 
-	err := p.finalizeJob(ctx, updater, staleJob, jobInfo, counts, &cancelRequested)
-	if !errors.Is(err, ErrCancelled) {
-		t.Fatalf("expected ErrCancelled, got: %v", err)
+	err := p.finalizeJob(ctx, cancelledCtx, updater, staleJob, jobInfo, counts)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got: %v", err)
 	}
 
 	// Verify that the final status written to the DB is cancelled, not completed.
@@ -334,6 +333,320 @@ func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 
 	if finalStatus.Status != openai.BatchStatusCancelled {
 		t.Fatalf("expected final status to be %s, got %s", openai.BatchStatusCancelled, finalStatus.Status)
+	}
+}
+
+// TestFinalizeJob_ShutdownDuringFinalization_CompletesNotCancelled verifies that a SIGTERM
+// (ctx cancelled) during finalization does NOT route the job to cancelled.
+// userCancelCtx is derived from context.Background(), so SIGTERM does not propagate into it.
+// The job must transition to completed regardless of whether the parent ctx is cancelled.
+func TestFinalizeJob_ShutdownDuringFinalization_CompletesNotCancelled(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	dbClient := newSpyBatchDB(newMockBatchDBClient())
+	statusClient := mockdb.NewMockBatchStatusClient()
+
+	jobID := "job-shutdown-during-final"
+	tenantID := "tenant-1"
+
+	dbJob := seedDBJob(t, dbClient, jobID)
+	dbJob.TenantID = tenantID
+	dbJob.Status = mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress})
+	setupCtx := testLoggerCtx(t)
+	if err := dbClient.DBStore(setupCtx, dbJob); err != nil {
+		t.Fatalf("DBStore: %v", err)
+	}
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  newMockFileDBClient(),
+		File:    &failNTimesFilesClient{failCount: 0},
+		Status:  statusClient,
+		Queue:   mockdb.NewMockBatchPriorityQueueClient(),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, dbClient)
+
+	updater := NewStatusUpdater(dbClient, statusClient, 86400)
+
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath, _ := p.jobOutputFilePath(jobID, tenantID)
+	if err := os.WriteFile(outputPath, []byte("test output\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	staleJob := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{
+			Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress}),
+		},
+	}
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
+
+	// Simulate SIGTERM: parent ctx is cancelled.
+	// userCancelCtx is derived from context.Background() — NOT from ctx — so it is not cancelled.
+	shutdownCtx, shutdownCancel := context.WithCancel(testLoggerCtx(t))
+	shutdownCancel() // SIGTERM fires
+
+	userCancelCtx := context.Background() // no user cancel
+
+	err := p.finalizeJob(shutdownCtx, userCancelCtx, updater, staleJob, jobInfo, counts)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	jobsFinal, _, _, getErr := dbClient.DBGet(testLoggerCtx(t), &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(jobsFinal) == 0 {
+		t.Fatalf("DBGet failed: err=%v len=%d", getErr, len(jobsFinal))
+	}
+	var finalStatus openai.BatchStatusInfo
+	if err := json.Unmarshal(jobsFinal[0].Status, &finalStatus); err != nil {
+		t.Fatalf("Unmarshal status: %v", err)
+	}
+	if finalStatus.Status != openai.BatchStatusCompleted {
+		t.Fatalf("expected completed (SIGTERM must not trigger user-cancel path), got %s", finalStatus.Status)
+	}
+}
+
+// --- failover file-ID preservation tests ---
+
+// TestFinalizeJob_CompletedWriteFails_FallsBackToFailedWithFileIDs verifies that when
+// uploads succeed but UpdateCompletedStatus fails, finalizeJob falls back to
+// UpdateFailedStatus with file IDs preserved (not empty). This prevents the orphan-file
+// scenario where real output exists in storage but the batch object has no references.
+func TestFinalizeJob_CompletedWriteFails_FallsBackToFailedWithFileIDs(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	innerDB := newMockBatchDBClient()
+	failDB := &failOnStatusDB{
+		inner:      innerDB,
+		failStatus: openai.BatchStatusCompleted,
+		failErr:    errors.New("injected: completed write failed"),
+	}
+	statusClient := mockdb.NewMockBatchStatusClient()
+
+	jobID := "job-failover-completed"
+	tenantID := "tenant-1"
+
+	dbJob := seedDBJob(t, innerDB, jobID)
+	dbJob.TenantID = tenantID
+
+	clients := &clientset.Clientset{
+		BatchDB: failDB,
+		FileDB:  newMockFileDBClient(),
+		File:    &failNTimesFilesClient{failCount: 0},
+		Status:  statusClient,
+		Queue:   mockdb.NewMockBatchPriorityQueueClient(),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, failDB)
+	updater := NewStatusUpdater(failDB, statusClient, 86400)
+
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath, _ := p.jobOutputFilePath(jobID, tenantID)
+	if err := os.WriteFile(outputPath, []byte(`{"id":"batch_req_1","custom_id":"r1","response":{"status_code":200}}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	staleJob := &db.BatchItem{
+		BaseIndexes:  db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress})},
+	}
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
+
+	ctx := testLoggerCtx(t)
+	err := p.finalizeJob(ctx, context.Background(), updater, staleJob, jobInfo, counts)
+
+	// Must return errFinalizeFailedOver (fallback succeeded).
+	if !errors.Is(err, errFinalizeFailedOver) {
+		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
+	}
+
+	// Verify DB state: status must be "failed" with file IDs preserved.
+	items, _, _, getErr := innerDB.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed", got.Status)
+	}
+	if got.OutputFileID == nil {
+		t.Fatal("output_file_id must be preserved in fallback, got nil")
+	}
+	if got.RequestCounts.Total != 1 || got.RequestCounts.Completed != 1 {
+		t.Fatalf("request_counts = %+v, want {1,1,0}", got.RequestCounts)
+	}
+}
+
+// TestFinalizeJob_CancelledWriteFails_FallsBackToFailedWithFileIDs verifies the cancel
+// path of the failover logic: uploads succeed, then user cancel triggers during
+// finalization, but UpdateCancelledStatus fails. The fallback must write "failed"
+// status with file IDs preserved, exactly like the completed-write-failure variant.
+func TestFinalizeJob_CancelledWriteFails_FallsBackToFailedWithFileIDs(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	innerDB := newMockBatchDBClient()
+	failDB := &failOnStatusDB{
+		inner:      innerDB,
+		failStatus: openai.BatchStatusCancelled,
+		failErr:    errors.New("injected: cancelled write failed"),
+	}
+	statusClient := mockdb.NewMockBatchStatusClient()
+
+	jobID := "job-failover-cancelled"
+	tenantID := "tenant-1"
+
+	dbJob := seedDBJob(t, innerDB, jobID)
+	dbJob.TenantID = tenantID
+
+	clients := &clientset.Clientset{
+		BatchDB: failDB,
+		FileDB:  newMockFileDBClient(),
+		File:    &failNTimesFilesClient{failCount: 0},
+		Status:  statusClient,
+		Queue:   mockdb.NewMockBatchPriorityQueueClient(),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, failDB)
+	updater := NewStatusUpdater(failDB, statusClient, 86400)
+
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath, _ := p.jobOutputFilePath(jobID, tenantID)
+	if err := os.WriteFile(outputPath, []byte(`{"id":"batch_req_1","custom_id":"r1","response":{"status_code":200}}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	staleJob := &db.BatchItem{
+		BaseIndexes:  db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress})},
+	}
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
+
+	// userCancelCtx is cancelled → finalization takes the cancel path.
+	ctx := testLoggerCtx(t)
+	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
+	userCancelFn()
+
+	err := p.finalizeJob(ctx, userCancelCtx, updater, staleJob, jobInfo, counts)
+
+	if !errors.Is(err, errFinalizeFailedOver) {
+		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
+	}
+
+	items, _, _, getErr := innerDB.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed", got.Status)
+	}
+	if got.OutputFileID == nil {
+		t.Fatal("output_file_id must be preserved in cancel-path fallback, got nil")
+	}
+	if got.RequestCounts.Total != 1 || got.RequestCounts.Completed != 1 {
+		t.Fatalf("request_counts = %+v, want {1,1,0}", got.RequestCounts)
+	}
+}
+
+// TestFinalizeJob_OneUploadFails_FailedWithSurvivingFileID verifies that when one of the
+// two concurrent uploads fails, finalizeJob marks the job as failed (not completed) and
+// preserves the surviving file ID in the DB. Marking completed with a missing artifact
+// would violate the batch contract; marking failed with empty file IDs would orphan the
+// successfully-uploaded artifact.
+func TestFinalizeJob_OneUploadFails_FailedWithSurvivingFileID(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	innerDB := newMockBatchDBClient()
+	statusClient := mockdb.NewMockBatchStatusClient()
+	filesClient := &failOnNthCallClient{
+		failN:   1,
+		failErr: errors.New("injected: one upload fails"),
+	}
+
+	jobID := "job-partial-upload"
+	tenantID := "tenant-1"
+
+	dbJob := seedDBJob(t, innerDB, jobID)
+	dbJob.TenantID = tenantID
+
+	clients := &clientset.Clientset{
+		BatchDB: innerDB,
+		FileDB:  newMockFileDBClient(),
+		File:    filesClient,
+		Status:  statusClient,
+		Queue:   mockdb.NewMockBatchPriorityQueueClient(),
+	}
+	p := mustNewProcessor(t, cfg, clients)
+	p.poller = NewPoller(clients.Queue, innerDB)
+	updater := NewStatusUpdater(innerDB, statusClient, 86400)
+
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath, _ := p.jobOutputFilePath(jobID, tenantID)
+	if err := os.WriteFile(outputPath, []byte(`{"id":"batch_req_1","custom_id":"r1","response":{"status_code":200}}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile output: %v", err)
+	}
+	errorPath, _ := p.jobErrorFilePath(jobID, tenantID)
+	if err := os.WriteFile(errorPath, []byte(`{"id":"batch_req_2","custom_id":"r2","error":{"code":"batch_failed"}}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	staleJob := &db.BatchItem{
+		BaseIndexes:  db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress})},
+	}
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	counts := &openai.BatchRequestCounts{Total: 2, Completed: 1, Failed: 1}
+
+	ctx := testLoggerCtx(t)
+	err := p.finalizeJob(ctx, context.Background(), updater, staleJob, jobInfo, counts)
+	if !errors.Is(err, errFinalizeFailedOver) {
+		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
+	}
+
+	items, _, _, getErr := innerDB.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed (partial upload must not be marked completed)", got.Status)
+	}
+
+	// Exactly one upload failed (1st Store call), so exactly one file ID should survive.
+	hasOutput := got.OutputFileID != nil
+	hasError := got.ErrorFileID != nil
+	if hasOutput == hasError {
+		t.Fatalf("expected exactly one surviving file ID, got output=%v error=%v", got.OutputFileID, got.ErrorFileID)
 	}
 }
 
@@ -437,7 +750,7 @@ func TestFinalizeJob_UploadsFilesInParallel(t *testing.T) {
 	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
 	counts := &openai.BatchRequestCounts{Total: 2, Completed: 1, Failed: 1}
 
-	err := p.finalizeJob(ctx, updater, dbJob, jobInfo, counts, nil)
+	err := p.finalizeJob(ctx, context.Background(), updater, dbJob, jobInfo, counts)
 	if err != nil {
 		t.Fatalf("finalizeJob returned error: %v", err)
 	}

--- a/internal/processor/worker/job_execution.go
+++ b/internal/processor/worker/job_execution.go
@@ -18,7 +18,6 @@ package worker
 
 import (
 	"context"
-	"sync/atomic"
 
 	db "github.com/llm-d-incubation/batch-gateway/internal/database/api"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
@@ -27,19 +26,20 @@ import (
 
 // jobExecutionParams holds the job-scoped state shared across processing stages.
 // Contexts are NOT stored here — they are passed explicitly per Go convention.
-//
-// cancelRequested must be a non-nil *atomic.Bool — it is shared across goroutines
-// (watchCancel, preProcessJob, executeJob, finalizeJob).
+// userCancelFn and requestAbortFn are exceptions: they are cancel functions stored
+// here so that the watchCancel goroutine can call them when a cancel event arrives.
+// userCancelFn cancels userCancelCtx (user-cancel signal, derived from context.Background).
+// requestAbortFn cancels requestAbortCtx (dispatch loop control, derived from sloCtx) to stop
+// dispatch immediately when the user cancels.
 type jobExecutionParams struct {
 	updater *StatusUpdater
 	jobItem *db.BatchItem
 	jobInfo *batch_types.JobInfo
 	task    *db.BatchJobPriority
 
-	eventWatcher *db.BatchEventsChan
-	abortInferFn context.CancelFunc
-
-	cancelRequested *atomic.Bool
+	eventWatcher   *db.BatchEventsChan
+	userCancelFn   context.CancelFunc
+	requestAbortFn context.CancelFunc
 
 	requestCounts *openai.BatchRequestCounts
 }

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -129,22 +129,38 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	}
 	defer eventWatcher.CloseFn()
 
-	// abortCtx is cancelled when the user requests batch cancellation, propagating
-	// the signal to all in-flight inference HTTP requests so they abort promptly.
-	// It is derived from sloCtx so the SLO deadline is also respected.
-	abortCtx, abortInferFn := context.WithCancel(sloCtx)
-	params.abortInferFn = abortInferFn
-	defer abortInferFn()
+	// userCancelCtx is a user-cancel-only signal: it is derived from context.Background so that
+	// SIGTERM and SLO expiry do NOT propagate into it. userCancelCtx.Err() != nil exclusively means
+	// the user requested cancellation via the API. watchCancel calls userCancelFn to set it,
+	// and also calls requestAbortFn to stop the dispatch loop immediately.
+	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
+	params.userCancelFn = userCancelFn
+	defer userCancelFn()
+
+	// requestAbortCtx is derived from sloCtx so SLO expiry and SIGTERM propagate automatically
+	// to all dispatch loops and inference calls. It is created here, before watchCancel starts,
+	// so params.requestAbortFn is set before any cancel event can arrive — eliminating the
+	// race window where watchCancel fires between runJob and executeJob setting the function.
+	requestAbortCtx, requestAbortFn := context.WithCancel(sloCtx)
+	params.requestAbortFn = requestAbortFn
+	defer requestAbortFn()
 
 	// watch for cancel event
 	params.eventWatcher = eventWatcher
 	go p.watchCancel(ctx, params)
 
 	// ingestion: pre-process job (rejects unregistered-model requests early)
-	if err := p.preProcessJob(ctx, params.jobInfo, params.cancelRequested); err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "pre-process failed")
+	if err := p.preProcessJob(ctx, sloCtx, userCancelCtx, params.jobInfo); err != nil {
+		// errExpired, errCancelled, and errShutdown are expected terminal states, not system errors.
+		if !errors.Is(err, errExpired) && !errors.Is(err, errCancelled) && !errors.Is(err, errShutdown) {
+			logger.Error(err, "Pre-processing failed")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "pre-process failed")
+		}
 		p.handleJobError(ctx, params, err)
+		// No RecordJobProcessingDuration here: preprocessing is ingestion (parsing, plan
+		// building), not inference execution. Recording elapsed time would pollute the
+		// processing-duration metric with ingestion overhead.
 		return
 	}
 
@@ -162,42 +178,32 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	// execution: execute inference requests
 	var execErr error
-	requestCounts, execErr = p.executeJob(ctx, sloCtx, abortCtx, params)
+	requestCounts, execErr = p.executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx, params)
 	params.requestCounts = requestCounts
 	if execErr != nil {
-		switch {
-		case errors.Is(execErr, ErrExpired):
-			if expiredErr := p.handleExpired(ctx, params.updater, params.jobItem, params.jobInfo, requestCounts); expiredErr != nil {
-				logger.Error(expiredErr, "Failed to finalize expired job")
-				span.RecordError(expiredErr)
-				span.SetStatus(codes.Error, "expired finalization failed")
-			}
-			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
-
-		case errors.Is(execErr, ErrCancelled):
-			if cancelErr := p.handleCancelled(ctx, params); cancelErr != nil {
-				logger.Error(cancelErr, "Failed to finalize cancelled job")
-				span.RecordError(cancelErr)
-				span.SetStatus(codes.Error, "cancelled finalization failed")
-			}
-			if requestCounts != nil {
-				metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
-			}
-
-		default:
+		// errExpired, errCancelled, and errShutdown are expected terminal states, not system errors.
+		if !errors.Is(execErr, errExpired) && !errors.Is(execErr, errCancelled) && !errors.Is(execErr, errShutdown) {
 			span.RecordError(execErr)
 			span.SetStatus(codes.Error, "execution failed")
-			p.handleJobError(ctx, params, execErr)
+		}
+		p.handleJobError(ctx, params, execErr)
+		// Record processing duration for any job that ran (partially or fully).
+		// executeJob always returns non-nil counts alongside its sentinel errors
+		// (errExpired, errCancelled, errShutdown, system errors) because partial
+		// work was done. The nil guard remains defensive for unexpected future paths.
+		if requestCounts != nil {
+			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 		}
 		return
 	}
 
 	// finalization: upload output, update status to completed
-	if err := p.finalizeJob(ctx, params.updater, params.jobItem, params.jobInfo, requestCounts, params.cancelRequested); err != nil {
-		if errors.Is(err, ErrCancelled) {
+	if err := p.finalizeJob(ctx, userCancelCtx, params.updater, params.jobItem, params.jobInfo, requestCounts); err != nil {
+		if errors.Is(err, errCancelled) {
 			// Cancel arrived during finalization — DB already updated to cancelled.
 			// Treat as successful cancellation (same as handleCancelled).
-			p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
+			// Use background context: ctx may be cancelled (SIGTERM) and cleanup is local I/O only.
+			p.cleanupJobArtifacts(context.Background(), params.jobItem.ID, params.jobItem.TenantID)
 			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 			recordE2ELatency(params.jobInfo, metrics.E2EStatusCancelled)
 			metrics.RecordCancellation(metrics.CancelPhaseFinalizing)
@@ -208,14 +214,24 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 		logger.Error(err, "Failed to finalize job")
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "finalize failed")
-		if failErr := p.handleFailed(ctx, params.updater, params.jobItem, requestCounts, params.jobInfo); failErr != nil {
-			logger.Error(failErr, "Failed to handle failed event")
+		if errors.Is(err, errFinalizeFailedOver) {
+			// finalizeJob already wrote failed status with file IDs preserved.
+			// Calling handleFailed would overwrite file IDs with empty strings.
+			p.cleanupJobArtifacts(context.Background(), params.jobItem.ID, params.jobItem.TenantID)
+			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
+			recordE2ELatency(params.jobInfo, metrics.E2EStatusFailed)
+			metrics.RecordJobProcessed(metrics.ResultFailed, metrics.ReasonSystemError)
+		} else {
+			// Pre-upload failure (e.g. finalizing status write) — no file IDs exist yet.
+			if failErr := p.handleFailed(ctx, params.updater, params.jobItem, requestCounts, params.jobInfo); failErr != nil {
+				logger.Error(failErr, "Failed to handle failed event")
+			}
 		}
 		return
 	}
 
-	// cleanup local artifacts (best-effort)
-	p.cleanupJobArtifacts(ctx, params.jobItem.ID, params.jobItem.TenantID)
+	// cleanup local artifacts (best-effort); use background context since ctx may be cancelled.
+	p.cleanupJobArtifacts(context.Background(), params.jobItem.ID, params.jobItem.TenantID)
 	metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
 	recordE2ELatency(params.jobInfo, metrics.E2EStatusCompleted)
 	metrics.RecordJobProcessed(metrics.ResultSuccess, metrics.ReasonNone)
@@ -266,33 +282,63 @@ func (p *Processor) handlePanicRecovery(
 	}
 }
 
-// handleJobError routes an error to the appropriate handler (cancel, re-enqueue, or fail).
-// requestCounts and jobInfo are non-nil only when the error originates from execution (executeJob).
+// handleJobError routes an error from preProcessJob or executeJob to the appropriate handler.
+// It is the single decision point for all job-level error routing.
 func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionParams, err error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	switch {
-	case errors.Is(err, ErrCancelled):
-		// Ingestion cancel: clear requestCounts so handleCancelled skips partial-output
-		// upload, but keep jobInfo so it can record E2E latency internally.
-		// Safe to mutate params — callers return immediately after handleJobError.
-		params.requestCounts = nil
+	case errors.Is(err, errCancelled):
+		// User-initiated cancel at any phase. requestCounts is nil for ingestion-phase cancels
+		// (preProcessJob returns errCancelled before execution begins) and non-nil for
+		// execution-phase cancels (executeJob returns partial counts). handleCancelled
+		// uses requestCounts == nil as the signal to skip partial-output upload.
 		if cancelErr := p.handleCancelled(ctx, params); cancelErr != nil {
 			logger.Error(cancelErr, "Failed to handle cancelled event")
+			if errors.Is(cancelErr, errFinalizeFailedOver) {
+				recordE2ELatency(params.jobInfo, metrics.E2EStatusFailed)
+				metrics.RecordJobProcessed(metrics.ResultFailed, metrics.ReasonSystemError)
+			}
 		}
 
-	case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
-		// Parent context was cancelled or deadline exceeded (e.g. pod shutdown).
-		// Re-enqueue so another worker can pick it up.
-		// Note: SLO expiry returns ErrExpired, which is handled before this function is called.
+	case errors.Is(err, errExpired):
+		// SLO deadline reached. requestCounts may be nil if SLO expired during preprocessing
+		// (before executeJob ran). handleExpired and UpdateExpiredStatus both tolerate nil
+		// counts — the DB field is left at zero, which is correct since no requests were processed.
+		if expiredErr := p.handleExpired(ctx, params.updater, params.jobItem, params.jobInfo, params.requestCounts); expiredErr != nil {
+			logger.Error(expiredErr, "Failed to finalize expired job")
+		}
+
+	case errors.Is(err, errShutdown):
+		// SIGTERM received — re-enqueue so another worker can pick up the job.
 		// Use a detached context because ctx is already cancelled.
+		//
+		// Known limitation: there is no way at SIGTERM time to distinguish a container
+		// restart (emptyDir survives, startup recovery can upload partial output) from a
+		// pod deletion (emptyDir destroyed, startup recovery cannot help). Re-enqueueing
+		// is therefore unconditional, which introduces a known race: if this was a
+		// container restart, startup recovery and the worker that picks up the re-enqueued
+		// job compete — startup recovery may mark the job failed while another worker
+		// runs it fresh.
+		// This race is accepted as a known limit until orphan reconciliation is
+		// implemented. Once it is, re-enqueue should be removed here and pod-deletion
+		// recovery delegated to the reconciler. (TODO: orphan reconciliation task)
 		if params.task != nil {
 			bgCtx, bgSpan := uotel.DetachedContext(ctx, "re-enqueue")
 			defer bgSpan.End()
 			if enqErr := p.poller.enqueueOne(bgCtx, params.task); enqErr != nil {
 				logger.Error(enqErr, "Failed to re-enqueue the job to the queue")
-				if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, nil, params.jobInfo); failErr != nil {
-					logger.Error(failErr, "Failed to mark job as failed after re-enqueue failure")
+				// executeJob flushed partial output/error files to disk before returning
+				// errShutdown. Upload them so the user can retrieve whatever completed
+				// before SIGTERM, rather than losing those results silently.
+				if params.requestCounts != nil && params.jobInfo != nil {
+					if failErr := p.handleFailedWithPartial(bgCtx, params.updater, params.jobItem, params.jobInfo, params.requestCounts); failErr != nil {
+						logger.Error(failErr, "Failed to handle failed event with partial output after re-enqueue failure")
+					}
+				} else {
+					if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, nil, params.jobInfo); failErr != nil {
+						logger.Error(failErr, "Failed to mark job as failed after re-enqueue failure")
+					}
 				}
 			} else {
 				metrics.RecordJobProcessed(metrics.ResultReEnqueued, metrics.ReasonSystemError)
@@ -350,15 +396,22 @@ func (p *Processor) uploadPartialResults(
 }
 
 // handleExpired finalizes a job whose SLO deadline fired.
-// Two cases reach here:
-// (1) deadline expired before dispatch began — executeJob skips dispatch (see its early-SLO comment):
+// Three cases reach here:
+// (1) deadline expired during ingestion (preProcessJob) — no output files exist yet;
+//
+//	uploadPartialResults uploads nothing, requestCounts is nil, DB counts remain zero.
+//
+// (2) deadline expired before dispatch began — executeJob skips dispatch:
 //
 //	no completions are written to the output file, but error.jsonl may already contain
-//	model_not_found lines from ingestion. uploadPartialResults still uploads whatever exists.
+//	model_not_found lines from ingestion. uploadPartialResults uploads whatever exists.
 //
-// (2) deadline expired during execution — completed requests remain in the output file and undispatched entries were drained
-// as "batch_expired" by drainUnprocessedRequests.
-// In both cases, this function uploads whatever files exist and transitions the job to expired status.
+// (3) deadline expired during execution — completed requests remain in the output file
+//
+//	and undispatched entries were drained as "batch_expired" by drainUnprocessedRequests.
+//
+// In all cases, this function uploads whatever files exist and transitions the job to expired status.
+// Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.
 func (p *Processor) handleExpired(
 	ctx context.Context,
 	updater *StatusUpdater,
@@ -366,17 +419,24 @@ func (p *Processor) handleExpired(
 	jobInfo *batch_types.JobInfo,
 	requestCounts *openai.BatchRequestCounts,
 ) error {
+	ioCtx, ioSpan := uotel.DetachedContext(ctx, "handle-expired")
+	ioCtx, ioCancel := context.WithTimeout(ioCtx, finalizationTimeout)
+	defer ioCancel()
+	defer ioSpan.End()
+
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Job SLO expired, finalizing as expired")
 
-	outputFileID, errorFileID := p.uploadPartialResults(ctx, jobInfo, dbJob)
+	outputFileID, errorFileID := p.uploadPartialResults(ioCtx, jobInfo, dbJob)
 
-	p.cleanupJobArtifacts(ctx, dbJob.ID, dbJob.TenantID)
-
-	if err := updater.UpdateExpiredStatus(ctx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
+	if err := updater.UpdateExpiredStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
 		logger.Error(err, "Failed to update status to expired")
 		return err
 	}
+
+	// Cleanup after terminal status write: if the write failed above, the local
+	// files survive for startup recovery to re-upload.
+	p.cleanupJobArtifacts(ioCtx, dbJob.ID, dbJob.TenantID)
 
 	setRequestCountAttrs(ctx, requestCounts)
 
@@ -390,6 +450,7 @@ func (p *Processor) handleExpired(
 // transitioning to failed status. Completed requests are preserved in the output file,
 // and unexecuted requests were already drained to the error file as "batch_failed".
 // Records E2E latency as failed.
+// Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.
 func (p *Processor) handleFailedWithPartial(
 	ctx context.Context,
 	updater *StatusUpdater,
@@ -397,17 +458,24 @@ func (p *Processor) handleFailedWithPartial(
 	jobInfo *batch_types.JobInfo,
 	requestCounts *openai.BatchRequestCounts,
 ) error {
+	ioCtx, ioSpan := uotel.DetachedContext(ctx, "handle-failed-partial")
+	ioCtx, ioCancel := context.WithTimeout(ioCtx, finalizationTimeout)
+	defer ioCancel()
+	defer ioSpan.End()
+
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Job failed mid-execution, uploading partial results")
 
-	outputFileID, errorFileID := p.uploadPartialResults(ctx, jobInfo, jobItem)
+	outputFileID, errorFileID := p.uploadPartialResults(ioCtx, jobInfo, jobItem)
 
-	p.cleanupJobArtifacts(ctx, jobItem.ID, jobItem.TenantID)
-
-	if err := updater.UpdateFailedStatus(ctx, jobItem, requestCounts, outputFileID, errorFileID); err != nil {
+	if err := updater.UpdateFailedStatus(ioCtx, jobItem, requestCounts, outputFileID, errorFileID); err != nil {
 		logger.Error(err, "Failed to update status to failed")
 		return err
 	}
+
+	// Cleanup after terminal status write: if the write failed above, the local
+	// files survive for startup recovery to re-upload.
+	p.cleanupJobArtifacts(ioCtx, jobItem.ID, jobItem.TenantID)
 
 	setRequestCountAttrs(ctx, requestCounts)
 
@@ -418,9 +486,11 @@ func (p *Processor) handleFailedWithPartial(
 }
 
 // handleFailed finalizes a failed job without partial output upload.
-// Used for ingestion failures (no output files), finalization failures (upload retries exhausted),
-// and re-enqueue failures (infrastructure-level issue). requestCounts is recorded in DB when non-nil.
+// Used for ingestion failures (no output files) and pre-upload finalization failures
+// (e.g. finalizing status write). requestCounts is recorded in DB when non-nil.
 // Records E2E latency as failed when jobInfo is available (nil-safe).
+// Uses a detached context so that a concurrent SIGTERM cannot abort the DB write.
+// If the caller already has a tighter deadline (e.g. panic recovery), that deadline is respected.
 func (p *Processor) handleFailed(
 	ctx context.Context,
 	updater *StatusUpdater,
@@ -428,11 +498,23 @@ func (p *Processor) handleFailed(
 	requestCounts *openai.BatchRequestCounts,
 	jobInfo *batch_types.JobInfo,
 ) error {
+	timeout := finalizationTimeout
+	if d, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(d); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+
+	ioCtx, ioSpan := uotel.DetachedContext(ctx, "handle-failed")
+	ioCtx, ioCancel := context.WithTimeout(ioCtx, timeout)
+	defer ioCancel()
+	defer ioSpan.End()
+
 	logger := logr.FromContextOrDiscard(ctx)
 
-	p.cleanupJobArtifacts(ctx, jobItem.ID, jobItem.TenantID)
+	p.cleanupJobArtifacts(ioCtx, jobItem.ID, jobItem.TenantID)
 
-	if err := updater.UpdateFailedStatus(ctx, jobItem, requestCounts, "", ""); err != nil {
+	if err := updater.UpdateFailedStatus(ioCtx, jobItem, requestCounts, "", ""); err != nil {
 		logger.Error(err, "Failed to update status to failed")
 		return err
 	}

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -131,17 +131,17 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	// userCancelCtx is a user-cancel-only signal: it is derived from context.Background so that
 	// SIGTERM and SLO expiry do NOT propagate into it. userCancelCtx.Err() != nil exclusively means
-	// the user requested cancellation via the API. watchCancel calls userCancelFn to set it,
-	// and also calls requestAbortFn to stop the dispatch loop immediately.
+	// the user requested cancellation via the API.
 	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
 	params.userCancelFn = userCancelFn
 	defer userCancelFn()
 
 	// requestAbortCtx is derived from sloCtx so SLO expiry and SIGTERM propagate automatically
-	// to all dispatch loops and inference calls. It is created here, before watchCancel starts,
-	// so params.requestAbortFn is set before any cancel event can arrive — eliminating the
-	// race window where watchCancel fires between runJob and executeJob setting the function.
+	// to all dispatch loops and inference calls. User cancel is wired via AfterFunc so that
+	// cancelling userCancelCtx automatically cancels requestAbortCtx without manual dispatch.
+	// Fatal I/O errors in executor.go still call requestAbortFn directly.
 	requestAbortCtx, requestAbortFn := context.WithCancel(sloCtx)
+	context.AfterFunc(userCancelCtx, requestAbortFn)
 	params.requestAbortFn = requestAbortFn
 	defer requestAbortFn()
 
@@ -269,14 +269,7 @@ func (p *Processor) handlePanicRecovery(
 	bgCtx, bgCancel := context.WithTimeout(context.Background(), panicRecoveryTimeout)
 	defer bgCancel()
 	bgCtx = logr.NewContext(bgCtx, logger)
-	if transitionedToInProgress && requestCounts != nil && params.jobInfo != nil {
-		if err := p.handleFailedWithPartial(bgCtx, params.updater, params.jobItem, params.jobInfo, requestCounts); err != nil {
-			logger.Error(err, "handleFailedWithPartial failed after panic, falling back to handleFailed")
-		} else {
-			return
-		}
-	}
-	if err := p.handleFailed(bgCtx, params.updater, params.jobItem, requestCounts, nil); err != nil {
+	if err := p.handleFailed(bgCtx, params.updater, params.jobItem, requestCounts, params.jobInfo); err != nil {
 		logger.Error(err, "Failed to mark job as failed after panic — job will remain in_progress until startup recovery runs",
 			"jobID", params.jobItem.ID, "tenantID", params.jobItem.TenantID)
 	}
@@ -331,14 +324,8 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 				// executeJob flushed partial output/error files to disk before returning
 				// errShutdown. Upload them so the user can retrieve whatever completed
 				// before SIGTERM, rather than losing those results silently.
-				if params.requestCounts != nil && params.jobInfo != nil {
-					if failErr := p.handleFailedWithPartial(bgCtx, params.updater, params.jobItem, params.jobInfo, params.requestCounts); failErr != nil {
-						logger.Error(failErr, "Failed to handle failed event with partial output after re-enqueue failure")
-					}
-				} else {
-					if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, nil, params.jobInfo); failErr != nil {
-						logger.Error(failErr, "Failed to mark job as failed after re-enqueue failure")
-					}
+				if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, params.requestCounts, params.jobInfo); failErr != nil {
+					logger.Error(failErr, "Failed to mark job as failed after re-enqueue failure")
 				}
 			} else {
 				metrics.RecordJobProcessed(metrics.ResultReEnqueued, metrics.ReasonSystemError)
@@ -347,14 +334,8 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 		}
 
 	default:
-		if params.requestCounts != nil && params.jobInfo != nil {
-			if failErr := p.handleFailedWithPartial(ctx, params.updater, params.jobItem, params.jobInfo, params.requestCounts); failErr != nil {
-				logger.Error(failErr, "Failed to handle failed event with partial output")
-			}
-		} else {
-			if failErr := p.handleFailed(ctx, params.updater, params.jobItem, nil, params.jobInfo); failErr != nil {
-				logger.Error(failErr, "Failed to handle failed event")
-			}
+		if failErr := p.handleFailed(ctx, params.updater, params.jobItem, params.requestCounts, params.jobInfo); failErr != nil {
+			logger.Error(failErr, "Failed to handle failed event")
 		}
 	}
 }
@@ -446,50 +427,14 @@ func (p *Processor) handleExpired(
 	return nil
 }
 
-// handleFailedWithPartial finalizes an execution failure by uploading partial results before
-// transitioning to failed status. Completed requests are preserved in the output file,
-// and unexecuted requests were already drained to the error file as "batch_failed".
-// Records E2E latency as failed.
-// Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.
-func (p *Processor) handleFailedWithPartial(
-	ctx context.Context,
-	updater *StatusUpdater,
-	jobItem *db.BatchItem,
-	jobInfo *batch_types.JobInfo,
-	requestCounts *openai.BatchRequestCounts,
-) error {
-	ioCtx, ioSpan := uotel.DetachedContext(ctx, "handle-failed-partial")
-	ioCtx, ioCancel := context.WithTimeout(ioCtx, finalizationTimeout)
-	defer ioCancel()
-	defer ioSpan.End()
-
-	logger := logr.FromContextOrDiscard(ctx)
-	logger.V(logging.INFO).Info("Job failed mid-execution, uploading partial results")
-
-	outputFileID, errorFileID := p.uploadPartialResults(ioCtx, jobInfo, jobItem)
-
-	if err := updater.UpdateFailedStatus(ioCtx, jobItem, requestCounts, outputFileID, errorFileID); err != nil {
-		logger.Error(err, "Failed to update status to failed")
-		return err
-	}
-
-	// Cleanup after terminal status write: if the write failed above, the local
-	// files survive for startup recovery to re-upload.
-	p.cleanupJobArtifacts(ioCtx, jobItem.ID, jobItem.TenantID)
-
-	setRequestCountAttrs(ctx, requestCounts)
-
-	recordE2ELatency(jobInfo, metrics.E2EStatusFailed)
-	metrics.RecordJobProcessed(metrics.ResultFailed, metrics.ReasonSystemError)
-	logger.V(logging.INFO).Info("Job failed handled with partial output", "outputFileID", outputFileID, "errorFileID", errorFileID)
-	return nil
-}
-
-// handleFailed finalizes a failed job without partial output upload.
-// Used for ingestion failures (no output files) and pre-upload finalization failures
-// (e.g. finalizing status write). requestCounts is recorded in DB when non-nil.
+// handleFailed finalizes a failed job by optionally uploading partial results before
+// transitioning to failed status. When jobInfo is non-nil and partial output exists on
+// disk, the output and error files are uploaded so the user can retrieve whatever
+// completed before the failure. When jobInfo is nil (e.g. ingestion failure, malformed
+// job), only the DB status transition is performed.
+//
 // Records E2E latency as failed when jobInfo is available (nil-safe).
-// Uses a detached context so that a concurrent SIGTERM cannot abort the DB write.
+// Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.
 // If the caller already has a tighter deadline (e.g. panic recovery), that deadline is respected.
 func (p *Processor) handleFailed(
 	ctx context.Context,
@@ -512,18 +457,23 @@ func (p *Processor) handleFailed(
 
 	logger := logr.FromContextOrDiscard(ctx)
 
-	p.cleanupJobArtifacts(ioCtx, jobItem.ID, jobItem.TenantID)
+	var outputFileID, errorFileID string
+	if jobInfo != nil {
+		outputFileID, errorFileID = p.uploadPartialResults(ioCtx, jobInfo, jobItem)
+	}
 
-	if err := updater.UpdateFailedStatus(ioCtx, jobItem, requestCounts, "", ""); err != nil {
+	if err := updater.UpdateFailedStatus(ioCtx, jobItem, requestCounts, outputFileID, errorFileID); err != nil {
 		logger.Error(err, "Failed to update status to failed")
 		return err
 	}
+
+	p.cleanupJobArtifacts(ioCtx, jobItem.ID, jobItem.TenantID)
 
 	setRequestCountAttrs(ctx, requestCounts)
 
 	recordE2ELatency(jobInfo, metrics.E2EStatusFailed)
 	metrics.RecordJobProcessed(metrics.ResultFailed, metrics.ReasonSystemError)
-	logger.V(logging.INFO).Info("Job failed handled")
+	logger.V(logging.INFO).Info("Job failed handled", "outputFileID", outputFileID, "errorFileID", errorFileID)
 	return nil
 }
 

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"sync/atomic"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,9 +13,12 @@ import (
 	mockdb "github.com/llm-d-incubation/batch-gateway/internal/database/mock"
 	mockfiles "github.com/llm-d-incubation/batch-gateway/internal/files_store/mock"
 	"github.com/llm-d-incubation/batch-gateway/internal/processor/config"
+	"github.com/llm-d-incubation/batch-gateway/internal/shared/converter"
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
+	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
+	"github.com/llm-d-incubation/batch-gateway/pkg/clients/inference"
 )
 
 type errEventClient struct {
@@ -171,10 +175,11 @@ func TestRunJob_PreProcessError_HandlesFailedStatus(t *testing.T) {
 	}
 }
 
-// TestRunJob_WithCancelRequested_ReachesPreProcess verifies that runJob with a properly
-// initialized cancelRequested field proceeds past the event watcher setup and into
-// preProcessJob without panicking.
-func TestRunJob_WithCancelRequested_ReachesPreProcess(t *testing.T) {
+// TestRunJob_ReachesPreProcess verifies that runJob proceeds past event watcher setup
+// and into preProcessJob. preProcessJob fails because the input file does not exist on
+// disk, so the job transitions to failed — confirming that handleJobError was reached
+// rather than a silent panic or early return.
+func TestRunJob_ReachesPreProcess(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.NumWorkers = 1
 	cfg.WorkDir = t.TempDir()
@@ -202,8 +207,8 @@ func TestRunJob_WithCancelRequested_ReachesPreProcess(t *testing.T) {
 		t.Fatalf("DBStore: %v", err)
 	}
 
-	// InputFileID is set so preProcessJob proceeds past the empty-check and reaches
-	// the cancelRequested.Load() call. Without cancelRequested initialized, this panics.
+	// InputFileID is set so preProcessJob proceeds past the empty-check and attempts
+	// to download the input file (which does not exist, causing a handled failure).
 	jobInfo := &batch_types.JobInfo{
 		JobID: "job-contract",
 		BatchJob: &openai.Batch{
@@ -221,12 +226,10 @@ func TestRunJob_WithCancelRequested_ReachesPreProcess(t *testing.T) {
 	}
 	p.wg.Add(1)
 
-	var cancelRequested atomic.Bool
 	p.runJob(ctx, &jobExecutionParams{
-		updater:         NewStatusUpdater(dbClient, statusClient, 86400),
-		jobItem:         jobItem,
-		jobInfo:         jobInfo,
-		cancelRequested: &cancelRequested,
+		updater: NewStatusUpdater(dbClient, statusClient, 86400),
+		jobItem: jobItem,
+		jobInfo: jobInfo,
 		task: &db.BatchJobPriority{
 			ID:  "job-contract",
 			SLO: time.Now().Add(1 * time.Hour),
@@ -465,6 +468,134 @@ func TestHandlePanicRecovery_BlockingDB_ReturnsWithinTimeout(t *testing.T) {
 	}
 }
 
+// TestRunJob_Success_CompletesAndCleansArtifacts verifies the full happy-path orchestration:
+//
+//	preProcessJob → in_progress → executeJob → finalizeJob → completed
+//
+// It asserts that the final DB status is completed, an output file ID was recorded,
+// and the local job directory was removed. It also verifies that runJob returns
+// without deadlock (wg and worker token are released).
+func TestRunJob_Success_CompletesAndCleansArtifacts(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	const (
+		jobID       = "job-happy-path"
+		tenantID    = "tenant-1"
+		inputFileID = "file-input-happy"
+	)
+
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	// Compute where MockBatchFilesClient stores/retrieves files.
+	folderName, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	storageName := ucom.FileStorageName(inputFileID, "input.jsonl") // "<inputFileID>.jsonl"
+	storageDir := filepath.Join("/tmp/batch-gateway-files", folderName)
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll storage dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(storageDir) })
+
+	inputContent := `{"custom_id":"req-1","body":{"model":"test-model","messages":[{"role":"user","content":"hello"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(storageDir, storageName), []byte(inputContent), 0o644); err != nil {
+		t.Fatalf("WriteFile input to mock storage: %v", err)
+	}
+
+	// Seed FileDB so openInputFileStream can resolve the input file.
+	fileDBClient := newMockFileDBClient()
+	fileItem, err := converter.FileToDBItem(&openai.FileObject{
+		ID:       inputFileID,
+		Filename: "input.jsonl",
+		Purpose:  openai.FileObjectPurposeBatch,
+		Object:   "file",
+	}, tenantID, db.Tags{})
+	if err != nil {
+		t.Fatalf("FileToDBItem: %v", err)
+	}
+	if err := fileDBClient.DBStore(ctx, fileItem); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	// Seed BatchDB with the job.
+	dbClient := newMockBatchDBClient()
+	jobItem := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{
+			Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusValidating}),
+		},
+	}
+	if err := dbClient.DBStore(ctx, jobItem); err != nil {
+		t.Fatalf("DBStore batch item: %v", err)
+	}
+
+	// Use MockBatchFilesClient so Retrieve reads from /tmp/batch-gateway-files
+	// (where we seeded the input file above) and Store writes output files there.
+	statusClient := mockdb.NewMockBatchStatusClient()
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		BatchDB:   dbClient,
+		FileDB:    fileDBClient,
+		File:      mockfiles.NewMockBatchFilesClient(),
+		Status:    statusClient,
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Inference: inference.NewSingleClientResolver(&mockInferenceClient{}),
+	})
+
+	jobInfo := &batch_types.JobInfo{
+		JobID:    jobID,
+		TenantID: tenantID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+				Endpoint:    "/v1/chat/completions",
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{Status: openai.BatchStatusValidating},
+		},
+	}
+
+	if !p.acquire(context.Background()) {
+		t.Fatalf("expected token acquire before runJob")
+	}
+	p.wg.Add(1)
+	p.runJob(ctx, &jobExecutionParams{
+		updater: NewStatusUpdater(dbClient, statusClient, 86400),
+		jobItem: jobItem,
+		jobInfo: jobInfo,
+		task: &db.BatchJobPriority{
+			ID:  jobID,
+			SLO: time.Now().Add(1 * time.Hour),
+		},
+	})
+
+	// Assert DB status is completed.
+	items, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var status openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Status != openai.BatchStatusCompleted {
+		t.Fatalf("expected completed, got %s", status.Status)
+	}
+
+	// Assert output file ID was recorded (inference succeeded, output.jsonl was uploaded).
+	if status.OutputFileID == nil || *status.OutputFileID == "" {
+		t.Fatalf("expected output_file_id to be set, got nil/empty")
+	}
+
+	// Assert local job directory was cleaned up.
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if _, err := os.Stat(jobDir); err == nil {
+		t.Fatalf("expected job dir to be removed after completion, still exists: %s", jobDir)
+	}
+}
+
 func assertJobStatus(t *testing.T, dbClient db.BatchDBClient, jobID string, want openai.BatchStatus) {
 	t.Helper()
 	items, _, _, err := dbClient.DBGet(context.Background(), &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
@@ -477,5 +608,214 @@ func assertJobStatus(t *testing.T, dbClient db.BatchDBClient, jobID string, want
 	}
 	if status.Status != want {
 		t.Fatalf("job %s: expected status %s, got %s", jobID, want, status.Status)
+	}
+}
+
+// TestRunJob_FinalizeFailedOver_PreservesFileIDsAndDoesNotCallHandleFailed verifies the
+// runJob → finalizeJob → errFinalizeFailedOver integration path. When the completed-status
+// DB write fails inside finalizeJob, the fallback writes "failed" status with file IDs
+// preserved. runJob must NOT call handleFailed again — that would overwrite the file IDs
+// with empty strings, orphaning the already-uploaded files.
+func TestRunJob_FinalizeFailedOver_PreservesFileIDsAndDoesNotCallHandleFailed(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	const (
+		jobID       = "job-finalize-failover"
+		tenantID    = "tenant-1"
+		inputFileID = "file-input-failover"
+	)
+
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	folderName, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	storageName := ucom.FileStorageName(inputFileID, "input.jsonl")
+	storageDir := filepath.Join("/tmp/batch-gateway-files", folderName)
+	if err := os.MkdirAll(storageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll storage dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(storageDir) })
+
+	inputContent := `{"custom_id":"req-1","body":{"model":"test-model","messages":[{"role":"user","content":"hello"}]}}` + "\n"
+	if err := os.WriteFile(filepath.Join(storageDir, storageName), []byte(inputContent), 0o644); err != nil {
+		t.Fatalf("WriteFile input: %v", err)
+	}
+
+	fileDBClient := newMockFileDBClient()
+	fileItem, err := converter.FileToDBItem(&openai.FileObject{
+		ID:       inputFileID,
+		Filename: "input.jsonl",
+		Purpose:  openai.FileObjectPurposeBatch,
+		Object:   "file",
+	}, tenantID, db.Tags{})
+	if err != nil {
+		t.Fatalf("FileToDBItem: %v", err)
+	}
+	if err := fileDBClient.DBStore(ctx, fileItem); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	// failOnStatusDB makes the completed-status write fail while allowing
+	// the fallback failed-status write to succeed.
+	innerDB := newMockBatchDBClient()
+	failDB := &failOnStatusDB{
+		inner:      innerDB,
+		failStatus: openai.BatchStatusCompleted,
+		failErr:    errors.New("injected: completed write failed"),
+	}
+
+	jobItem := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{
+			Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusValidating}),
+		},
+	}
+	if err := innerDB.DBStore(ctx, jobItem); err != nil {
+		t.Fatalf("DBStore batch item: %v", err)
+	}
+
+	statusClient := mockdb.NewMockBatchStatusClient()
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		BatchDB:   failDB,
+		FileDB:    fileDBClient,
+		File:      mockfiles.NewMockBatchFilesClient(),
+		Status:    statusClient,
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Inference: inference.NewSingleClientResolver(&mockInferenceClient{}),
+	})
+	p.poller = NewPoller(mockdb.NewMockBatchPriorityQueueClient(), failDB)
+
+	jobInfo := &batch_types.JobInfo{
+		JobID:    jobID,
+		TenantID: tenantID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+				Endpoint:    "/v1/chat/completions",
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{Status: openai.BatchStatusValidating},
+		},
+	}
+
+	if !p.acquire(context.Background()) {
+		t.Fatalf("expected token acquire before runJob")
+	}
+	p.wg.Add(1)
+	p.runJob(ctx, &jobExecutionParams{
+		updater: NewStatusUpdater(failDB, statusClient, 86400),
+		jobItem: jobItem,
+		jobInfo: jobInfo,
+		task: &db.BatchJobPriority{
+			ID:  jobID,
+			SLO: time.Now().Add(1 * time.Hour),
+		},
+	})
+
+	// DB status must be "failed" (fallback), not "completed" (which was injected to fail).
+	items, _, _, getErr := innerDB.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if getErr != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", getErr, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed (errFinalizeFailedOver path)", got.Status)
+	}
+	// File IDs must be preserved by the failover — handleFailed must NOT have overwritten them.
+	if got.OutputFileID == nil {
+		t.Fatal("output_file_id must be preserved in failover path, got nil")
+	}
+}
+
+// TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput verifies that when
+// errShutdown triggers a re-enqueue that fails, the fallback uploads partial output files
+// and preserves their file IDs in the DB. Before this fix, the fallback called handleFailed
+// with nil counts and empty file IDs, losing already-flushed results.
+func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	cfg := config.NewConfig()
+	cfg.NumWorkers = 1
+	cfg.WorkDir = t.TempDir()
+
+	dbClient := newMockBatchDBClient()
+	statusClient := mockdb.NewMockBatchStatusClient()
+	pqClient := &errPQClient{err: errors.New("queue unavailable")}
+
+	p := mustNewProcessor(t, cfg, &clientset.Clientset{
+		BatchDB:   dbClient,
+		FileDB:    newMockFileDBClient(),
+		File:      mockfiles.NewMockBatchFilesClient(),
+		Status:    statusClient,
+		Queue:     pqClient,
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		Inference: inference.NewSingleClientResolver(&fakeInferenceClient{}),
+	})
+	p.poller = NewPoller(pqClient, dbClient)
+
+	jobID := "job-shutdown-enqueue-fail"
+	tenantID := "tenant__tenantA"
+
+	jobItem := &db.BatchItem{
+		BaseIndexes: db.BaseIndexes{ID: jobID, TenantID: tenantID},
+		BaseContents: db.BaseContents{
+			Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress}),
+		},
+	}
+	if err := dbClient.DBStore(ctx, jobItem); err != nil {
+		t.Fatalf("DBStore: %v", err)
+	}
+
+	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
+	counts := &openai.BatchRequestCounts{Total: 5, Completed: 3, Failed: 2}
+
+	jobDir, _ := p.jobRootDir(jobID, tenantID)
+	if err := os.MkdirAll(jobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	outputPath := filepath.Join(jobDir, "output.jsonl")
+	if err := os.WriteFile(outputPath, []byte(`{"custom_id":"r1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile output: %v", err)
+	}
+	errorPath := filepath.Join(jobDir, "error.jsonl")
+	if err := os.WriteFile(errorPath, []byte(`{"custom_id":"e1"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	updater := NewStatusUpdater(dbClient, statusClient, 86400)
+	params := &jobExecutionParams{
+		updater:       updater,
+		jobItem:       jobItem,
+		jobInfo:       jobInfo,
+		requestCounts: counts,
+		task:          &db.BatchJobPriority{ID: jobID},
+	}
+
+	p.handleJobError(ctx, params, errShutdown)
+
+	items, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != openai.BatchStatusFailed {
+		t.Fatalf("status = %s, want failed", got.Status)
+	}
+	if got.RequestCounts.Total != 5 || got.RequestCounts.Completed != 3 || got.RequestCounts.Failed != 2 {
+		t.Fatalf("request_counts = %+v, want {5,3,2}", got.RequestCounts)
+	}
+	// handleFailedWithPartial uploads partial results; at least one file ID should be present.
+	if got.OutputFileID == nil && got.ErrorFileID == nil {
+		t.Fatal("expected at least one file ID to be preserved from partial upload")
 	}
 }

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -369,13 +369,13 @@ func TestHandlePanicRecovery_CancelledContext_StillMarksFailed(t *testing.T) {
 	assertJobStatus(t, dbClient, "job-panic-cancelled-ctx", openai.BatchStatusFailed)
 }
 
-func TestHandlePanicRecovery_PartialFails_FallbackSucceeds(t *testing.T) {
+func TestHandlePanicRecovery_DBError_DoesNotCrash(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	dbClient := &dbUpdateFailOnceWrapper{inner: newMockBatchDBClient(), failCount: 1}
 	statusClient := mockdb.NewMockBatchStatusClient()
 
 	jobItem := &db.BatchItem{
-		BaseIndexes:  db.BaseIndexes{ID: "job-panic-fallback", TenantID: "tenantA"},
+		BaseIndexes:  db.BaseIndexes{ID: "job-panic-db-err", TenantID: "tenantA"},
 		BaseContents: db.BaseContents{Status: mustJSON(t, openai.BatchStatusInfo{Status: openai.BatchStatusInProgress})},
 	}
 	if err := dbClient.DBStore(ctx, jobItem); err != nil {
@@ -387,10 +387,10 @@ func TestHandlePanicRecovery_PartialFails_FallbackSucceeds(t *testing.T) {
 	p.handlePanicRecovery(ctx, &jobExecutionParams{
 		updater: NewStatusUpdater(dbClient, statusClient, 86400),
 		jobItem: jobItem,
-		jobInfo: &batch_types.JobInfo{JobID: "job-panic-fallback"},
+		jobInfo: &batch_types.JobInfo{JobID: "job-panic-db-err"},
 	}, true, counts)
 
-	assertJobStatus(t, dbClient, "job-panic-fallback", openai.BatchStatusFailed)
+	assertJobStatus(t, dbClient, "job-panic-db-err", openai.BatchStatusInProgress)
 }
 
 func TestHandlePanicRecovery_NilParams_DoesNotPanic(t *testing.T) {
@@ -814,7 +814,7 @@ func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.
 	if got.RequestCounts.Total != 5 || got.RequestCounts.Completed != 3 || got.RequestCounts.Failed != 2 {
 		t.Fatalf("request_counts = %+v, want {5,3,2}", got.RequestCounts)
 	}
-	// handleFailedWithPartial uploads partial results; at least one file ID should be present.
+	// handleFailed uploads partial results when jobInfo is non-nil; at least one file ID should be present.
 	if got.OutputFileID == nil && got.ErrorFileID == nil {
 		t.Fatal("expected at least one file ID to be preserved from partial upload")
 	}

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -21,11 +21,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
 	"os"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -42,35 +42,30 @@ import (
 // error entries for requests targeting unregistered models.
 // The rejected count is persisted in model_map.json so executeJob can
 // seed BatchRequestCounts.Failed without an extra parameter.
-func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobInfo, cancelRequested *atomic.Bool) error {
+func (p *Processor) preProcessJob(ctx, sloCtx, userCancelCtx context.Context, jobInfo *batch_types.JobInfo) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Pre-processing job") // job id is in the logger already
 	planBuildStart := time.Now()
 	jobID := jobInfo.JobID
 	inputFileID := jobInfo.BatchJob.InputFileID
 	if inputFileID == "" {
-		err := fmt.Errorf("input file ID is empty")
-		logger.Error(err, "Input file ID is empty")
-		return err
+		return fmt.Errorf("input file ID is empty")
 	}
 
 	jobRootDir, err := p.jobRootDir(jobID, jobInfo.TenantID)
 	if err != nil {
-		logger.Error(err, "Failed to resolve job root directory")
-		return err
+		return fmt.Errorf("resolve job root directory: %w", err)
 	}
 
 	// job directory creation
 	if err := os.MkdirAll(jobRootDir, 0o700); err != nil {
-		logger.Error(err, "Failed to create job root directory", "jobRootDir", jobRootDir)
-		return err
+		return fmt.Errorf("create job root directory %q: %w", jobRootDir, err)
 	}
 
 	// input file stream open
 	reader, metadata, err := p.openInputFileStream(ctx, inputFileID)
 	if err != nil {
-		logger.Error(err, "Failed to open input file stream", "inputFileId", inputFileID)
-		return err
+		return fmt.Errorf("open input file stream %q: %w", inputFileID, err)
 	}
 	defer reader.Close()
 
@@ -81,8 +76,7 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	// create local input file
 	localInputFile, localInputFilePath, err := p.createLocalInputFile(jobID, jobInfo.TenantID)
 	if err != nil {
-		logger.Error(err, "Failed to create local input file", "path", localInputFilePath)
-		return err
+		return fmt.Errorf("create local input file: %w", err)
 	}
 	defer localInputFile.Close()
 
@@ -131,22 +125,24 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	inputFileReader := bufio.NewReaderSize(reader, 1024*1024)
 
 	for {
-		// Ingestion uses the parent ctx (not abortCtx), so user-cancel signals do not
-		// propagate through the context tree. Check cancelRequested explicitly.
-		if ctx.Err() != nil {
-			return ctx.Err()
+		// Priority: SLO expiry > user cancel > pod shutdown, matching processModel's
+		// drain switch. This ensures a user cancel is honoured even when SIGTERM arrives
+		// concurrently, instead of re-enqueueing a job the user asked to cancel.
+		if errors.Is(sloCtx.Err(), context.DeadlineExceeded) {
+			return errExpired
 		}
-		if cancelRequested.Load() {
+		if userCancelCtx.Err() != nil {
 			logger.V(logging.INFO).Info("preProcess: cancel requested")
-			return ErrCancelled
+			return errCancelled
+		}
+		if ctx.Err() != nil {
+			return errShutdown
 		}
 
 		// read a line from the input file
 		line, done, err := readNormalizedLine(inputFileReader)
 		if err != nil {
-			// if error occurs, fail the pre-processing and the job
-			logger.Error(err, "Failed to read line from input file")
-			return err
+			return fmt.Errorf("read line %d from input file: %w", lineCount+1, err)
 		}
 		if done {
 			break
@@ -156,20 +152,16 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 
 		// write the line to the input file.
 		if _, err := writer.Write(line); err != nil {
-			logger.Error(err, "Failed to write line to input file", "path", localInputFilePath, "lineCount", lineCount)
-			return err
+			return fmt.Errorf("write line %d to input file %q: %w", lineCount, localInputFilePath, err)
 		}
 
 		requestMeta, err := extractAndValidateLine(line)
 		if err != nil {
-			logger.Error(err, "Failed to validate request line", "lineCount", lineCount)
-			return err
+			return fmt.Errorf("validate request at line %d: %w", lineCount, err)
 		}
 
 		if _, exists := seenCustomIDs[requestMeta.CustomID]; exists {
-			err := fmt.Errorf("line %d: duplicate custom_id %q", lineCount, requestMeta.CustomID)
-			logger.Error(err, "Duplicate custom_id in batch input")
-			return err
+			return fmt.Errorf("line %d: duplicate custom_id %q", lineCount, requestMeta.CustomID)
 		}
 		seenCustomIDs[requestMeta.CustomID] = struct{}{}
 
@@ -215,19 +207,16 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 
 	// flush input.jsonl file
 	if err := writer.Flush(); err != nil {
-		logger.Error(err, "Failed to flush input file", "path", localInputFilePath)
-		return err
+		return fmt.Errorf("flush input file %q: %w", localInputFilePath, err)
 	}
 
 	if err := finalizePlanFiles(acc, modelToSafe); err != nil {
-		logger.Error(err, "Failed to finalize plan files")
-		return err
+		return fmt.Errorf("finalize plan files: %w", err)
 	}
 
 	// model map file writing
 	if err := writeModelMappings(jobRootDir, modelToSafe, lineCount, rejectedCount); err != nil {
-		logger.Error(err, "Failed to write model map file")
-		return err
+		return fmt.Errorf("write model map: %w", err)
 	}
 
 	metrics.RecordPlanBuildDuration(time.Since(planBuildStart), metrics.GetSizeBucket(int(lineCount)))
@@ -239,17 +228,6 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 		"inputFilePath", localInputFilePath, "planFilePath", acc.plansDir(),
 		"lineCount", lineCount, "rejected", rejectedCount, "models", modelCounts)
 
-	return nil
-}
-
-// checkAbortCondition returns a non-nil error if dispatch should stop because the context
-// is done (cancelled, deadline exceeded, or SLO deadline). It does NOT check the
-// cancelRequested flag; that flag is only consulted in the error-handling path to
-// distinguish the cancellation reason (user cancel vs SLO vs pod shutdown).
-func checkAbortCondition(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -103,8 +102,7 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -254,8 +252,7 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -376,39 +373,34 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 	}
 	defer evCh.CloseFn()
 
-	var cancelRequested atomic.Bool
-	abortCtx, abortInferFn := context.WithCancel(ctx)
+	userCancelCtx, userCancelFn := context.WithCancel(ctx)
+	requestAbortCtx, requestAbortFn := context.WithCancel(ctx)
 
-	// Start watching cancel in background
 	params := &jobExecutionParams{
-		eventWatcher:    evCh,
-		updater:         updater,
-		jobItem:         jobItem,
-		abortInferFn:    abortInferFn,
-		cancelRequested: &cancelRequested,
+		eventWatcher:   evCh,
+		updater:        updater,
+		jobItem:        jobItem,
+		userCancelFn:   userCancelFn,
+		requestAbortFn: requestAbortFn,
 	}
 	go p.watchCancel(ctx, params)
 
-	// Send cancel event
 	_, _ = eventClient.ECProducerSendEvents(ctx, []db.BatchEvent{
 		{ID: jobID, Type: db.BatchEventCancel, TTL: 60},
 	})
 
-	// Verify cancelRequested flag was set
-	deadline := time.Now().Add(2 * time.Second)
-	for !params.cancelRequested.Load() && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if !params.cancelRequested.Load() {
-		t.Fatalf("cancelRequested was not set")
+	// Verify userCancelFn was called (user-cancel signal).
+	select {
+	case <-userCancelCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("userCancelCtx was not cancelled within 2s after cancel event")
 	}
 
-	// Verify abort context was cancelled
+	// Verify requestAbortFn was called (dispatch abort signal).
 	select {
-	case <-abortCtx.Done():
-		// success — abortInferFn was called
+	case <-requestAbortCtx.Done():
 	case <-time.After(2 * time.Second):
-		t.Fatal("abortCtx was not cancelled within 2s after cancel event")
+		t.Fatal("requestAbortCtx was not cancelled within 2s after cancel event")
 	}
 
 	// Verify that watchCancel does NOT update status to cancelling
@@ -489,11 +481,160 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	cancelRequested.Store(true)
-	err = p.preProcessJob(ctx, jobInfo, &cancelRequested)
-	if !errors.Is(err, ErrCancelled) {
-		t.Fatalf("expected ErrCancelled, got: %v", err)
+	userCancelCtx, abortFn := context.WithCancel(ctx)
+	abortFn()
+	err = p.preProcessJob(ctx, ctx, userCancelCtx, jobInfo)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled, got: %v", err)
+	}
+}
+
+// TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled verifies that when both userCancelCtx
+// and ctx (SIGTERM) are cancelled, preProcessJob returns errCancelled — not errShutdown.
+// This matches processModel's priority (SLO > cancel > shutdown) and prevents re-enqueueing
+// a job the user asked to cancel.
+func TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	workDir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.WorkDir = workDir
+	dbClient := newMockBatchDBClient()
+	fileDBClient := newMockFileDBClient()
+	filesClient := mockfiles.NewMockBatchFilesClient()
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  fileDBClient,
+		File:    filesClient,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	jobID := "job-preprocess-cancel-sigterm"
+	inputFileID := "file-preprocess-cancel-sigterm"
+	tenantID := uniqueTestFolder(t, "tenantA/preprocess-cancel-sigterm")
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	cleanMockFilesFolder(t, folder)
+
+	models := make([]string, 0, 2000)
+	for i := 0; i < 2000; i++ {
+		models = append(models, "mA")
+	}
+	lines := makeInputLines(models)
+	var remoteBuf bytes.Buffer
+	for _, ln := range lines {
+		remoteBuf.Write(ln)
+	}
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, "input.jsonl"), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
+	fileSpec := &openai.FileObject{Filename: "input.jsonl"}
+	if err := fileDBClient.DBStore(ctx, &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: mustJSON(t, fileSpec)},
+	}); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	jobInfo := &batch_types.JobInfo{
+		JobID: jobID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{
+				Status: openai.BatchStatusInProgress,
+			},
+		},
+		TenantID: tenantID,
+	}
+
+	// Both ctx (SIGTERM) and userCancelCtx are cancelled.
+	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
+	shutdownCancel()
+
+	userCancelCtx, userCancelFn := context.WithCancel(ctx)
+	userCancelFn()
+
+	err = p.preProcessJob(shutdownCtx, shutdownCtx, userCancelCtx, jobInfo)
+	if !errors.Is(err, errCancelled) {
+		t.Fatalf("expected errCancelled when both SIGTERM and user cancel fire, got: %v", err)
+	}
+}
+
+func TestPreProcess_SLOExpiredDuringIngestion_ReturnsErrExpired(t *testing.T) {
+	ctx := testLoggerCtx(t)
+
+	workDir := t.TempDir()
+	cfg := config.NewConfig()
+	cfg.WorkDir = workDir
+	dbClient := newMockBatchDBClient()
+	fileDBClient := newMockFileDBClient()
+	filesClient := mockfiles.NewMockBatchFilesClient()
+
+	clients := &clientset.Clientset{
+		BatchDB: dbClient,
+		FileDB:  fileDBClient,
+		File:    filesClient,
+	}
+	p := mustNewProcessor(t, cfg, clients)
+
+	jobID := "job-preprocess-slo-expired"
+	inputFileID := "file-preprocess-slo-expired"
+	tenantID := uniqueTestFolder(t, "tenantA/preprocess-slo-expired")
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		t.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	cleanMockFilesFolder(t, folder)
+
+	// A single request is enough: sloCtx is already expired, so the ingestion loop
+	// returns errExpired on the first iteration before reading any lines.
+	lines := makeInputLines([]string{"any-model"}) // content irrelevant; loop exits before reading
+	var remoteBuf bytes.Buffer
+	for _, ln := range lines {
+		remoteBuf.Write(ln)
+	}
+
+	if _, err := filesClient.Store(ctx, ucom.FileStorageName(inputFileID, "input.jsonl"), folder, 0, 0, bytes.NewReader(remoteBuf.Bytes())); err != nil {
+		t.Fatalf("files.Store: %v", err)
+	}
+	fileSpec := &openai.FileObject{Filename: "input.jsonl"}
+	if err := fileDBClient.DBStore(ctx, &db.FileItem{
+		BaseIndexes: db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{
+			Spec: mustJSON(t, fileSpec),
+		},
+	}); err != nil {
+		t.Fatalf("DBStore file item: %v", err)
+	}
+
+	jobInfo := &batch_types.JobInfo{
+		JobID: jobID,
+		BatchJob: &openai.Batch{
+			ID: jobID,
+			BatchSpec: openai.BatchSpec{
+				InputFileID: inputFileID,
+			},
+			BatchStatusInfo: openai.BatchStatusInfo{
+				Status: openai.BatchStatusInProgress,
+			},
+		},
+		TenantID: tenantID,
+	}
+
+	// Use a context with a deadline in the past so sloCtx.Err() == DeadlineExceeded immediately.
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
+	defer sloCancel()
+
+	err = p.preProcessJob(ctx, sloCtx, context.Background(), jobInfo)
+	if !errors.Is(err, errExpired) {
+		t.Fatalf("expected errExpired, got: %v", err)
 	}
 }
 
@@ -558,6 +699,18 @@ func TestHandleCancelled_CleansDir_UpdatesCancelled(t *testing.T) {
 	jobs, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
 	if err != nil || len(jobs) != 1 {
 		t.Fatalf("DBGet job after cancel: err=%v len=%d", err, len(jobs))
+	}
+
+	var status openai.BatchStatusInfo
+	if err := json.Unmarshal(jobs[0].Status, &status); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if status.Status != openai.BatchStatusCancelled {
+		t.Fatalf("status = %s, want %s", status.Status, openai.BatchStatusCancelled)
+	}
+	// handleCancelled was called before executeJob (requestCounts nil) so counts remain zero.
+	if status.RequestCounts.Total != 0 {
+		t.Fatalf("expected zero request_counts for pre-execution cancel, got %+v", status.RequestCounts)
 	}
 }
 
@@ -1148,8 +1301,7 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	err = p.preProcessJob(ctx, jobInfo, &cancelRequested)
+	err = p.preProcessJob(ctx, ctx, context.Background(), jobInfo)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for input with stream: true")
 	}
@@ -1217,8 +1369,7 @@ func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	err = p.preProcessJob(ctx, jobInfo, &cancelRequested)
+	err = p.preProcessJob(ctx, ctx, context.Background(), jobInfo)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for duplicate custom_id")
 	}
@@ -1289,8 +1440,7 @@ func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("expected preProcessJob to succeed with unique custom_ids, got: %v", err)
 	}
 }
@@ -1368,8 +1518,7 @@ func TestPreProcess_UnregisteredModel_RejectedToErrorFile(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1488,8 +1637,7 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1532,10 +1680,9 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 		t.Fatalf("plan files = %d, want 0", planFiles)
 	}
 
-	counts, execErr := p.executeJob(ctx, ctx, ctx, &jobExecutionParams{
-		updater:         NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
-		jobInfo:         jobInfo,
-		cancelRequested: &cancelRequested,
+	counts, execErr := p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+		updater: NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
+		jobInfo: jobInfo,
 	})
 	if execErr != nil {
 		t.Fatalf("executeJob: %v", execErr)
@@ -1625,8 +1772,7 @@ func TestPreProcess_ReEnqueue_TruncatesStaleErrorFile(t *testing.T) {
 		t.Fatalf("WriteFile stale error: %v", err)
 	}
 
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1711,8 +1857,7 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	}
 
 	// Run ingestion — should reject model-b and write to error.jsonl.
-	var cancelRequested atomic.Bool
-	if err := p.preProcessJob(ctx, jobInfo, &cancelRequested); err != nil {
+	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1731,13 +1876,12 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer sloCancel()
 
-	counts, execErr := p.executeJob(ctx, sloCtx, sloCtx, &jobExecutionParams{
-		updater:         NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
-		jobInfo:         jobInfo,
-		cancelRequested: &cancelRequested,
+	counts, execErr := p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+		updater: NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
+		jobInfo: jobInfo,
 	})
-	if !errors.Is(execErr, ErrExpired) {
-		t.Fatalf("expected ErrExpired, got: %v", execErr)
+	if !errors.Is(execErr, errExpired) {
+		t.Fatalf("expected errExpired, got: %v", execErr)
 	}
 	if counts.Failed != 1 {
 		t.Fatalf("Failed = %d, want 1 (model_not_found from ingestion)", counts.Failed)

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -375,6 +375,7 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 
 	userCancelCtx, userCancelFn := context.WithCancel(ctx)
 	requestAbortCtx, requestAbortFn := context.WithCancel(ctx)
+	context.AfterFunc(userCancelCtx, requestAbortFn)
 
 	params := &jobExecutionParams{
 		eventWatcher:   evCh,

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -136,6 +137,33 @@ func (f *failNTimesFilesClient) GetContext(p context.Context, _ time.Duration) (
 }
 func (f *failNTimesFilesClient) Close() error { return nil }
 
+// failOnNthCallClient fails the Nth Store call (1-based). All other calls succeed.
+// Thread-safe for concurrent callers.
+type failOnNthCallClient struct {
+	failN   int32
+	calls   atomic.Int32
+	failErr error
+}
+
+func (f *failOnNthCallClient) Store(_ context.Context, _ string, _ string, _, _ int64, _ io.Reader) (*filesapi.BatchFileMetadata, error) {
+	n := f.calls.Add(1)
+	if n == f.failN {
+		return nil, f.failErr
+	}
+	return &filesapi.BatchFileMetadata{Size: 42}, nil
+}
+func (f *failOnNthCallClient) Retrieve(_ context.Context, _, _ string) (io.ReadCloser, *filesapi.BatchFileMetadata, error) {
+	return nil, nil, nil
+}
+func (f *failOnNthCallClient) List(_ context.Context, _ string) ([]filesapi.BatchFileMetadata, error) {
+	return nil, nil
+}
+func (f *failOnNthCallClient) Delete(_ context.Context, _, _ string) error { return nil }
+func (f *failOnNthCallClient) GetContext(p context.Context, _ time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithCancel(p)
+}
+func (f *failOnNthCallClient) Close() error { return nil }
+
 // ---------------------------------------------------------------------------
 // Mock DB error wrappers
 // ---------------------------------------------------------------------------
@@ -255,6 +283,37 @@ func (s *spyBatchDB) StatusCalls(status openai.BatchStatus) int {
 	defer s.mu.Unlock()
 	return s.calls[status]
 }
+
+// failOnStatusDB wraps a BatchDBClient and injects an error when DBUpdate tries
+// to write a specific status. All other operations pass through.
+type failOnStatusDB struct {
+	inner      db.BatchDBClient
+	failStatus openai.BatchStatus
+	failErr    error
+}
+
+func (f *failOnStatusDB) DBStore(ctx context.Context, item *db.BatchItem) error {
+	return f.inner.DBStore(ctx, item)
+}
+func (f *failOnStatusDB) DBGet(ctx context.Context, query *db.BatchQuery, includeStatic bool, start, limit int) ([]*db.BatchItem, int, bool, error) {
+	return f.inner.DBGet(ctx, query, includeStatic, start, limit)
+}
+func (f *failOnStatusDB) DBUpdate(ctx context.Context, item *db.BatchItem) error {
+	if len(item.Status) > 0 {
+		var st openai.BatchStatusInfo
+		if err := json.Unmarshal(item.Status, &st); err == nil && st.Status == f.failStatus {
+			return f.failErr
+		}
+	}
+	return f.inner.DBUpdate(ctx, item)
+}
+func (f *failOnStatusDB) DBDelete(ctx context.Context, IDs []string) ([]string, error) {
+	return f.inner.DBDelete(ctx, IDs)
+}
+func (f *failOnStatusDB) GetContext(parentCtx context.Context, timeLimit time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parentCtx, timeLimit)
+}
+func (f *failOnStatusDB) Close() error { return f.inner.Close() }
 
 // ---------------------------------------------------------------------------
 // Processor construction helpers

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -311,11 +310,10 @@ func (p *Processor) runPollingLoop(pollingCtx, jobBaseCtx context.Context) error
 
 		p.wg.Add(1)
 		go p.runJob(jobCtx, &jobExecutionParams{
-			updater:         p.updater,
-			jobItem:         jobItem,
-			jobInfo:         jobInfo,
-			task:            task,
-			cancelRequested: &atomic.Bool{},
+			updater: p.updater,
+			jobItem: jobItem,
+			jobInfo: jobInfo,
+			task:    task,
 		})
 	}
 }


### PR DESCRIPTION
## Why is this PR needed?

The existing error handling works correctly in normal operation, but has structural properties that make it harder to maintain and extend safely:

1. **Dual cancellation mechanism**: User cancel propagates via `atomic.Bool` flag polled at checkpoints, while SIGTERM and SLO expiry propagate via context cancellation. Both paths work today, but contributors must remember to poll the flag at every new checkpoint. Missing one silently degrades cancel responsiveness rather than failing visibly.

2. **Finalization under parent context**: `handleCancelled`, `handleExpired`, and `handleFailedWithPartial` run uploads and DB writes under the parent context. If SIGTERM arrives during finalization, these writes can be interrupted, potentially leaving a job in a non-terminal state. This is recoverable via startup recovery, but the window exists.

3. **No failover on cancelled-status DB write**: If `UpdateCancelledStatus` fails (e.g. transient DB error), there is no fallback. The job stays non-terminal with no output file IDs recorded, even if uploads already succeeded.

None of these have caused production incidents today. This PR consolidates the two cancellation mechanisms into a single context hierarchy, uses detached contexts for finalization I/O, and adds DB write failover, reducing the maintenance surface before further work on recovery and dispatcher integration.

## What does this PR do?

Replaces the `atomic.Bool` cancel flag with an explicit context hierarchy and restructures error handling for resilience.

**Context hierarchy** (replaces `cancelRequested *atomic.Bool`):
- `ctx` — cancelled by SIGTERM only
- `sloCtx` — cancelled when SLO deadline fires
- `userCancelCtx` — derived from `context.Background()`; cancelled only on user cancel (isolated from SIGTERM/SLO)
- `requestAbortCtx` — derived from `sloCtx`; cancelled by SLO expiry, SIGTERM (via parent chain), user cancel (`watchCancel` calls `requestAbortFn`), or fatal I/O error (sibling model abort). This is the unified stop signal for all dispatch loops and inference calls.

**Error handling improvements**:
- Unexport sentinel errors; add `errShutdown`, `errRequestInputRead`, `errFinalizeFailedOver` for finer routing via `errors.Is`
- `handleCancelled`/`handleExpired`/`handleFailedWithPartial`: use detached context for uploads and DB writes so SIGTERM cannot interrupt finalization
- `handleCancelled`: failover to `UpdateFailedStatus` when cancelled-status write fails, preserving uploaded file IDs
- Move `cleanupJobArtifacts` after terminal DB write so local files survive for startup recovery on DB failure
- `preprocessor`: replace flag polling with dedicated context checks (`sloCtx.Err()`, `userCancelCtx.Err()`) for cancel/expired/shutdown discrimination

**New test coverage** (21 new test functions):
- Context cancellation: cancel after completion, SIGTERM after completion, cancel+SIGTERM race, SLO expiry during ingestion, sibling abort
- Error routing: `errCancelled`, `errShutdown`, `errExpired` with nil task/nil counts edge cases
- DB write failover: cancelled-write falls back to failed, completed-write falls back to failed, file IDs preserved through failover
- Finalization resilience: SIGTERM during finalization still completes, one upload fails while other survives
- End-to-end: `runJob` reaches preprocess, `runJob` completes full lifecycle, `errFinalizeFailedOver` does not trigger double `handleFailed`

### Suggested review order

1. `errors.go` : new sentinel errors (small, sets the vocabulary)
2. `job_execution.go` : new context fields in params struct (small)
3. `worker.go` : `runJob` call site updated (small)
4. `preprocessor.go` :  cancel flag polling → dedicated context checks
5. `job_runner.go` :  context hierarchy setup + `handleJobError` routing
6. `executor.go` :  dispatch loop context usage + sibling abort
7. `cancel.go` :  `watchCancel` + `handleCancelled` failover
8. `finalizer.go` :  detached context for uploads/DB writes
9. Test files :  verify the above

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Pre-commit checks pass
- [x] Integration/e2e tests verified

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Follow-up planned

- Recovery path (`recovery.go`) error handling refactor — same patterns, separate PR
- Godoc consistency check across updated functions
- Documentation update for error handling design
- Centralize duplicated batch error code messages (#298)

## Related Issues

- Related to #298 — batch error code messages are still duplicated across call sites in `executor.go`; centralizing them is a follow-up.
