### PR TITLE
ci: test integration with both S3 and filesystem storage backends

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -19,9 +19,13 @@ permissions:
 
 jobs:
   integration-tests:
-    name: Integration Tests (Kind)
+    name: Integration Tests (${{ matrix.file_client_type }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        file_client_type: [s3, fs]
     steps:
       - uses: actions/checkout@v6
 
@@ -37,6 +41,8 @@ jobs:
 
       - name: Deploy dev environment
         run: make dev-deploy
+        env:
+          FILE_CLIENT_TYPE: ${{ matrix.file_client_type }}
 
       - name: Run integration tests
         run: make test-e2e


### PR DESCRIPTION
## Why is this PR needed?

The integration test workflow currently runs with only the S3 (MinIO) storage backend. This leaves the filesystem backend untested in CI. Raised in [PR #338 review](https://github.com/llm-d-incubation/batch-gateway/pull/338#discussion_r3060362090).

## What does this PR do?

- Adds a `file_client_type: [s3, fs]` job matrix to `ci-integration-tests.yml`
- Passes `FILE_CLIENT_TYPE` to `make dev-deploy` so each variant deploys with the correct storage backend

A successful run on my fork: https://github.com/yizhaodev/batch-gateway/actions/runs/24793298908

<img width="378" height="261" alt="image" src="https://github.com/user-attachments/assets/17e48133-e15d-4dc1-9773-02210068c3c0" />

## How was this tested?

- [x] Both matrix jobs pass on fork: [workflow run](https://github.com/yizhaodev/batch-gateway/actions/runs/24793298908)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #345