### PR TITLE
chore: enforce CLAUDE.md error handling and safety conventions

### DIFF
--- a/internal/database/redis/redis_db.go
+++ b/internal/database/redis/redis_db.go
@@ -37,7 +37,6 @@ func (c *BatchDBClientRedis) DBStore(ctx context.Context, item *db_api.BatchItem
 		ctx = context.Background()
 	}
 	if err = item.Validate(); err != nil {
-		logr.FromContextOrDiscard(ctx).Error(err, "DBStore[Batch]: item validation failed")
 		return
 	}
 	return c.dbStore(ctx, &item.BaseIndexes, &item.BaseContents,
@@ -50,7 +49,6 @@ func (c *FileDBClientRedis) DBStore(ctx context.Context, item *db_api.FileItem) 
 		ctx = context.Background()
 	}
 	if err = item.Validate(); err != nil {
-		logr.FromContextOrDiscard(ctx).Error(err, "DBStore[File]: item validation failed")
 		return
 	}
 	return c.dbStore(ctx, &item.BaseIndexes, &item.BaseContents,
@@ -68,7 +66,6 @@ func (c *DSClientRedis) dbStore(ctx context.Context,
 
 	ptags, err := packTags(indexes.Tags)
 	if err != nil {
-		logger.Error(err, logPref+": tags packing failed")
 		return err
 	}
 	args := []any{itemType, versionV1, indexes.ID, indexes.TenantID,
@@ -82,12 +79,10 @@ func (c *DSClientRedis) dbStore(ctx context.Context,
 	res, err := redisScriptStore.Run(cctx, c.redisClient,
 		[]string{getKeyForStore(indexes.ID, itemType)}, args...).Text()
 	if err != nil {
-		logger.Error(err, logPref+": script failed")
 		return err
 	}
 	if len(res) > 0 {
 		err = fmt.Errorf("%s", res)
-		logger.Error(err, logPref+": script failed")
 		return
 	}
 
@@ -121,7 +116,6 @@ func (c *BatchDBClientRedis) DBUpdate(ctx context.Context, item *db_api.BatchIte
 		ctx = context.Background()
 	}
 	if err = item.Validate(); err != nil {
-		logr.FromContextOrDiscard(ctx).Error(err, "DBUpdate[Batch]: item validation failed")
 		return
 	}
 	return c.dbUpdate(ctx, &item.BaseIndexes, &item.BaseContents, itemTypeBatch, "DBUpdate[Batch]")
@@ -133,7 +127,6 @@ func (c *FileDBClientRedis) DBUpdate(ctx context.Context, item *db_api.FileItem)
 		ctx = context.Background()
 	}
 	if err = item.Validate(); err != nil {
-		logr.FromContextOrDiscard(ctx).Error(err, "DBUpdate[File]: item validation failed")
 		return
 	}
 	return c.dbUpdate(ctx, &item.BaseIndexes, &item.BaseContents, itemTypeFile, "DBUpdate[File]")
@@ -150,7 +143,6 @@ func (c *DSClientRedis) dbUpdate(ctx context.Context,
 
 	fields, updatedStatus, updatedTags, err := getUpdateFields(contents.Status, indexes.Tags)
 	if err != nil {
-		logger.Error(err, logPref+": getUpdateFields failed")
 		return err
 	}
 	if len(fields) == 0 {
@@ -162,7 +154,6 @@ func (c *DSClientRedis) dbUpdate(ctx context.Context,
 	defer ccancel()
 	err = c.redisClient.HSet(cctx, getKeyForStore(indexes.ID, itemType), fields...).Err()
 	if err != nil {
-		logger.Error(err, logPref+": HSet failed")
 		return
 	}
 
@@ -201,13 +192,11 @@ func (c *DSClientRedis) dBDelete(ctx context.Context, IDs []string, itemType, lo
 		return nil
 	})
 	if err != nil {
-		logger.Error(err, logPref+": Pipelined failed")
 		return
 	}
 	for _, cmd := range cmds {
 		if cmd.Err() != nil && cmd.Err() != goredis.Nil {
 			err = cmd.Err()
-			logger.Error(err, logPref+": Command inside pipeline failed")
 			break
 		}
 	}
@@ -230,7 +219,6 @@ func (c *DSClientRedis) dbGet(
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	logger := logr.FromContextOrDiscard(ctx)
 	includeSpec := strconv.FormatBool(includeStatic)
 
 	if len(IDs) > 0 {
@@ -244,7 +232,6 @@ func (c *DSClientRedis) dbGet(
 		res, err = redisScriptGetByIDs.Run(cctx, c.redisClient,
 			keys, tenantID, includeSpec).Slice()
 		if err != nil {
-			logger.Error(err, logPref+": script failed")
 			return
 		}
 
@@ -253,7 +240,6 @@ func (c *DSClientRedis) dbGet(
 		cond, found := db_api.LogicalCondNames[tagsLogicalCond]
 		if !found {
 			err = fmt.Errorf("invalid logical condition value: %d", tagsLogicalCond)
-			logger.Error(err, logPref+":")
 			return
 		}
 		ctags := convertTags(tagSelectors)
@@ -262,7 +248,6 @@ func (c *DSClientRedis) dbGet(
 		res, err = redisScriptGetByTags.Run(cctx, c.redisClient,
 			ctags, cond, getKeyPatternForStore(itemType), start, limit, tenantID, includeSpec).Slice()
 		if err != nil {
-			logger.Error(err, logPref+": script failed")
 			return
 		}
 
@@ -275,7 +260,6 @@ func (c *DSClientRedis) dbGet(
 			[]string{}, curTimestamp, getKeyPatternForStore(itemType),
 			start, limit, tenantID, includeSpec).Slice()
 		if err != nil {
-			logger.Error(err, logPref+": script failed")
 			return
 		}
 
@@ -287,7 +271,6 @@ func (c *DSClientRedis) dbGet(
 			[]string{}, purpose, getKeyPatternForStore(itemType),
 			start, limit, tenantID, includeSpec).Slice()
 		if err != nil {
-			logger.Error(err, logPref+": script failed")
 			return
 		}
 
@@ -299,7 +282,6 @@ func (c *DSClientRedis) dbGet(
 			[]string{}, tenantID, getKeyPatternForStore(itemType),
 			start, limit, includeSpec).Slice()
 		if err != nil {
-			logger.Error(err, logPref+": script failed")
 			return
 		}
 
@@ -331,7 +313,6 @@ func (c *BatchDBClientRedis) DBGet(
 	if res != nil {
 		cursor, expectMore, items, err = processGetScriptResultBatch(res)
 		if err != nil {
-			logger.Error(err, "DBGet[Batch]: processGetScriptResultBatch failed")
 			return
 		}
 	}
@@ -363,7 +344,6 @@ func (c *FileDBClientRedis) DBGet(
 	if res != nil {
 		cursor, expectMore, items, err = processGetScriptResultFile(res)
 		if err != nil {
-			logger.Error(err, "DBGet[File]: processGetScriptResultFile failed")
 			return
 		}
 	}
@@ -390,8 +370,12 @@ func processGetScriptResultBatch(res []any) (
 		return
 	}
 	items = make([]*db_api.BatchItem, 0, len(resItems))
-	for _, resItem := range resItems {
-		item, err := batchItemFromHget(resItem.([]any))
+	for i, resItem := range resItems {
+		fields, ok := resItem.([]any)
+		if !ok {
+			return 0, false, nil, fmt.Errorf("unexpected item type at index %d: %T", i, resItem)
+		}
+		item, err := batchItemFromHget(fields)
 		if err != nil {
 			return 0, false, nil, err
 		}
@@ -423,8 +407,12 @@ func processGetScriptResultFile(res []any) (
 		return
 	}
 	items = make([]*db_api.FileItem, 0, len(resItems))
-	for _, resItem := range resItems {
-		item, err := fileItemFromHget(resItem.([]any))
+	for i, resItem := range resItems {
+		fields, ok := resItem.([]any)
+		if !ok {
+			return 0, false, nil, fmt.Errorf("unexpected item type at index %d: %T", i, resItem)
+		}
+		item, err := fileItemFromHget(fields)
 		if err != nil {
 			return 0, false, nil, err
 		}

--- a/internal/database/redis/redis_db.go
+++ b/internal/database/redis/redis_db.go
@@ -40,7 +40,7 @@ func (c *BatchDBClientRedis) DBStore(ctx context.Context, item *db_api.BatchItem
 		return
 	}
 	return c.dbStore(ctx, &item.BaseIndexes, &item.BaseContents,
-		itemTypeBatch, "DBStore[Batch]", nil)
+		itemTypeBatch, nil)
 }
 
 func (c *FileDBClientRedis) DBStore(ctx context.Context, item *db_api.FileItem) (err error) {
@@ -52,12 +52,12 @@ func (c *FileDBClientRedis) DBStore(ctx context.Context, item *db_api.FileItem) 
 		return
 	}
 	return c.dbStore(ctx, &item.BaseIndexes, &item.BaseContents,
-		itemTypeFile, "DBStore[File]", []any{item.Purpose})
+		itemTypeFile, []any{item.Purpose})
 }
 
 func (c *DSClientRedis) dbStore(ctx context.Context,
 	indexes *db_api.BaseIndexes, contents *db_api.BaseContents,
-	itemType, logPref string, extraFields []any) (err error) {
+	itemType string, extraFields []any) (err error) {
 
 	if ctx == nil {
 		ctx = context.Background()
@@ -86,7 +86,7 @@ func (c *DSClientRedis) dbStore(ctx context.Context,
 		return
 	}
 
-	logger.Info(logPref + ": succeeded")
+	logger.Info("DBStore: succeeded")
 	return nil
 }
 

--- a/internal/database/redis/redis_ds_client.go
+++ b/internal/database/redis/redis_ds_client.go
@@ -172,7 +172,6 @@ func NewDSClientRedis(ctx context.Context, conf *uredis.RedisClientConfig, opTim
 	logger := logr.FromContextOrDiscard(ctx)
 	if conf == nil {
 		err := fmt.Errorf("empty redis config")
-		logger.Error(err, "NewBatchDSClientRedis:")
 		return nil, err
 	}
 	if opTimeout <= 0 {

--- a/internal/database/redis/redis_event.go
+++ b/internal/database/redis/redis_event.go
@@ -124,12 +124,10 @@ func (c *ExchangeDBClientRedis) ECProducerSendEvents(ctx context.Context, events
 	logger := logr.FromContextOrDiscard(ctx)
 	if len(events) == 0 {
 		err = fmt.Errorf("empty events")
-		logger.Error(err, "ECProducerSendEvents:")
 		return
 	}
 	for _, event := range events {
 		if err = event.IsValid(); err != nil {
-			logger.Error(err, "ECProducerSendEvents: invalid event")
 			return
 		}
 	}
@@ -148,7 +146,6 @@ func (c *ExchangeDBClientRedis) ECProducerSendEvents(ctx context.Context, events
 		return nil
 	})
 	if err != nil {
-		logger.Error(err, "ECProducerSendEvents: Pipelined failed")
 		return
 	}
 	sentIDs = make([]string, 0, len(resMap))

--- a/internal/database/redis/redis_queue.go
+++ b/internal/database/redis/redis_queue.go
@@ -41,11 +41,9 @@ func (c *ExchangeDBClientRedis) PQEnqueue(ctx context.Context, item *db_api.Batc
 	logger := logr.FromContextOrDiscard(ctx)
 	if item == nil {
 		err = fmt.Errorf("empty item")
-		logger.Error(err, "PQEnqueue:")
 		return
 	}
 	if err = item.IsValid(); err != nil {
-		logger.Error(err, "PQEnqueue: item is invalid")
 		return
 	}
 	logger = logger.WithValues("ID", item.ID)
@@ -53,7 +51,6 @@ func (c *ExchangeDBClientRedis) PQEnqueue(ctx context.Context, item *db_api.Batc
 	data, lerr := json.Marshal(item)
 	if lerr != nil {
 		err = lerr
-		logger.Error(err, "PQEnqueue: Marshal failed")
 		return
 	}
 	zitem := goredis.Z{
@@ -71,16 +68,13 @@ func (c *ExchangeDBClientRedis) PQEnqueue(ctx context.Context, item *db_api.Batc
 	})
 	if lerr != nil {
 		err = lerr
-		logger.Error(err, "PQEnqueue:")
 	}
 	if cmdRes == nil {
 		err = fmt.Errorf("redis command result is nil")
-		logger.Error(err, "PQEnqueue:")
 		return
 	}
 	for _, cmd := range cmdRes {
 		if err = cmd.Err(); err != nil {
-			logger.Error(err, "PQEnqueue: redis command failed", "cmd", cmd.Name())
 			return
 		}
 	}
@@ -97,11 +91,9 @@ func (c *ExchangeDBClientRedis) PQDelete(ctx context.Context, item *db_api.Batch
 	logger := logr.FromContextOrDiscard(ctx)
 	if item == nil {
 		err = fmt.Errorf("empty item")
-		logger.Error(err, "PQDelete:")
 		return
 	}
 	if err = item.IsValid(); err != nil {
-		logger.Error(err, "PQDelete: item is invalid")
 		return
 	}
 	logger = logger.WithValues("ID", item.ID)
@@ -112,7 +104,6 @@ func (c *ExchangeDBClientRedis) PQDelete(ctx context.Context, item *db_api.Batch
 	res := c.redisClient.ZRemRangeByScore(cctx, priorityQueueKeyName, score, score)
 	if res == nil {
 		err = fmt.Errorf("redis command result is nil")
-		logger.Error(err, "PQDelete:")
 		return
 	}
 	if res.Err() == goredis.Nil {
@@ -120,7 +111,6 @@ func (c *ExchangeDBClientRedis) PQDelete(ctx context.Context, item *db_api.Batch
 		return
 	}
 	if err = res.Err(); err != nil {
-		logger.Error(err, "PQDelete: redis ZRemRangeByScore failed")
 		return
 	}
 	nDeleted = int(res.Val())
@@ -177,7 +167,12 @@ func (c *ExchangeDBClientRedis) PQDequeue(ctx context.Context, timeout time.Dura
 	jobPriorities = make([]*db_api.BatchJobPriority, 0, len(vals))
 	for _, val := range vals {
 		item := &db_api.BatchJobPriority{}
-		err = json.Unmarshal([]byte(val.Member.(string)), item)
+		member, ok := val.Member.(string)
+		if !ok {
+			err = fmt.Errorf("unexpected member type: %T", val.Member)
+			return
+		}
+		err = json.Unmarshal([]byte(member), item)
 		if err != nil {
 			logger.Error(err, "PQDequeue: Unmarshal failed")
 			return

--- a/internal/database/redis/redis_status.go
+++ b/internal/database/redis/redis_status.go
@@ -36,13 +36,11 @@ func (c *ExchangeDBClientRedis) StatusSet(ctx context.Context, ID string, TTL in
 	logger := logr.FromContextOrDiscard(ctx)
 	if len(ID) == 0 {
 		err = fmt.Errorf("empty ID")
-		logger.Error(err, "StatusSet:")
 		return
 	}
 	logger = logger.WithValues("ID", ID)
 	if len(data) == 0 {
 		err = fmt.Errorf("empty data")
-		logger.Error(err, "StatusSet:")
 		return
 	}
 	if TTL <= 0 {
@@ -54,11 +52,9 @@ func (c *ExchangeDBClientRedis) StatusSet(ctx context.Context, ID string, TTL in
 	res := c.redisClient.Set(cctx, getKeyForStatus(ID), data, time.Duration(TTL)*time.Second)
 	if res == nil {
 		err = fmt.Errorf("nil redis command result")
-		logger.Error(err, "StatusSet:")
 		return
 	}
 	if err = res.Err(); err != nil {
-		logger.Error(err, "StatusSet: redis command error")
 		return
 	}
 
@@ -75,7 +71,6 @@ func (c *ExchangeDBClientRedis) StatusGet(ctx context.Context, ID string) (data 
 	logger := logr.FromContextOrDiscard(ctx)
 	if len(ID) == 0 {
 		err = fmt.Errorf("empty ID")
-		logger.Error(err, "StatusGet:")
 		return
 	}
 	logger = logger.WithValues("ID", ID)
@@ -85,14 +80,12 @@ func (c *ExchangeDBClientRedis) StatusGet(ctx context.Context, ID string) (data 
 	res := c.redisClient.Get(cctx, getKeyForStatus(ID))
 	if res == nil {
 		err = fmt.Errorf("nil redis command result")
-		logger.Error(err, "StatusGet:")
 		return
 	}
 	if res.Err() == goredis.Nil {
 		logger.Info("StatusGet: no status")
 		return
 	} else if err = res.Err(); err != nil {
-		logger.Error(err, "StatusGet: redis command error")
 		return
 	}
 
@@ -110,7 +103,6 @@ func (c *ExchangeDBClientRedis) StatusDelete(ctx context.Context, ID string) (nD
 	logger := logr.FromContextOrDiscard(ctx)
 	if len(ID) == 0 {
 		err = fmt.Errorf("empty ID")
-		logger.Error(err, "StatusDelete:")
 		return
 	}
 	logger = logger.WithValues("ID", ID)
@@ -120,11 +112,9 @@ func (c *ExchangeDBClientRedis) StatusDelete(ctx context.Context, ID string) (nD
 	res := c.redisClient.Del(cctx, getKeyForStatus(ID))
 	if res == nil {
 		err = fmt.Errorf("nil redis command result")
-		logger.Error(err, "StatusDelete:")
 		return
 	}
 	if err = res.Err(); err != nil {
-		logger.Error(err, "StatusDelete: redis command error")
 		return
 	}
 	nDeleted = int(res.Val())

--- a/internal/processor/worker/poller.go
+++ b/internal/processor/worker/poller.go
@@ -49,13 +49,12 @@ func (p *Poller) validate() error {
 }
 
 func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
 	tasks, err := p.pq.PQDequeue(ctx, 0, 1) // get only one job without blocking the queue
 	if err != nil {
-		logger.Error(err, "Failed to dequeue a batch job")
 		return nil, err
 	}
+
+	logger := logr.FromContextOrDiscard(ctx)
 
 	// there's no backlog
 	if len(tasks) == 0 {
@@ -68,32 +67,23 @@ func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
 }
 
 func (p *Poller) enqueueOne(ctx context.Context, task *db.BatchJobPriority) error {
-	logger := logr.FromContextOrDiscard(ctx)
 	if task == nil {
-		err := fmt.Errorf("cannot enqueue nil batch job task")
-		logger.Error(err, "CRITICAL: Failed to enqueue a job")
-		return err
+		return fmt.Errorf("cannot enqueue nil batch job task")
 	}
-	err := p.pq.PQEnqueue(ctx, task)
-	if err != nil {
-		logger.Error(err, "CRITICAL: Failed to enqueue a job")
-		return err
-	}
-	return nil
+	return p.pq.PQEnqueue(ctx, task)
 }
 
 func (p *Poller) fetchJobItemByID(ctx context.Context, jobID string) (*db.BatchItem, error) {
-	logger := logr.FromContextOrDiscard(ctx)
-
 	jobs, _, _, err := p.db.DBGet(ctx,
 		&db.BatchQuery{
 			BaseQuery: db.BaseQuery{IDs: []string{jobID}},
 		},
 		true, 0, 1)
 	if err != nil {
-		logger.Error(err, "Failed to fetch job item from DB")
 		return nil, err
 	}
+
+	logger := logr.FromContextOrDiscard(ctx)
 
 	// (nil, nil) signals "not found" — caller decides how to handle.
 	if len(jobs) == 0 {

--- a/internal/processor/worker/recovery.go
+++ b/internal/processor/worker/recovery.go
@@ -122,7 +122,6 @@ func (p *Processor) recoverJob(ctx context.Context, jobID string) error {
 	// next container restart retries. If the pod is evicted (emptyDir destroyed), this job
 	// becomes an orphan that only an external entity can detect.
 	if err != nil {
-		logger.Error(err, "Startup recovery: DB lookup failed, skipping (will retry on next restart)")
 		metrics.RecordStartupRecovery(string(recoveryUnknownStatus), recoveryActionError)
 		return err
 	}

--- a/internal/processor/worker/status_updater.go
+++ b/internal/processor/worker/status_updater.go
@@ -94,11 +94,8 @@ func (s *StatusUpdater) UpdatePersistentStatus(
 		return fmt.Errorf("dbJob.Status is empty")
 	}
 
-	logger := logr.FromContextOrDiscard(ctx)
-
 	var original openai.BatchStatusInfo
 	if err := json.Unmarshal(dbJob.Status, &original); err != nil {
-		logger.Error(err, "Failed to unmarshal batch status")
 		return err
 	}
 
@@ -106,7 +103,6 @@ func (s *StatusUpdater) UpdatePersistentStatus(
 	// to set additional fields (e.g. file IDs) that aren't part of the standard transition.
 	updated, err := batch_utils.BuildUpdatedStatusInfo(&original, newStatus, counts, slo)
 	if err != nil {
-		logger.Error(err, "Failed to build updated batch status")
 		return err
 	}
 
@@ -116,7 +112,6 @@ func (s *StatusUpdater) UpdatePersistentStatus(
 
 	statusBytes, err := json.Marshal(updated)
 	if err != nil {
-		logger.Error(err, "Failed to marshal updated batch status")
 		return err
 	}
 
@@ -128,9 +123,9 @@ func (s *StatusUpdater) UpdatePersistentStatus(
 			Status: statusBytes,
 		},
 	}); err != nil {
-		logger.Error(err, "Failed to update batch status in DB")
 		return err
 	}
+	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Batch status updated successfully", "newStatus", newStatus)
 	return nil
 }

--- a/internal/util/redis/redis_client.go
+++ b/internal/util/redis/redis_client.go
@@ -66,18 +66,13 @@ func NewRedisClient(ctx context.Context, cnf *RedisClientConfig) (*gredis.Client
 	}
 	logger := logr.FromContextOrDiscard(ctx)
 	if cnf == nil {
-		err = fmt.Errorf("redis config was not provided")
-		logger.Error(err, "NewRedisClient")
-		return nil, err
+		return nil, fmt.Errorf("redis config was not provided")
 	}
 	if cnf.Url == "" {
-		err = fmt.Errorf("redis config has empty url")
-		logger.Error(err, "NewRedisClient")
-		return nil, err
+		return nil, fmt.Errorf("redis config has empty url")
 	}
 	redisOps, err = gredis.ParseURL(cnf.Url)
 	if err != nil {
-		logger.Error(err, "NewRedisClient")
 		return nil, err
 	}
 	if redisOps.ClientName == "" {
@@ -131,7 +126,6 @@ func NewRedisClient(ctx context.Context, cnf *RedisClientConfig) (*gredis.Client
 			caCertFile,
 		)
 		if err != nil {
-			logger.Error(err, "NewRedisClient")
 			return nil, err
 		}
 	}
@@ -140,13 +134,10 @@ func NewRedisClient(ctx context.Context, cnf *RedisClientConfig) (*gredis.Client
 	}
 	rds := gredis.NewClient(redisOps)
 	if rds == nil {
-		err = fmt.Errorf("redis.NewClient returned nil client [addr: %s]", redisOps.Addr)
-		logger.Error(err, "NewRedisClient")
-		return nil, err
+		return nil, fmt.Errorf("redis.NewClient returned nil client [addr: %s]", redisOps.Addr)
 	}
 	if cnf.EnableTracing {
 		if err := redisotel.InstrumentTracing(rds); err != nil {
-			logger.Error(err, "NewRedisClient: failed to instrument Redis tracing")
 			_ = rds.Close()
 			return nil, err
 		}
@@ -155,7 +146,6 @@ func NewRedisClient(ctx context.Context, cnf *RedisClientConfig) (*gredis.Client
 	defer cancel()
 	_, err = rds.Ping(ctx).Result()
 	if err != nil {
-		logger.Error(err, "NewRedisClient")
 		_ = rds.Close()
 		return nil, err
 	}
@@ -167,7 +157,6 @@ func CheckClient(ctx context.Context, rds *gredis.Client, cmdTimeout time.Durati
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	logger := logr.FromContextOrDiscard(ctx)
 	cctx, ccancel := context.WithTimeout(ctx, cmdTimeout)
 	err = rds.Set(cctx, getPingKeyName(keyPrefix, serviceName), "ping", 10*time.Second).Err()
 	ccancel()
@@ -178,19 +167,16 @@ func CheckClient(ctx context.Context, rds *gredis.Client, cmdTimeout time.Durati
 		ccancel()
 		if err == nil {
 			if !strings.Contains(info, "role:slave") {
-				// In this case the client is determined as good.
-				logger.Info("CheckClient: success")
 				return nil
 			} else {
 				err = fmt.Errorf("slave confirmed")
 			}
 		} else {
-			err = fmt.Errorf("info failed: %s", err.Error())
+			err = fmt.Errorf("info failed: %w", err)
 		}
 	} else {
-		err = fmt.Errorf("write failed: %s", err.Error())
+		err = fmt.Errorf("write failed: %w", err)
 	}
-	logger.Error(err, "CheckClient: failed")
 	return
 }
 

--- a/internal/util/tls/tls.go
+++ b/internal/util/tls/tls.go
@@ -50,7 +50,7 @@ func GetTlsConfig(loadType LoadType, insecure bool, certFile string, keyFile str
 	if certFile != "" {
 		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
-			return nil, fmt.Errorf("GetTlsConfig: LoadX509KeyPair failed: %v", err) // pragma: allowlist secret
+			return nil, fmt.Errorf("GetTlsConfig: LoadX509KeyPair failed: %w", err) // pragma: allowlist secret
 		}
 		tlsConf.Certificates = []tls.Certificate{certificate}
 	}
@@ -60,7 +60,7 @@ func GetTlsConfig(loadType LoadType, insecure bool, certFile string, keyFile str
 	} else if caCertFile != "" {
 		ca, err := os.ReadFile(caCertFile)
 		if err != nil {
-			return nil, fmt.Errorf("GetTlsConfig: Could not read CA certificate file: %v", err) // pragma: allowlist secret
+			return nil, fmt.Errorf("GetTlsConfig: Could not read CA certificate file: %w", err) // pragma: allowlist secret
 		}
 		certPool := x509.NewCertPool()
 		if ok := certPool.AppendCertsFromPEM(ca); !ok {

--- a/pkg/clients/http/http_client.go
+++ b/pkg/clients/http/http_client.go
@@ -111,7 +111,11 @@ func NewHTTPClient(config Config, logger logr.Logger) (*HTTPClient, error) {
 
 	// Configure transport - start with Go's secure defaults (http.DefaultTransport)
 	// This gives us: TLS 1.2+, system root CAs, certificate verification, proper timeouts
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unexpected default transport type: %T", http.DefaultTransport)
+	}
+	transport := defaultTransport.Clone()
 
 	// Override only the settings we need to customize for batch processing
 	transport.MaxIdleConns = config.MaxIdleConns


### PR DESCRIPTION
## Why is this PR needed?

#365 added `CLAUDE.md` with coding conventions. This PR addresses #366 by auditing the codebase against those conventions and fixing all violations found.

## What does this PR do?

Enforces three CLAUDE.md rules across 11 files:

### 1. Handle errors once — return OR log, never both

Removes `logger.Error` calls from synchronous helper functions that return the error to their caller. Every removed log was verified to have a caller that already logs at the appropriate boundary:

### 2. Use `%w` not `%v` for wrapping errors

Fixes instances where `%v` or `%s` broke the error chain, preventing
callers from using `errors.Is` / `errors.As`:

### 3. Always use comma-ok form for type assertions

Converts four bare type assertions to comma-ok form to prevent panics on
unexpected data

### What was intentionally left unchanged

- **`cmd/*/main.go`**: top-level entrypoints are the final error consumer. log + exit is correct.
- **`recovery.go` fallback chains**: intermediate logging records the primary failure before fallback; if `recoverWithFailed` succeeds it returns `nil`, making the intermediate log the only record.
- **Background goroutines** (`redis_event.go` listener, `redis_queue.go`, `PQDequeue`): no caller to return errors to. logging is the only option.

## How was this tested?

- [x] Unit tests pass (`make test`)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Manual check: Verified every removed log has a caller that logs the error

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #366