### PR TITLE
refactor: extract common LastHeaderValue helper

### DIFF
--- a/internal/apiserver/batch/batch_handler.go
+++ b/internal/apiserver/batch/batch_handler.go
@@ -198,18 +198,8 @@ func (c *BatchAPIHandler) CreateBatch(w http.ResponseWriter, r *http.Request) {
 
 	// Capture configured pass-through headers into tags with "pth:" prefix
 	for _, headerName := range c.config.BatchAPI.PassThroughHeaders {
-		// The external auth service (via Envoy ext_authz) may append
-		// request headers as separate entries instead of overwriting them. If a client
-		// sends a spoofed pass-through header, the auth service appends the real value as a
-		// second entry. We take the last entry from r.Header.Values() because Envoy's
-		// ext_authz pipeline guarantees auth-injected entries come after client-supplied
-		// ones.
-		if values := r.Header.Values(headerName); len(values) > 0 {
-			// Skip empty last values to avoid persisting blank tags (e.g. when the
-			// auth service clears a spoofed header by appending an empty entry).
-			if last := values[len(values)-1]; last != "" {
-				tags[batch_types.TagPrefixPassThroughHeader+headerName] = last
-			}
+		if v := common.LastHeaderValue(r, headerName, ""); v != "" {
+			tags[batch_types.TagPrefixPassThroughHeader+headerName] = v
 		}
 	}
 

--- a/internal/apiserver/common/rest.go
+++ b/internal/apiserver/common/rest.go
@@ -126,3 +126,15 @@ func GetTenantIDFromContext(ctx context.Context) string {
 	}
 	return DefaultTenantID
 }
+
+// LastHeaderValue returns the last value of the named header, or defaultVal
+// if the header is absent or empty. Taking the last entry is intentional:
+// Envoy ext_authz appends auth-injected values after client-supplied ones.
+func LastHeaderValue(r *http.Request, header, defaultVal string) string {
+	if vals := r.Header.Values(header); len(vals) > 0 {
+		if v := vals[len(vals)-1]; v != "" {
+			return v
+		}
+	}
+	return defaultVal
+}

--- a/internal/apiserver/middleware/request_middleware.go
+++ b/internal/apiserver/middleware/request_middleware.go
@@ -59,20 +59,7 @@ func NewRequestMiddleware(config *common.ServerConfig) common.RouteMiddleware {
 			w.Header().Set(RequestIdHeaderKey, requestID)
 
 			// Extract tenant ID from header.
-			// The external auth service (via Envoy ext_authz) may append
-			// request headers as separate entries instead of overwriting them. If a client
-			// sends a spoofed tenant header, the auth service appends the real value as a
-			// second entry. We take the last entry from r.Header.Values() because Envoy's
-			// ext_authz pipeline guarantees auth-injected entries come after client-supplied
-			// ones.
-			tenantHeader := config.GetTenantHeader()
-			tenantID := common.DefaultTenantID
-			if tenants := r.Header.Values(tenantHeader); len(tenants) > 0 {
-				tenantID = tenants[len(tenants)-1]
-			}
-			if tenantID == "" {
-				tenantID = common.DefaultTenantID
-			}
+			tenantID := common.LastHeaderValue(r, config.GetTenantHeader(), common.DefaultTenantID)
 
 			// Extract file ID and batch ID from path values for logging
 			fileID := r.PathValue(common.PathParamFileID)


### PR DESCRIPTION
## Why is this PR needed?

The "take last header value" pattern (needed because Envoy ext_authz appends auth-injected values after client-supplied ones) was duplicated in `batch_handler.go` and `request_middleware.go` with identical logic and lengthy comments.

## What does this PR do?

Extracts a shared `LastHeaderValue(r, header, defaultVal)` helper into `common/rest.go`

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)