### PR TITLE
fix: override image repository in dev-deploy helm args

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -843,8 +843,10 @@ install_batch_gateway() {
     local vllm_sim_b_url="http://${VLLM_SIM_B_NAME}.${NAMESPACE}.svc.cluster.local:8000"
 
     local helm_args=(
+        --set "apiserver.image.repository=${APISERVER_IMG%:*}"
         --set apiserver.image.pullPolicy=IfNotPresent
         --set "apiserver.image.tag=${IMAGE_TAG}"
+        --set "processor.image.repository=${PROCESSOR_IMG%:*}"
         --set processor.image.pullPolicy=IfNotPresent
         --set "processor.image.tag=${IMAGE_TAG}"
         --set "global.fileClient.type=${FILE_CLIENT_TYPE}"
@@ -873,6 +875,7 @@ install_batch_gateway() {
         --set "processor.config.enablePprof=true"
         --set "processor.resources.requests.memory=256Mi"
         --set "gc.enabled=true"
+        --set "gc.image.repository=${GC_IMG%:*}"
         --set "gc.image.pullPolicy=IfNotPresent"
         --set "gc.image.tag=${IMAGE_TAG}"
         --set "gc.config.interval=5s"


### PR DESCRIPTION
## Why is this PR needed?

Fixes integration test failures on [opendatahub-io/batch-gateway](https://github.com/opendatahub-io/batch-gateway/actions/runs/25119721986) introduced by [9ca46ecb](https://github.com/opendatahub-io/batch-gateway/commit/9ca46ecba9546d6e93eaaa6ab3ec790e77ce7656).

That commit changed `values.yaml` default image repositories from `ghcr.io/llm-d-incubation/...` to `quay.io/opendatahub/...`. 

However, `dev-deploy.sh` only overrides `image.tag` via `--set` — not `image.repository`. As a result, helm deploys pods referencing `quay.io/...` images that were never loaded into kind (the locally built images use `ghcr.io/...`), causing the apiserver deployment to time out.

## What does this PR do?

Adds `--set "*.image.repository=..."` overrides for apiserver, processor, and gc in the helm args, derived from the `*_IMG` variables already used to build and load images. 

This ensures the helm chart always uses the same image references that were loaded into kind, regardless of `values.yaml` defaults.

## How was this tested?

- [x] Manual testing performed

## Checklist

- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)