### PR TITLE
feat: send x-gateway-inference-fairness-id header for per-tenant fairness

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -94,6 +94,9 @@ data:
       {{- end }}
     {{- end }}
 
+    {{- if .Values.processor.config.sendFairnessHeader }}
+    send_fairness_header: true
+    {{- end }}
     default_output_expiration_seconds: {{ .Values.processor.config.defaultOutputExpirationSeconds }}
     progress_ttl_seconds: {{ .Values.processor.config.progressTTLSeconds }}
 

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -333,6 +333,20 @@ tests:
           path: data["config.yaml"]
           pattern: 'global_inference_gateway:[\s\S]*inference_objective:'
 
+  - it: should not render send_fairness_header when false (default)
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'send_fairness_header:'
+
+  - it: should render send_fairness_header when enabled
+    set:
+      processor.config.sendFairnessHeader: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'send_fairness_header: true'
+
   - it: should not render ConfigMap when processor is disabled
     set:
       processor.enabled: false

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -366,6 +366,9 @@ processor:
     #     maxRetries: 1
     defaultOutputExpirationSeconds: 7776000  # 90 days
     progressTTLSeconds: 86400  # 24 hours
+    # Whether to send x-gateway-inference-fairness-id on inference requests.
+    # false (default) omits the header entirely.
+    sendFairnessHeader: false
     # Enable pprof profiling endpoints on the observability server (/debug/pprof/)
     enablePprof: false
 

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -79,3 +79,7 @@ default_output_expiration_seconds: 7776000  # 90 days
 
 # TTL for temporary progress updates in the status store (Redis), in seconds.
 progress_ttl_seconds: 86400  # 24 hours
+
+# Whether to send x-gateway-inference-fairness-id on inference requests.
+# false (default) omits the fairness header entirely.
+send_fairness_header: false

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -100,6 +100,11 @@ type ProcessorConfig struct {
 	// Each recovery can involve DB lookups, S3 uploads, and status updates.
 	RecoveryMaxConcurrency int `yaml:"recovery_max_concurrency"`
 
+	// SendFairnessHeader controls whether the processor sends
+	// x-gateway-inference-fairness-id on inference requests.
+	// false (default) omits the fairness header.
+	SendFairnessHeader bool `yaml:"send_fairness_header"`
+
 	// EnablePprof enables pprof profiling endpoints on the observability server.
 	EnablePprof bool `yaml:"enable_pprof"`
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -86,6 +86,9 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if c.GlobalInferenceGateway != nil {
 		t.Fatalf("GlobalInferenceGateway should be nil by default")
 	}
+	if c.SendFairnessHeader {
+		t.Fatalf("SendFairnessHeader = true, want false by default")
+	}
 
 	want90Days := int64(90 * 24 * 60 * 60)
 	if c.DefaultOutputExpirationSeconds != want90Days {
@@ -433,6 +436,7 @@ model_gateways:
     tls_insecure_skip_verify: true
 default_output_expiration_seconds: 86400
 progress_ttl_seconds: 3600
+send_fairness_header: true
 `)
 
 	if err := os.WriteFile(path, yamlData, 0o600); err != nil {
@@ -494,6 +498,9 @@ progress_ttl_seconds: 3600
 	}
 	if c.ProgressTTLSeconds != 3600 {
 		t.Fatalf("ProgressTTLSeconds = %d, want %d", c.ProgressTTLSeconds, 3600)
+	}
+	if !c.SendFairnessHeader {
+		t.Fatalf("SendFairnessHeader = false, want true")
 	}
 }
 

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -267,6 +267,8 @@ func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx conte
 	// from sloCtx (derived from context.Background), so SLO expiry and SIGTERM do
 	// not set it. processModel's drain phase checks sloCtx.Err() vs
 	// userCancelCtx.Err() to choose the right error code (errExpired vs errCancelled).
+	tenantID := params.jobInfo.TenantID
+
 	for safeModelID, modelID := range modelMap.SafeToModel {
 		// Ordering guarantee: processModel returns → requestAbortFn → errCh send.
 		// This ensures the first real error reaches errCh before any context.Canceled
@@ -282,6 +284,7 @@ func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx conte
 				writers,
 				progress,
 				passThroughHeaders,
+				tenantID,
 			)
 			// Abort all sibling models when any model hits a fatal I/O error
 			// (e.g. output file write failure). modelErr is only set for local
@@ -387,6 +390,7 @@ func (p *Processor) processModel(
 	writers *outputWriters,
 	progress *executionProgress,
 	passThroughHeaders map[string]string,
+	tenantID string,
 ) error {
 	logger := logr.FromContextOrDiscard(requestAbortCtx).WithValues("model", modelID)
 	requestAbortCtx = logr.NewContext(requestAbortCtx, logger)
@@ -436,7 +440,7 @@ dispatch:
 			defer modelSem.Release()
 			defer p.globalSem.Release()
 
-			result, execErr := p.executeOneRequest(requestAbortCtx, sloCtx, inputFile, entry, modelID, passThroughHeaders)
+			result, execErr := p.executeOneRequest(requestAbortCtx, sloCtx, inputFile, entry, modelID, passThroughHeaders, tenantID)
 			if execErr != nil {
 				// Fatal read failure: the input file is unreadable at this offset
 				// (e.g. disk corruption). We do not know the CustomID, so we cannot
@@ -621,17 +625,21 @@ func (p *Processor) drainUnprocessedRequests(
 const (
 	sloTTFTMSHeader          = "x-slo-ttft-ms"
 	inferenceObjectiveHeader = "x-gateway-inference-objective"
+	fairnessIDHeader         = "x-gateway-inference-fairness-id"
 )
 
 // mergeInferenceHeaders adds processor-managed headers to the outgoing inference request:
 //   - x-slo-ttft-ms: remaining milliseconds until the SLO deadline (>= 0).
 //   - x-gateway-inference-objective: name of the InferenceObjective CRD that
 //     determines the priority band for this request.
+//   - x-gateway-inference-fairness-id: tenant identifier for per-tenant fairness
+//     within a priority band.
 //
 // Headers are only added when the relevant value is available/configured.
 // If sloCtx has no deadline, is cancelled, or has an expired deadline, the SLO
 // header is not set. If inferenceObjective is empty, the objective header is not set.
-func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, inferenceObjective string) map[string]string {
+// If fairnessID is empty, the fairness header is not set.
+func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, inferenceObjective, fairnessID string) map[string]string {
 	hasSLO := false
 	var sloMs int64
 	if sloCtx.Err() == nil {
@@ -644,8 +652,9 @@ func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, in
 		}
 	}
 	hasObjective := inferenceObjective != ""
+	hasFairness := fairnessID != ""
 
-	if !hasSLO && !hasObjective {
+	if !hasSLO && !hasObjective && !hasFairness {
 		return headers
 	}
 	if headers == nil {
@@ -656,6 +665,9 @@ func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, in
 	}
 	if hasObjective {
 		headers[inferenceObjectiveHeader] = inferenceObjective
+	}
+	if hasFairness {
+		headers[fairnessIDHeader] = fairnessID
 	}
 	return headers
 }
@@ -669,6 +681,7 @@ func (p *Processor) executeOneRequest(
 	entry planEntry,
 	modelID string,
 	passThroughHeaders map[string]string,
+	tenantID string,
 ) (*outputLine, error) {
 	// read the request line from input.jsonl at the given offset and length
 	buf := make([]byte, entry.Length)
@@ -719,7 +732,7 @@ func (p *Processor) executeOneRequest(
 	}
 
 	headers := maps.Clone(passThroughHeaders)
-	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID))
+	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID), tenantID)
 
 	inferReq := &inference.GenerateRequest{
 		RequestID: newBatchRequestID(requestID),

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -638,7 +638,8 @@ const (
 // Headers are only added when the relevant value is available/configured.
 // If sloCtx has no deadline, is cancelled, or has an expired deadline, the SLO
 // header is not set. If inferenceObjective is empty, the objective header is not set.
-// If fairnessID is empty, the fairness header is not set.
+// If fairnessID is non-empty, the fairness header is only set when the outgoing
+// headers do not already include x-gateway-inference-fairness-id.
 func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, inferenceObjective, fairnessID string) map[string]string {
 	hasSLO := false
 	var sloMs int64
@@ -653,6 +654,11 @@ func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, in
 	}
 	hasObjective := inferenceObjective != ""
 	hasFairness := fairnessID != ""
+	if hasFairness && headers != nil {
+		if _, exists := headers[fairnessIDHeader]; exists {
+			hasFairness = false
+		}
+	}
 
 	if !hasSLO && !hasObjective && !hasFairness {
 		return headers

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -638,8 +638,12 @@ const (
 // Headers are only added when the relevant value is available/configured.
 // If sloCtx has no deadline, is cancelled, or has an expired deadline, the SLO
 // header is not set. If inferenceObjective is empty, the objective header is not set.
-// If fairnessID is non-empty, the fairness header is only set when the outgoing
-// headers do not already include x-gateway-inference-fairness-id.
+// If fairnessID is non-empty, the fairness header is set only when the outgoing
+// headers do not already include x-gateway-inference-fairness-id. Unlike SLO and
+// objective (which are processor-authoritative and always override), fairness is
+// user-overridable: callers can supply a custom flow key (e.g. API key, group ID)
+// via pass-through headers, and the processor falls back to tenantID only when no
+// override is present.
 func mergeInferenceHeaders(headers map[string]string, sloCtx context.Context, inferenceObjective, fairnessID string) map[string]string {
 	hasSLO := false
 	var sloMs int64

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -737,8 +737,13 @@ func (p *Processor) executeOneRequest(
 		return result, nil
 	}
 
+	fairnessID := ""
+	if p.cfg.SendFairnessHeader {
+		fairnessID = tenantID
+	}
+
 	headers := maps.Clone(passThroughHeaders)
-	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID), tenantID)
+	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID), fairnessID)
 
 	inferReq := &inference.GenerateRequest{
 		RequestID: newBatchRequestID(requestID),

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -3124,7 +3124,7 @@ func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
 			sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(5*time.Second))
 			defer sloCancel()
 
-			_, err = env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], tt.modelID, nil)
+			_, err = env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], tt.modelID, nil, jobInfo.TenantID)
 			if err != nil {
 				t.Fatalf("executeOneRequest error: %v", err)
 			}

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -72,7 +72,7 @@ func TestExecuteOneRequest_Success(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest error: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestExecuteOneRequest_NonHTTPError(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest should not return error for inference failure, got: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestExecuteOneRequest_NilInferenceClient(t *testing.T) {
 
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := p.executeOneRequest(ctx, sloCtx, inputFile, allEntries[0], "m1", nil)
+	result, err := p.executeOneRequest(ctx, sloCtx, inputFile, allEntries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestExecuteOneRequest_HTTPError(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestExecuteOneRequest_HTTPErrorEmptyBody(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -358,7 +358,7 @@ func TestExecuteOneRequest_HTTPErrorNonJSONBody(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -403,7 +403,7 @@ func TestExecuteOneRequest_NilResponse(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest should not return error, got: %v", err)
 	}
@@ -443,7 +443,7 @@ func TestExecuteOneRequest_BadJSONResponse(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest should not return error, got: %v", err)
 	}
@@ -472,7 +472,7 @@ func TestExecuteOneRequest_BadOffset(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
 	defer sloCancel()
-	_, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, badEntry, "m1", nil)
+	_, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, badEntry, "m1", nil, "")
 	if err == nil {
 		t.Fatalf("expected error for bad offset")
 	}
@@ -503,7 +503,7 @@ func TestExecuteOneRequest_SLOExpiredBeforeExecution(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest error: %v", err)
 	}
@@ -543,7 +543,7 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	ctx := testLoggerCtx(t)
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(10*time.Nanosecond))
 	defer sloCancel()
-	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil)
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
 	if err != nil {
 		t.Fatalf("executeOneRequest error: %v", err)
 	}
@@ -600,7 +600,7 @@ func TestProcessModel_Success(t *testing.T) {
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	if err != nil {
 		t.Fatalf("processModel error: %v", err)
 	}
@@ -662,7 +662,7 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(baseCtx)
 	cancel()
 
-	err := env.p.processModel(ctx, baseCtx, context.Background(), ctx, inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	err := env.p.processModel(ctx, baseCtx, context.Background(), ctx, inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	if !errors.Is(err, errCancelled) {
 		t.Fatalf("expected errCancelled, got: %v", err)
 	}
@@ -727,7 +727,7 @@ func TestProcessModel_CancelWritesInFlightToErrorFile(t *testing.T) {
 	}
 
 	ctx := testLoggerCtx(t)
-	modelErr := env.p.processModel(ctx, ctx, ctx, userCancelCtx, inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	modelErr := env.p.processModel(ctx, ctx, ctx, userCancelCtx, inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	if !errors.Is(modelErr, errCancelled) {
 		t.Fatalf("expected errCancelled from processModel, got: %v", modelErr)
 	}
@@ -809,7 +809,7 @@ func TestProcessModel_InferenceFatalError(t *testing.T) {
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	err := env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	if err == nil {
 		t.Fatalf("expected error from closed input file")
 	}
@@ -859,7 +859,7 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
+		done <- env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	}()
 
 	<-started
@@ -910,7 +910,7 @@ func TestProcessModel_SiblingAbort_ReturnsNil(t *testing.T) {
 	requestAbortCtx, requestAbortFn := context.WithCancel(mainCtx)
 	requestAbortFn() // simulate sibling model calling requestAbortFn
 
-	err := env.p.processModel(requestAbortCtx, mainCtx, mainCtx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil)
+	err := env.p.processModel(requestAbortCtx, mainCtx, mainCtx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	// requestAbortCtx cancelled, but no SLO / user-cancel / SIGTERM → nil, not errShutdown
 	if err != nil {
 		t.Fatalf("expected nil when only requestAbortCtx is cancelled (sibling abort), got: %v", err)
@@ -2790,11 +2790,11 @@ func TestJsonNumericToFloat64(t *testing.T) {
 
 func TestMergeInferenceHeaders(t *testing.T) {
 	t.Run("no deadline no objective leaves headers unchanged", func(t *testing.T) {
-		if got := mergeInferenceHeaders(nil, context.Background(), ""); got != nil {
+		if got := mergeInferenceHeaders(nil, context.Background(), "", ""); got != nil {
 			t.Fatalf("nil headers: got %v, want nil", got)
 		}
 		in := map[string]string{"a": "b"}
-		got := mergeInferenceHeaders(in, context.Background(), "")
+		got := mergeInferenceHeaders(in, context.Background(), "", "")
 		if len(got) != 1 {
 			t.Fatalf("expected no new keys, got len=%d %#v", len(got), got)
 		}
@@ -2810,7 +2810,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 		want := 5*time.Second + 123*time.Millisecond
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(want))
 		defer cancel()
-		h := mergeInferenceHeaders(nil, ctx, "")
+		h := mergeInferenceHeaders(nil, ctx, "", "")
 		got, err := strconv.ParseInt(h[sloTTFTMSHeader], 10, 64)
 		if err != nil {
 			t.Fatalf("parse header: %v", err)
@@ -2826,11 +2826,11 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	t.Run("deadline in the past leaves headers unchanged", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		if got := mergeInferenceHeaders(nil, ctx, ""); got != nil {
+		if got := mergeInferenceHeaders(nil, ctx, "", ""); got != nil {
 			t.Fatalf("nil headers: got %v, want nil (expired deadline => no merge)", got)
 		}
 		in := map[string]string{"a": "b"}
-		got := mergeInferenceHeaders(in, ctx, "")
+		got := mergeInferenceHeaders(in, ctx, "", "")
 		if len(got) != 1 {
 			t.Fatalf("expected no new keys, got len=%d %#v", len(got), got)
 		}
@@ -2845,7 +2845,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	t.Run("preserves existing headers", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
 		defer cancel()
-		h := mergeInferenceHeaders(map[string]string{"a": "b"}, ctx, "")
+		h := mergeInferenceHeaders(map[string]string{"a": "b"}, ctx, "", "")
 		if h["a"] != "b" {
 			t.Fatal("lost existing header")
 		}
@@ -2860,7 +2860,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(want))
 		defer cancel()
 		in := map[string]string{}
-		h := mergeInferenceHeaders(in, ctx, "")
+		h := mergeInferenceHeaders(in, ctx, "", "")
 		got, err := strconv.ParseInt(in[sloTTFTMSHeader], 10, 64)
 		if err != nil {
 			t.Fatalf("parse: %v", err)
@@ -2877,7 +2877,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	})
 
 	t.Run("objective header sent when configured", func(t *testing.T) {
-		h := mergeInferenceHeaders(nil, context.Background(), "batch-low-priority")
+		h := mergeInferenceHeaders(nil, context.Background(), "batch-low-priority", "")
 		if h[inferenceObjectiveHeader] != "batch-low-priority" {
 			t.Fatalf("got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")
 		}
@@ -2887,7 +2887,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	})
 
 	t.Run("objective header not sent when empty", func(t *testing.T) {
-		h := mergeInferenceHeaders(map[string]string{"a": "b"}, context.Background(), "")
+		h := mergeInferenceHeaders(map[string]string{"a": "b"}, context.Background(), "", "")
 		if _, ok := h[inferenceObjectiveHeader]; ok {
 			t.Fatal("objective header should not be set when empty")
 		}
@@ -2896,7 +2896,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	t.Run("both SLO and objective headers", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 		defer cancel()
-		h := mergeInferenceHeaders(nil, ctx, "batch-low-priority")
+		h := mergeInferenceHeaders(nil, ctx, "batch-low-priority", "")
 		if _, ok := h[sloTTFTMSHeader]; !ok {
 			t.Fatal("SLO header missing")
 		}
@@ -2908,12 +2908,72 @@ func TestMergeInferenceHeaders(t *testing.T) {
 	t.Run("objective only with expired deadline", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 		defer cancel()
-		h := mergeInferenceHeaders(nil, ctx, "batch-low-priority")
+		h := mergeInferenceHeaders(nil, ctx, "batch-low-priority", "")
 		if _, ok := h[sloTTFTMSHeader]; ok {
 			t.Fatal("SLO header should not be set with expired deadline")
 		}
 		if h[inferenceObjectiveHeader] != "batch-low-priority" {
 			t.Fatalf("objective header: got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")
+		}
+	})
+
+	t.Run("fairness header sent when tenantID is non-empty", func(t *testing.T) {
+		h := mergeInferenceHeaders(nil, context.Background(), "", "tenant-abc")
+		if h[fairnessIDHeader] != "tenant-abc" {
+			t.Fatalf("fairness header: got %q, want %q", h[fairnessIDHeader], "tenant-abc")
+		}
+	})
+
+	t.Run("fairness header not sent when tenantID is empty", func(t *testing.T) {
+		h := mergeInferenceHeaders(map[string]string{"a": "b"}, context.Background(), "", "")
+		if _, ok := h[fairnessIDHeader]; ok {
+			t.Fatal("fairness header should not be set when tenantID is empty")
+		}
+	})
+
+	t.Run("all three headers together", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+		defer cancel()
+		h := mergeInferenceHeaders(nil, ctx, "batch-low-priority", "tenant-xyz")
+		if _, ok := h[sloTTFTMSHeader]; !ok {
+			t.Fatal("SLO header missing")
+		}
+		if h[inferenceObjectiveHeader] != "batch-low-priority" {
+			t.Fatalf("objective header: got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")
+		}
+		if h[fairnessIDHeader] != "tenant-xyz" {
+			t.Fatalf("fairness header: got %q, want %q", h[fairnessIDHeader], "tenant-xyz")
+		}
+	})
+
+	t.Run("fairness header with default tenant", func(t *testing.T) {
+		h := mergeInferenceHeaders(nil, context.Background(), "", "default")
+		if h[fairnessIDHeader] != "default" {
+			t.Fatalf("fairness header: got %q, want %q", h[fairnessIDHeader], "default")
+		}
+	})
+
+	t.Run("processor-managed headers override pass-through conflicts", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+		defer cancel()
+		passThrough := map[string]string{
+			fairnessIDHeader:         "stale-value",
+			inferenceObjectiveHeader: "stale-objective",
+			sloTTFTMSHeader:          "9999",
+			"x-custom":               "keep-me",
+		}
+		h := mergeInferenceHeaders(passThrough, ctx, "batch-low-priority", "real-tenant")
+		if h[fairnessIDHeader] != "real-tenant" {
+			t.Fatalf("fairness header: got %q, want processor-managed value %q", h[fairnessIDHeader], "real-tenant")
+		}
+		if h[inferenceObjectiveHeader] != "batch-low-priority" {
+			t.Fatalf("objective header: got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")
+		}
+		if h[sloTTFTMSHeader] == "9999" {
+			t.Fatal("SLO header should be overwritten by processor-managed value")
+		}
+		if h["x-custom"] != "keep-me" {
+			t.Fatal("non-conflicting pass-through header was lost")
 		}
 	})
 }

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2953,7 +2953,7 @@ func TestMergeInferenceHeaders(t *testing.T) {
 		}
 	})
 
-	t.Run("processor-managed headers override pass-through conflicts", func(t *testing.T) {
+	t.Run("fairness header honors pass-through value when present", func(t *testing.T) {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
 		defer cancel()
 		passThrough := map[string]string{
@@ -2963,8 +2963,8 @@ func TestMergeInferenceHeaders(t *testing.T) {
 			"x-custom":               "keep-me",
 		}
 		h := mergeInferenceHeaders(passThrough, ctx, "batch-low-priority", "real-tenant")
-		if h[fairnessIDHeader] != "real-tenant" {
-			t.Fatalf("fairness header: got %q, want processor-managed value %q", h[fairnessIDHeader], "real-tenant")
+		if h[fairnessIDHeader] != "stale-value" {
+			t.Fatalf("fairness header: got %q, want pass-through value %q", h[fairnessIDHeader], "stale-value")
 		}
 		if h[inferenceObjectiveHeader] != "batch-low-priority" {
 			t.Fatalf("objective header: got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -558,6 +558,74 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	}
 }
 
+func TestExecuteOneRequest_FairnessHeader(t *testing.T) {
+	requests := []batch_types.Request{
+		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+
+	t.Run("sent when SendFairnessHeader=true and tenantID non-empty", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.WorkDir = t.TempDir()
+		cfg.SendFairnessHeader = true
+
+		var gotHeaders map[string]string
+		mock := &mockInferenceClient{
+			generateFn: func(_ context.Context, req *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+				gotHeaders = req.Headers
+				return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+			},
+		}
+
+		env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+		inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+		inputFile, _ := os.Open(inputPath)
+		defer inputFile.Close()
+		jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+		entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+		ctx := testLoggerCtx(t)
+		sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second))
+		defer cancel()
+		if _, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "tenant-x"); err != nil {
+			t.Fatalf("executeOneRequest error: %v", err)
+		}
+		if gotHeaders[fairnessIDHeader] != "tenant-x" {
+			t.Fatalf("fairness header: got %q, want %q", gotHeaders[fairnessIDHeader], "tenant-x")
+		}
+	})
+
+	t.Run("not sent when SendFairnessHeader=false", func(t *testing.T) {
+		cfg := config.NewConfig()
+		cfg.WorkDir = t.TempDir()
+		cfg.SendFairnessHeader = false
+
+		var gotHeaders map[string]string
+		mock := &mockInferenceClient{
+			generateFn: func(_ context.Context, req *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+				gotHeaders = req.Headers
+				return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
+			},
+		}
+
+		env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+		inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+		inputFile, _ := os.Open(inputPath)
+		defer inputFile.Close()
+		jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+		entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+		ctx := testLoggerCtx(t)
+		sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second))
+		defer cancel()
+		if _, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "tenant-x"); err != nil {
+			t.Fatalf("executeOneRequest error: %v", err)
+		}
+		if _, ok := gotHeaders[fairnessIDHeader]; ok {
+			t.Fatalf("fairness header should not be set when SendFairnessHeader=false, got %q", gotHeaders[fairnessIDHeader])
+		}
+	})
+}
+
 // =====================================================================
 // Tests: processModel
 // =====================================================================


### PR DESCRIPTION
## Why is this PR needed?

The processor doesn't currently send the `x-gateway-inference-fairness-id` header — all batch requests share GIE's default flow (`"default-flow"`). For multi-tenant batch platforms using `round-robin` fairness in the batch priority band, the processor should send this header with the tenant identifier from each job, enabling GIE to enforce per-tenant fair scheduling within the batch band.

## What does this PR do?

Threads `jobInfo.TenantID` through the execution path (`executeJob` → `processModel` → `executeOneRequest` → `mergeInferenceHeaders`) and sets the `x-gateway-inference-fairness-id` header when the tenant ID is non-empty.

- Adds `fairnessIDHeader` constant and extends `mergeInferenceHeaders` with a `fairnessID` parameter.
- No config change required — the header is automatically sent when `TenantID` is present on the job (which is always the case for jobs created through the API, since middleware defaults to `"default"`).
- Header is omitted for empty tenant ID

## How was this tested?

- [x] Unit tests added/updated/verified
  - Fairness header present when tenantID is non-empty
  - Fairness header absent when tenantID is empty
  - All three processor-managed headers set simultaneously
  - Processor-managed headers override conflicting pass-through headers
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (pre-commit + dev-deploy + e2e)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #401