### PR TITLE
feat(processor): support per-model InferenceObjective in gateway config

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -94,10 +94,6 @@ data:
       {{- end }}
     {{- end }}
 
-    {{- if .Values.processor.config.inferenceObjective }}
-    inference_objective: {{ .Values.processor.config.inferenceObjective | quote }}
-    {{- end }}
-
     default_output_expiration_seconds: {{ .Values.processor.config.defaultOutputExpirationSeconds }}
     progress_ttl_seconds: {{ .Values.processor.config.progressTTLSeconds }}
 

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -38,6 +38,9 @@ data:
     {{- with .Values.processor.config.globalInferenceGateway }}
     global_inference_gateway:
       url: {{ .url | quote }}
+      {{- if .inferenceObjective }}
+      inference_objective: {{ .inferenceObjective | quote }}
+      {{- end }}
       request_timeout: {{ .requestTimeout | quote }}
       max_retries: {{ .maxRetries }}
       initial_backoff: {{ .initialBackoff | quote }}
@@ -65,6 +68,9 @@ data:
       {{- range $model, $cfg := .Values.processor.config.modelGateways }}
       {{ $model | quote }}:
         url: {{ $cfg.url | quote }}
+        {{- if $cfg.inferenceObjective }}
+        inference_objective: {{ $cfg.inferenceObjective | quote }}
+        {{- end }}
         request_timeout: {{ $cfg.requestTimeout | quote }}
         max_retries: {{ $cfg.maxRetries }}
         initial_backoff: {{ $cfg.initialBackoff | quote }}

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -273,6 +273,80 @@ tests:
           path: data["config.yaml"]
           pattern: 'inference_objective: "batch-low-priority"'
 
+  - it: should render per-model inferenceObjective when set
+    set:
+      processor.config.modelGateways:
+        "llama-3":
+          url: "http://gie-a-epp:8081"
+          inferenceObjective: "batch-sheddable-a"
+          requestTimeout: "5m"
+          maxRetries: 3
+          initialBackoff: "1s"
+          maxBackoff: "60s"
+        "mistral":
+          url: "http://gie-b-epp:8081"
+          inferenceObjective: "batch-sheddable-b"
+          requestTimeout: "2m"
+          maxRetries: 1
+          initialBackoff: "500ms"
+          maxBackoff: "30s"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '"llama-3":[\s\S]*inference_objective: "batch-sheddable-a"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '"mistral":[\s\S]*inference_objective: "batch-sheddable-b"'
+
+  - it: should not render per-model inferenceObjective when empty
+    set:
+      processor.config.modelGateways:
+        "llama-3":
+          url: "http://gw:8000"
+          requestTimeout: "5m"
+          maxRetries: 3
+          initialBackoff: "1s"
+          maxBackoff: "60s"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '"llama-3":'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: '"llama-3":[\s\S]*inference_objective:'
+
+  - it: should render inferenceObjective on global_inference_gateway when set
+    set:
+      processor.config.globalInferenceGateway:
+        url: "http://global-gw:8000"
+        inferenceObjective: "batch-sheddable-global"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "1s"
+        maxBackoff: "60s"
+      processor.config.modelGateways: null
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'global_inference_gateway:[\s\S]*inference_objective: "batch-sheddable-global"'
+
+  - it: should not render inferenceObjective on global_inference_gateway when empty
+    set:
+      processor.config.globalInferenceGateway:
+        url: "http://global-gw:8000"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "1s"
+        maxBackoff: "60s"
+      processor.config.modelGateways: null
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'global_inference_gateway:'
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'global_inference_gateway:[\s\S]*inference_objective:'
+
   - it: should not render ConfigMap when processor is disabled
     set:
       processor.enabled: false

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -259,20 +259,6 @@ tests:
           path: data["config.yaml"]
           pattern: 'retry:\n\s+max_retries: 3\n\s+initial_backoff: "1s"\n\s+max_backoff: "10s"'
 
-  - it: should not render inference_objective when empty (default)
-    asserts:
-      - notMatchRegex:
-          path: data["config.yaml"]
-          pattern: 'inference_objective:'
-
-  - it: should render inference_objective when configured
-    set:
-      processor.config.inferenceObjective: "batch-low-priority"
-    asserts:
-      - matchRegex:
-          path: data["config.yaml"]
-          pattern: 'inference_objective: "batch-low-priority"'
-
   - it: should render per-model inferenceObjective when set
     set:
       processor.config.modelGateways:

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -331,7 +331,7 @@ processor:
     # Mutually exclusive with modelGateways — the processor rejects config with both set.
     # globalInferenceGateway:
     #   url: "http://inference-gateway:8000"
-    #   inferenceObjective: ""        # overrides processor-level inferenceObjective for this gateway
+    #   inferenceObjective: ""        # InferenceObjective CRD name for x-gateway-inference-objective header
     #   requestTimeout: "5m"
     #   maxRetries: 3
     #   initialBackoff: "1s"
@@ -344,9 +344,9 @@ processor:
     # modelGateways maps specific model names to gateway configs.
     # Only models listed here are routed; unlisted models get a request-level error.
     # Either globalInferenceGateway or modelGateways must be configured.
-    # Each entry may set inferenceObjective to override the global value for that model's
-    # GIE InferencePool. This enables multi-pool deployments where each model routes through
-    # a separate InferencePool with its own priority band configuration.
+    # Each entry may set inferenceObjective to specify the InferenceObjective CRD name
+    # for the x-gateway-inference-objective header. This enables multi-pool deployments
+    # where each model routes through a separate InferencePool with its own priority band.
     # modelGateways:
     #   "llama-3":
     #     url: "http://gie-a-epp:8081"
@@ -366,12 +366,6 @@ processor:
     #     maxRetries: 1
     defaultOutputExpirationSeconds: 7776000  # 90 days
     progressTTLSeconds: 86400  # 24 hours
-    # Default GIE InferenceObjective CRD name for the
-    # x-gateway-inference-objective header on inference requests.
-    # Used by GIE flow control to assign batch requests to a priority band.
-    # Per-gateway inferenceObjective (above) takes precedence when set.
-    # Empty (default) means the header is not sent.
-    inferenceObjective: ""
     # Enable pprof profiling endpoints on the observability server (/debug/pprof/)
     enablePprof: false
 

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -331,6 +331,7 @@ processor:
     # Mutually exclusive with modelGateways — the processor rejects config with both set.
     # globalInferenceGateway:
     #   url: "http://inference-gateway:8000"
+    #   inferenceObjective: ""        # overrides processor-level inferenceObjective for this gateway
     #   requestTimeout: "5m"
     #   maxRetries: 3
     #   initialBackoff: "1s"
@@ -343,9 +344,13 @@ processor:
     # modelGateways maps specific model names to gateway configs.
     # Only models listed here are routed; unlisted models get a request-level error.
     # Either globalInferenceGateway or modelGateways must be configured.
+    # Each entry may set inferenceObjective to override the global value for that model's
+    # GIE InferencePool. This enables multi-pool deployments where each model routes through
+    # a separate InferencePool with its own priority band configuration.
     # modelGateways:
     #   "llama-3":
-    #     url: "http://gateway-a:8000"
+    #     url: "http://gie-a-epp:8081"
+    #     inferenceObjective: "batch-sheddable-a"   # references gie-a pool
     #     requestTimeout: "5m"
     #     maxRetries: 3
     #     initialBackoff: "1s"
@@ -355,15 +360,16 @@ processor:
     #     tlsClientCertFile: ""
     #     tlsClientKeyFile: ""
     #   "mistral":
-    #     url: "http://gateway-b:8000"
-    #     apiKeyName: "gateway-b-api-key"
+    #     url: "http://gie-b-epp:8081"
+    #     inferenceObjective: "batch-sheddable-b"   # references gie-b pool
     #     requestTimeout: "2m"
     #     maxRetries: 1
     defaultOutputExpirationSeconds: 7776000  # 90 days
     progressTTLSeconds: 86400  # 24 hours
-    # Name of a GIE InferenceObjective CRD to reference in the
+    # Default GIE InferenceObjective CRD name for the
     # x-gateway-inference-objective header on inference requests.
     # Used by GIE flow control to assign batch requests to a priority band.
+    # Per-gateway inferenceObjective (above) takes precedence when set.
     # Empty (default) means the header is not sent.
     inferenceObjective: ""
     # Enable pprof profiling endpoints on the observability server (/debug/pprof/)

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -41,6 +41,7 @@ work_dir: "/var/lib/batch-gateway/processor"
 # When set, model_gateways entries are ignored for routing.
 global_inference_gateway:
   url: "http://localhost:8000"
+  # inference_objective: ""    # InferenceObjective CRD name for x-gateway-inference-objective header
   request_timeout: "5m"
   max_retries: 3
   initial_backoff: "1s"
@@ -57,7 +58,7 @@ global_inference_gateway:
 # model_gateways:
 #   "llama-3":
 #     url: "http://gateway-a:8000"
-#     inference_objective: ""    # per-model override; falls back to global inference_objective
+#     inference_objective: ""    # InferenceObjective CRD name for x-gateway-inference-objective header
 #     request_timeout: "5m"
 #     max_retries: 3
 #     initial_backoff: "1s"

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -57,6 +57,7 @@ global_inference_gateway:
 # model_gateways:
 #   "llama-3":
 #     url: "http://gateway-a:8000"
+#     inference_objective: ""    # per-model override; falls back to global inference_objective
 #     request_timeout: "5m"
 #     max_retries: 3
 #     initial_backoff: "1s"

--- a/docs/guides/flow-control-setup.md
+++ b/docs/guides/flow-control-setup.md
@@ -133,7 +133,7 @@ spec:
 Batch Gateway sets the following flow-control headers on each inference request:
 
 - **`x-slo-ttft-ms`**: Remaining milliseconds until the batch job's SLO deadline. GIE's `slo-deadline-ordering-policy` reads this header to order batch requests by urgency within the batch priority band.
-- **`x-gateway-inference-objective`**: Name of the `InferenceObjective` CRD that determines the priority band. Only sent when `inference_objective` is configured (see below).
+- **`x-gateway-inference-objective`**: Name of the `InferenceObjective` CRD that determines the priority band. Only sent when the resolved inference objective is non-empty (per-gateway override or processor-level default; see below).
 - **`x-gateway-inference-fairness-id`**: Tenant identifier for per-tenant fairness within a priority band. Automatically set to the job's tenant ID when it is non-empty. GIE uses this header to group requests into separate flows so that a `round-robin` fairness policy can schedule them fairly.
 
 **Note:** The recommended batch band configuration above uses `global-strict` fairness, which ignores flow boundaries and maximizes throughput. The fairness header only has effect if operators switch the batch band's fairness policy to `round-robin`.
@@ -143,9 +143,6 @@ Batch Gateway sets the following flow-control headers on each inference request:
 The following `batch-processor` configuration settings interact with flow control:
 
 ```yaml
-# Name of the InferenceObjective CRD for batch requests.
-inference_objective: "batch-sheddable"
-
 # Processor concurrency settings
 global_concurrency: 100        # Max in-flight requests across all models
 per_model_max_concurrency: 20  # Max in-flight requests per model
@@ -157,6 +154,53 @@ initial_backoff: "2s"          # Initial retry backoff
 max_backoff: "30s"             # Max retry backoff
 ```
 
+#### InferenceObjective Configuration
+
+The `inference_objective` setting controls which `InferenceObjective` CRD name is sent in the `x-gateway-inference-objective` header. It can be configured at two levels:
+
+- **Per-gateway** (`model_gateways.<model>.inference_objective` or `global_inference_gateway.inference_objective`): Sets the objective for a specific gateway. Use this when different models route through separate InferencePools.
+- **Processor-level** (`inference_objective`): Applied to any model whose gateway does not set its own `inference_objective`. Use this as the default when most or all models share one InferencePool.
+
+Resolution order: per-gateway override > processor-level default > no header (when both are empty).
+
+**Single-pool example** (all models share one InferencePool):
+
+```yaml
+inference_objective: "batch-sheddable"
+
+global_inference_gateway:
+  url: "http://gie-epp:8081"
+```
+
+**Multi-pool example** (each model has its own InferencePool):
+
+```yaml
+model_gateways:
+  "model-a":
+    url: "http://gie-a-epp:8081"
+    inference_objective: "batch-sheddable-a"  # references pool-a
+  "model-b":
+    url: "http://gie-b-epp:8081"
+    inference_objective: "batch-sheddable-b"  # references pool-b
+```
+
+**Mixed example** (most models share one pool, one model has its own):
+
+```yaml
+inference_objective: "batch-sheddable"  # default for models without override
+
+model_gateways:
+  "model-a":
+    url: "http://gie-shared-epp:8081"
+    # no inference_objective → uses processor-level "batch-sheddable"
+  "model-b":
+    url: "http://gie-shared-epp:8081"
+    # no inference_objective → uses processor-level "batch-sheddable"
+  "model-c":
+    url: "http://gie-c-epp:8081"
+    inference_objective: "batch-sheddable-c"  # override for model-c's own pool
+```
+
 #### Key Considerations
 
 - **`request_timeout`**: With flow control enabled, requests may spend time in the GIE queue before reaching the backend. Set this high enough to accommodate queuing time plus inference time. 5 minutes is a reasonable starting point.
@@ -165,6 +209,8 @@ max_backoff: "30s"             # Max retry backoff
 
 #### Helm Values
 
+Single-pool deployment:
+
 ```yaml
 processor:
   config:
@@ -172,11 +218,35 @@ processor:
     perModelMaxConcurrency: 20
     inferenceObjective: "batch-sheddable"
     globalInferenceGateway:
-      url: "http://llm-d-router:8000"
+      url: "http://gie-epp:8081"
       requestTimeout: "5m"
       maxRetries: 3
       initialBackoff: "2s"
       maxBackoff: "30s"
+```
+
+Multi-pool deployment (per-model InferenceObjective):
+
+```yaml
+processor:
+  config:
+    globalConcurrency: 100
+    perModelMaxConcurrency: 20
+    modelGateways:
+      "model-a":
+        url: "http://gie-a-epp:8081"
+        inferenceObjective: "batch-sheddable-a"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "2s"
+        maxBackoff: "30s"
+      "model-b":
+        url: "http://gie-b-epp:8081"
+        inferenceObjective: "batch-sheddable-b"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "2s"
+        maxBackoff: "30s"
 ```
 
 ## How the System Behaves Under Load

--- a/docs/guides/flow-control-setup.md
+++ b/docs/guides/flow-control-setup.md
@@ -133,7 +133,7 @@ spec:
 Batch Gateway sets the following flow-control headers on each inference request:
 
 - **`x-slo-ttft-ms`**: Remaining milliseconds until the batch job's SLO deadline. GIE's `slo-deadline-ordering-policy` reads this header to order batch requests by urgency within the batch priority band.
-- **`x-gateway-inference-objective`**: Name of the `InferenceObjective` CRD that determines the priority band. Only sent when the resolved inference objective is non-empty (per-gateway override or processor-level default; see below).
+- **`x-gateway-inference-objective`**: Name of the `InferenceObjective` CRD that determines the priority band. Only sent when `inference_objective` is configured on the gateway (see below).
 - **`x-gateway-inference-fairness-id`**: Tenant identifier for per-tenant fairness within a priority band. Automatically set to the job's tenant ID when it is non-empty. GIE uses this header to group requests into separate flows so that a `round-robin` fairness policy can schedule them fairly.
 
 **Note:** The recommended batch band configuration above uses `global-strict` fairness, which ignores flow boundaries and maximizes throughput. The fairness header only has effect if operators switch the batch band's fairness policy to `round-robin`.
@@ -156,20 +156,14 @@ max_backoff: "30s"             # Max retry backoff
 
 #### InferenceObjective Configuration
 
-The `inference_objective` setting controls which `InferenceObjective` CRD name is sent in the `x-gateway-inference-objective` header. It can be configured at two levels:
-
-- **Per-gateway** (`model_gateways.<model>.inference_objective` or `global_inference_gateway.inference_objective`): Sets the objective for a specific gateway. Use this when different models route through separate InferencePools.
-- **Processor-level** (`inference_objective`): Applied to any model whose gateway does not set its own `inference_objective`. Use this as the default when most or all models share one InferencePool.
-
-Resolution order: per-gateway override > processor-level default > no header (when both are empty).
+The `inference_objective` setting controls which `InferenceObjective` CRD name is sent in the `x-gateway-inference-objective` header. Set it directly on each gateway entry — `global_inference_gateway.inference_objective` or `model_gateways.<model>.inference_objective`. When empty, the header is not sent.
 
 **Single-pool example** (all models share one InferencePool):
 
 ```yaml
-inference_objective: "batch-sheddable"
-
 global_inference_gateway:
   url: "http://gie-epp:8081"
+  inference_objective: "batch-sheddable"
 ```
 
 **Multi-pool example** (each model has its own InferencePool):
@@ -187,18 +181,16 @@ model_gateways:
 **Mixed example** (most models share one pool, one model has its own):
 
 ```yaml
-inference_objective: "batch-sheddable"  # default for models without override
-
 model_gateways:
   "model-a":
     url: "http://gie-shared-epp:8081"
-    # no inference_objective → uses processor-level "batch-sheddable"
+    inference_objective: "batch-sheddable"
   "model-b":
     url: "http://gie-shared-epp:8081"
-    # no inference_objective → uses processor-level "batch-sheddable"
+    inference_objective: "batch-sheddable"
   "model-c":
     url: "http://gie-c-epp:8081"
-    inference_objective: "batch-sheddable-c"  # override for model-c's own pool
+    inference_objective: "batch-sheddable-c"
 ```
 
 #### Key Considerations
@@ -216,9 +208,9 @@ processor:
   config:
     globalConcurrency: 100
     perModelMaxConcurrency: 20
-    inferenceObjective: "batch-sheddable"
     globalInferenceGateway:
       url: "http://gie-epp:8081"
+      inferenceObjective: "batch-sheddable"
       requestTimeout: "5m"
       maxRetries: 3
       initialBackoff: "2s"

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -135,6 +135,12 @@ type ModelGatewayConfig struct {
 	APIKeyName string `yaml:"api_key_name"`
 	APIKeyFile string `yaml:"api_key_file"`
 
+	// InferenceObjective overrides the processor-level inference_objective
+	// for requests routed through this gateway (x-gateway-inference-objective
+	// header). Use this to target per-model InferencePools in multi-pool
+	// GIE deployments. When empty, the processor-level default is used.
+	InferenceObjective string `yaml:"inference_objective"`
+
 	RequestTimeout *time.Duration `yaml:"request_timeout"`
 	MaxRetries     *int           `yaml:"max_retries"`
 	InitialBackoff *time.Duration `yaml:"initial_backoff"`
@@ -150,6 +156,22 @@ type BucketConfig struct {
 	BucketStart  float64 `yaml:"start"`
 	BucketFactor float64 `yaml:"factor"`
 	BucketCount  int     `yaml:"count"`
+}
+
+// InferenceObjectiveFor returns the effective inference objective for a model.
+// Resolution: per-gateway override > processor-level default.
+// Returns "" when no objective is configured, which means the header is not sent.
+func (c *ProcessorConfig) InferenceObjectiveFor(modelID string) string {
+	if c.GlobalInferenceGateway != nil {
+		if c.GlobalInferenceGateway.InferenceObjective != "" {
+			return c.GlobalInferenceGateway.InferenceObjective
+		}
+		return c.InferenceObjective
+	}
+	if gw, ok := c.ModelGateways[modelID]; ok && gw.InferenceObjective != "" {
+		return gw.InferenceObjective
+	}
+	return c.InferenceObjective
 }
 
 // LoadFromYaml loads the configuration from a YAML file.

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -100,12 +100,6 @@ type ProcessorConfig struct {
 	// Each recovery can involve DB lookups, S3 uploads, and status updates.
 	RecoveryMaxConcurrency int `yaml:"recovery_max_concurrency"`
 
-	// InferenceObjective is the name of a GIE InferenceObjective CRD to reference
-	// in the x-gateway-inference-objective header on inference requests.
-	// Used by GIE's flow control to assign batch requests to a priority band.
-	// Empty (default) means the header is not sent.
-	InferenceObjective string `yaml:"inference_objective"`
-
 	// EnablePprof enables pprof profiling endpoints on the observability server.
 	EnablePprof bool `yaml:"enable_pprof"`
 
@@ -135,10 +129,10 @@ type ModelGatewayConfig struct {
 	APIKeyName string `yaml:"api_key_name"`
 	APIKeyFile string `yaml:"api_key_file"`
 
-	// InferenceObjective overrides the processor-level inference_objective
-	// for requests routed through this gateway (x-gateway-inference-objective
-	// header). Use this to target per-model InferencePools in multi-pool
-	// GIE deployments. When empty, the processor-level default is used.
+	// InferenceObjective is the name of a GIE InferenceObjective CRD sent in
+	// the x-gateway-inference-objective header on inference requests. Use this
+	// to target per-model InferencePools in multi-pool GIE deployments.
+	// When empty, the header is not sent.
 	InferenceObjective string `yaml:"inference_objective"`
 
 	RequestTimeout *time.Duration `yaml:"request_timeout"`
@@ -158,20 +152,17 @@ type BucketConfig struct {
 	BucketCount  int     `yaml:"count"`
 }
 
-// InferenceObjectiveFor returns the effective inference objective for a model.
-// Resolution: per-gateway override > processor-level default.
+// InferenceObjectiveFor returns the inference objective configured on the
+// gateway that will handle requests for modelID.
 // Returns "" when no objective is configured, which means the header is not sent.
 func (c *ProcessorConfig) InferenceObjectiveFor(modelID string) string {
 	if c.GlobalInferenceGateway != nil {
-		if c.GlobalInferenceGateway.InferenceObjective != "" {
-			return c.GlobalInferenceGateway.InferenceObjective
-		}
-		return c.InferenceObjective
+		return c.GlobalInferenceGateway.InferenceObjective
 	}
-	if gw, ok := c.ModelGateways[modelID]; ok && gw.InferenceObjective != "" {
+	if gw, ok := c.ModelGateways[modelID]; ok {
 		return gw.InferenceObjective
 	}
-	return c.InferenceObjective
+	return ""
 }
 
 // LoadFromYaml loads the configuration from a YAML file.

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -161,7 +161,6 @@ model_gateways:
     max_retries: 0
     initial_backoff: 1s
     max_backoff: 60s
-inference_objective: "batch-sheddable"
 progress_ttl_seconds: 86400
 `)
 
@@ -195,15 +194,12 @@ progress_ttl_seconds: 86400
 	if noRetry.InferenceObjective != "" {
 		t.Fatalf("no-retry-model InferenceObjective = %q, want empty", noRetry.InferenceObjective)
 	}
-	if c.InferenceObjective != "batch-sheddable" {
-		t.Fatalf("InferenceObjective = %q, want %q", c.InferenceObjective, "batch-sheddable")
-	}
 
 	if c.InferenceObjectiveFor("llama-3") != "batch-sheddable-a" {
 		t.Fatalf("InferenceObjectiveFor(llama-3) = %q, want per-model override", c.InferenceObjectiveFor("llama-3"))
 	}
-	if c.InferenceObjectiveFor("no-retry-model") != "batch-sheddable" {
-		t.Fatalf("InferenceObjectiveFor(no-retry-model) = %q, want global fallback", c.InferenceObjectiveFor("no-retry-model"))
+	if c.InferenceObjectiveFor("no-retry-model") != "" {
+		t.Fatalf("InferenceObjectiveFor(no-retry-model) = %q, want empty", c.InferenceObjectiveFor("no-retry-model"))
 	}
 
 	if err := c.Validate(); err != nil {
@@ -515,16 +511,7 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 			want:    "",
 		},
 		{
-			name: "global fallback only",
-			cfg: ProcessorConfig{
-				ModelGateways:      validPerModelConfig(),
-				InferenceObjective: "batch-sheddable",
-			},
-			modelID: "llama-3",
-			want:    "batch-sheddable",
-		},
-		{
-			name: "per-model overrides global",
+			name: "per-model objective set",
 			cfg: ProcessorConfig{
 				ModelGateways: map[string]ModelGatewayConfig{
 					"llama-3": {
@@ -536,13 +523,12 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 						MaxBackoff:         ptr.To(60 * time.Second),
 					},
 				},
-				InferenceObjective: "batch-sheddable",
 			},
 			modelID: "llama-3",
 			want:    "batch-sheddable-a",
 		},
 		{
-			name: "unlisted model falls back to global",
+			name: "unlisted model returns empty",
 			cfg: ProcessorConfig{
 				ModelGateways: map[string]ModelGatewayConfig{
 					"llama-3": {
@@ -554,13 +540,12 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 						MaxBackoff:         ptr.To(60 * time.Second),
 					},
 				},
-				InferenceObjective: "batch-sheddable",
 			},
 			modelID: "mistral",
-			want:    "batch-sheddable",
+			want:    "",
 		},
 		{
-			name: "per-model empty falls back to global",
+			name: "per-model empty returns empty",
 			cfg: ProcessorConfig{
 				ModelGateways: map[string]ModelGatewayConfig{
 					"llama-3": {
@@ -571,13 +556,12 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 						MaxBackoff:     ptr.To(60 * time.Second),
 					},
 				},
-				InferenceObjective: "batch-sheddable",
 			},
 			modelID: "llama-3",
-			want:    "batch-sheddable",
+			want:    "",
 		},
 		{
-			name: "global gateway with per-gateway objective",
+			name: "global gateway with objective",
 			cfg: ProcessorConfig{
 				GlobalInferenceGateway: &ModelGatewayConfig{
 					URL:                "http://global-gw:8000",
@@ -587,13 +571,12 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 					InitialBackoff:     ptr.To(1 * time.Second),
 					MaxBackoff:         ptr.To(60 * time.Second),
 				},
-				InferenceObjective: "fallback",
 			},
 			modelID: "any-model",
 			want:    "batch-sheddable-global",
 		},
 		{
-			name: "global gateway without per-gateway objective uses global fallback",
+			name: "global gateway without objective returns empty",
 			cfg: ProcessorConfig{
 				GlobalInferenceGateway: &ModelGatewayConfig{
 					URL:            "http://global-gw:8000",
@@ -602,10 +585,9 @@ func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
 					InitialBackoff: ptr.To(1 * time.Second),
 					MaxBackoff:     ptr.To(60 * time.Second),
 				},
-				InferenceObjective: "batch-sheddable",
 			},
 			modelID: "any-model",
-			want:    "batch-sheddable",
+			want:    "",
 		},
 	}
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -150,6 +150,7 @@ e2e_latency_bucket:
 model_gateways:
   "llama-3":
     url: "http://llama-gw:8000"
+    inference_objective: "batch-sheddable-a"
     request_timeout: 5m
     max_retries: 3
     initial_backoff: 1s
@@ -160,6 +161,7 @@ model_gateways:
     max_retries: 0
     initial_backoff: 1s
     max_backoff: 60s
+inference_objective: "batch-sheddable"
 progress_ttl_seconds: 86400
 `)
 
@@ -181,6 +183,27 @@ progress_ttl_seconds: 86400
 	}
 	if *noRetry.MaxRetries != 0 {
 		t.Fatalf("no-retry-model MaxRetries = %d, want 0 (explicit zero must not be overwritten by default)", *noRetry.MaxRetries)
+	}
+
+	llama, ok := c.ModelGateways["llama-3"]
+	if !ok {
+		t.Fatal("ModelGateways missing llama-3")
+	}
+	if llama.InferenceObjective != "batch-sheddable-a" {
+		t.Fatalf("llama-3 InferenceObjective = %q, want %q", llama.InferenceObjective, "batch-sheddable-a")
+	}
+	if noRetry.InferenceObjective != "" {
+		t.Fatalf("no-retry-model InferenceObjective = %q, want empty", noRetry.InferenceObjective)
+	}
+	if c.InferenceObjective != "batch-sheddable" {
+		t.Fatalf("InferenceObjective = %q, want %q", c.InferenceObjective, "batch-sheddable")
+	}
+
+	if c.InferenceObjectiveFor("llama-3") != "batch-sheddable-a" {
+		t.Fatalf("InferenceObjectiveFor(llama-3) = %q, want per-model override", c.InferenceObjectiveFor("llama-3"))
+	}
+	if c.InferenceObjectiveFor("no-retry-model") != "batch-sheddable" {
+		t.Fatalf("InferenceObjectiveFor(no-retry-model) = %q, want global fallback", c.InferenceObjectiveFor("no-retry-model"))
 	}
 
 	if err := c.Validate(); err != nil {
@@ -475,5 +498,123 @@ progress_ttl_seconds: 3600
 	}
 	if c.ProgressTTLSeconds != 3600 {
 		t.Fatalf("ProgressTTLSeconds = %d, want %d", c.ProgressTTLSeconds, 3600)
+	}
+}
+
+func TestProcessorConfig_InferenceObjectiveFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     ProcessorConfig
+		modelID string
+		want    string
+	}{
+		{
+			name:    "no objective configured anywhere",
+			cfg:     ProcessorConfig{ModelGateways: validPerModelConfig()},
+			modelID: "llama-3",
+			want:    "",
+		},
+		{
+			name: "global fallback only",
+			cfg: ProcessorConfig{
+				ModelGateways:      validPerModelConfig(),
+				InferenceObjective: "batch-sheddable",
+			},
+			modelID: "llama-3",
+			want:    "batch-sheddable",
+		},
+		{
+			name: "per-model overrides global",
+			cfg: ProcessorConfig{
+				ModelGateways: map[string]ModelGatewayConfig{
+					"llama-3": {
+						URL:                "http://gw:8000",
+						InferenceObjective: "batch-sheddable-a",
+						RequestTimeout:     ptr.To(5 * time.Minute),
+						MaxRetries:         ptr.To(3),
+						InitialBackoff:     ptr.To(1 * time.Second),
+						MaxBackoff:         ptr.To(60 * time.Second),
+					},
+				},
+				InferenceObjective: "batch-sheddable",
+			},
+			modelID: "llama-3",
+			want:    "batch-sheddable-a",
+		},
+		{
+			name: "unlisted model falls back to global",
+			cfg: ProcessorConfig{
+				ModelGateways: map[string]ModelGatewayConfig{
+					"llama-3": {
+						URL:                "http://gw:8000",
+						InferenceObjective: "batch-sheddable-a",
+						RequestTimeout:     ptr.To(5 * time.Minute),
+						MaxRetries:         ptr.To(3),
+						InitialBackoff:     ptr.To(1 * time.Second),
+						MaxBackoff:         ptr.To(60 * time.Second),
+					},
+				},
+				InferenceObjective: "batch-sheddable",
+			},
+			modelID: "mistral",
+			want:    "batch-sheddable",
+		},
+		{
+			name: "per-model empty falls back to global",
+			cfg: ProcessorConfig{
+				ModelGateways: map[string]ModelGatewayConfig{
+					"llama-3": {
+						URL:            "http://gw:8000",
+						RequestTimeout: ptr.To(5 * time.Minute),
+						MaxRetries:     ptr.To(3),
+						InitialBackoff: ptr.To(1 * time.Second),
+						MaxBackoff:     ptr.To(60 * time.Second),
+					},
+				},
+				InferenceObjective: "batch-sheddable",
+			},
+			modelID: "llama-3",
+			want:    "batch-sheddable",
+		},
+		{
+			name: "global gateway with per-gateway objective",
+			cfg: ProcessorConfig{
+				GlobalInferenceGateway: &ModelGatewayConfig{
+					URL:                "http://global-gw:8000",
+					InferenceObjective: "batch-sheddable-global",
+					RequestTimeout:     ptr.To(5 * time.Minute),
+					MaxRetries:         ptr.To(3),
+					InitialBackoff:     ptr.To(1 * time.Second),
+					MaxBackoff:         ptr.To(60 * time.Second),
+				},
+				InferenceObjective: "fallback",
+			},
+			modelID: "any-model",
+			want:    "batch-sheddable-global",
+		},
+		{
+			name: "global gateway without per-gateway objective uses global fallback",
+			cfg: ProcessorConfig{
+				GlobalInferenceGateway: &ModelGatewayConfig{
+					URL:            "http://global-gw:8000",
+					RequestTimeout: ptr.To(5 * time.Minute),
+					MaxRetries:     ptr.To(3),
+					InitialBackoff: ptr.To(1 * time.Second),
+					MaxBackoff:     ptr.To(60 * time.Second),
+				},
+				InferenceObjective: "batch-sheddable",
+			},
+			modelID: "any-model",
+			want:    "batch-sheddable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.InferenceObjectiveFor(tt.modelID)
+			if got != tt.want {
+				t.Fatalf("InferenceObjectiveFor(%q) = %q, want %q", tt.modelID, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -719,7 +719,7 @@ func (p *Processor) executeOneRequest(
 	}
 
 	headers := maps.Clone(passThroughHeaders)
-	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjective)
+	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID))
 
 	inferReq := &inference.GenerateRequest{
 		RequestID: newBatchRequestID(requestID),

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2926,12 +2926,11 @@ func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
 	tests := []struct {
 		name          string
 		modelGateways map[string]config.ModelGatewayConfig
-		globalObj     string
 		modelID       string
 		wantObjective string
 	}{
 		{
-			name: "per-model objective overrides global",
+			name: "per-model objective set",
 			modelGateways: map[string]config.ModelGatewayConfig{
 				"m1": {
 					URL:                "http://gw-a:8000",
@@ -2942,12 +2941,11 @@ func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
 					MaxBackoff:         ptr.To(60 * time.Second),
 				},
 			},
-			globalObj:     "batch-sheddable",
 			modelID:       "m1",
 			wantObjective: "batch-sheddable-a",
 		},
 		{
-			name: "no per-model objective falls back to global",
+			name: "no per-model objective omits header",
 			modelGateways: map[string]config.ModelGatewayConfig{
 				"m1": {
 					URL:            "http://gw-a:8000",
@@ -2957,22 +2955,6 @@ func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
 					MaxBackoff:     ptr.To(60 * time.Second),
 				},
 			},
-			globalObj:     "batch-sheddable",
-			modelID:       "m1",
-			wantObjective: "batch-sheddable",
-		},
-		{
-			name: "no objective anywhere omits header",
-			modelGateways: map[string]config.ModelGatewayConfig{
-				"m1": {
-					URL:            "http://gw-a:8000",
-					RequestTimeout: ptr.To(5 * time.Minute),
-					MaxRetries:     ptr.To(3),
-					InitialBackoff: ptr.To(1 * time.Second),
-					MaxBackoff:     ptr.To(60 * time.Second),
-				},
-			},
-			globalObj:     "",
 			modelID:       "m1",
 			wantObjective: "",
 		},
@@ -2983,7 +2965,6 @@ func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
 			cfg := config.NewConfig()
 			cfg.WorkDir = t.TempDir()
 			cfg.ModelGateways = tt.modelGateways
-			cfg.InferenceObjective = tt.globalObj
 
 			var gotObjective string
 			mock := &mockInferenceClient{

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/llm-d-incubation/batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d-incubation/batch-gateway/internal/shared/types"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
+	"github.com/llm-d-incubation/batch-gateway/internal/util/ptr"
 
 	httpclient "github.com/llm-d-incubation/batch-gateway/pkg/clients/http"
 	"github.com/llm-d-incubation/batch-gateway/pkg/clients/inference"
@@ -2915,4 +2916,113 @@ func TestMergeInferenceHeaders(t *testing.T) {
 			t.Fatalf("objective header: got %q, want %q", h[inferenceObjectiveHeader], "batch-low-priority")
 		}
 	})
+}
+
+// =====================================================================
+// Tests: per-model inference objective in executeOneRequest
+// =====================================================================
+
+func TestExecuteOneRequest_PerModelInferenceObjective(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelGateways map[string]config.ModelGatewayConfig
+		globalObj     string
+		modelID       string
+		wantObjective string
+	}{
+		{
+			name: "per-model objective overrides global",
+			modelGateways: map[string]config.ModelGatewayConfig{
+				"m1": {
+					URL:                "http://gw-a:8000",
+					InferenceObjective: "batch-sheddable-a",
+					RequestTimeout:     ptr.To(5 * time.Minute),
+					MaxRetries:         ptr.To(3),
+					InitialBackoff:     ptr.To(1 * time.Second),
+					MaxBackoff:         ptr.To(60 * time.Second),
+				},
+			},
+			globalObj:     "batch-sheddable",
+			modelID:       "m1",
+			wantObjective: "batch-sheddable-a",
+		},
+		{
+			name: "no per-model objective falls back to global",
+			modelGateways: map[string]config.ModelGatewayConfig{
+				"m1": {
+					URL:            "http://gw-a:8000",
+					RequestTimeout: ptr.To(5 * time.Minute),
+					MaxRetries:     ptr.To(3),
+					InitialBackoff: ptr.To(1 * time.Second),
+					MaxBackoff:     ptr.To(60 * time.Second),
+				},
+			},
+			globalObj:     "batch-sheddable",
+			modelID:       "m1",
+			wantObjective: "batch-sheddable",
+		},
+		{
+			name: "no objective anywhere omits header",
+			modelGateways: map[string]config.ModelGatewayConfig{
+				"m1": {
+					URL:            "http://gw-a:8000",
+					RequestTimeout: ptr.To(5 * time.Minute),
+					MaxRetries:     ptr.To(3),
+					InitialBackoff: ptr.To(1 * time.Second),
+					MaxBackoff:     ptr.To(60 * time.Second),
+				},
+			},
+			globalObj:     "",
+			modelID:       "m1",
+			wantObjective: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewConfig()
+			cfg.WorkDir = t.TempDir()
+			cfg.ModelGateways = tt.modelGateways
+			cfg.InferenceObjective = tt.globalObj
+
+			var gotObjective string
+			mock := &mockInferenceClient{
+				generateFn: func(_ context.Context, req *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+					gotObjective = req.Headers[inferenceObjectiveHeader]
+					return &inference.GenerateResponse{
+						RequestID: "srv-obj",
+						Response:  []byte(`{"result":"ok"}`),
+					}, nil
+				},
+			}
+
+			requests := []batch_types.Request{
+				{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": tt.modelID, "prompt": "hi"}},
+			}
+			env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{tt.modelID: tt.modelID})
+
+			inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+			inputFile, err := os.Open(inputPath)
+			if err != nil {
+				t.Fatalf("open input: %v", err)
+			}
+			defer inputFile.Close()
+
+			jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+			entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+			ctx := testLoggerCtx(t)
+			sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(5*time.Second))
+			defer sloCancel()
+
+			_, err = env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], tt.modelID, nil)
+			if err != nil {
+				t.Fatalf("executeOneRequest error: %v", err)
+			}
+
+			if gotObjective != tt.wantObjective {
+				t.Fatalf("objective header = %q, want %q", gotObjective, tt.wantObjective)
+			}
+		})
+	}
 }

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -1043,7 +1043,7 @@ install_batch_gateway() {
 
     if [ "${ENABLE_GIE}" = "true" ]; then
         helm_args+=(
-            --set "processor.config.inferenceObjective=batch-sheddable"
+            --set "processor.config.modelGateways.${VLLM_SIM_MODEL}.inferenceObjective=batch-sheddable"
             --set "processor.config.perModelMaxConcurrency=20"
             --set "processor.config.modelGateways.${VLLM_SIM_MODEL}.initialBackoff=2s"
             --set "processor.config.modelGateways.${VLLM_SIM_MODEL}.maxBackoff=30s"


### PR DESCRIPTION
## Why is this PR needed?

The processor currently supports a single global `inference_objective` setting that applies the same `x-gateway-inference-objective` header to all inference requests. However, GIE's intended architecture uses separate InferencePool instances per model, each with its own InferenceObjective CRD referencing that pool via `poolRef`. Sending the wrong objective name for a model causes GIE to fail the pool lookup.

This blocks multi-model flow control setups where models route through different InferencePools.

## What does this PR do?

Adds an optional `inference_objective` field to `ModelGatewayConfig` (and `globalInferenceGateway`) so each gateway can specify the InferenceObjective CRD name for its InferencePool.

Resolution order: **per-gateway override > processor-level default > no header** (when both are empty).

This means operators can set a processor-level default for models that share a pool, and override only the ones that need a different pool — no need to repeat the same value on every entry.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [X] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #406