### PR TITLE
ci: add helm lint and unittest to PR workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,6 +28,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
       - name: Install Go tools (goimports, gosec, ruleguard)
         run: make install-pre-commit-tools
 
@@ -38,3 +41,6 @@ jobs:
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1
+
+      - name: Lint Helm chart
+        run: helm lint charts/batch-gateway

--- a/Makefile
+++ b/Makefile
@@ -233,8 +233,7 @@ install-pre-commit-tools:
 	$(GO) install github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.4.5
 	@if command -v helm >/dev/null 2>&1; then \
 		helm plugin list | grep -q unittest || \
-			helm plugin install https://github.com/helm-unittest/helm-unittest.git || \
-			helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest.git; \
+			helm plugin install --verify=false --version v1.0.3 https://github.com/helm-unittest/helm-unittest.git; \
 	else \
 		echo "helm not found, skipping helm-unittest plugin install"; \
 	fi


### PR DESCRIPTION
## Why is this PR needed?

The pre-commit workflow has a `helm-unittest` hook but it silently skips in CI because Helm is not installed before `pre-commit/action` runs. `helm lint` is not configured anywhere. This means broken Helm charts can be merged and published.

## What does this PR do?

- Install Helm and the helm-unittest plugin before pre-commit hooks run, so the existing hook actually executes
- Add an explicit `helm lint` step to catch chart issues before merge

## How was this tested?

- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)