### PR TITLE
feat: send x-batch-request header on inference requests

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -626,6 +626,7 @@ const (
 	sloTTFTMSHeader          = "x-slo-ttft-ms"
 	inferenceObjectiveHeader = "x-gateway-inference-objective"
 	fairnessIDHeader         = "x-gateway-inference-fairness-id"
+	batchRequestHeader       = "x-batch-request"
 )
 
 // mergeInferenceHeaders adds processor-managed headers to the outgoing inference request:
@@ -748,6 +749,10 @@ func (p *Processor) executeOneRequest(
 
 	headers := maps.Clone(passThroughHeaders)
 	headers = mergeInferenceHeaders(headers, sloCtx, p.cfg.InferenceObjectiveFor(modelID), fairnessID)
+	if headers == nil {
+		headers = make(map[string]string)
+	}
+	headers[batchRequestHeader] = "true"
 
 	inferReq := &inference.GenerateRequest{
 		RequestID: newBatchRequestID(requestID),

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -47,6 +47,9 @@ func TestExecuteOneRequest_Success(t *testing.T) {
 			if _, ok := req.Headers[sloTTFTMSHeader]; !ok {
 				t.Fatalf("expected %s header to be set", sloTTFTMSHeader)
 			}
+			if req.Headers[batchRequestHeader] != "true" {
+				t.Fatalf("expected %s header to be \"true\", got %q", batchRequestHeader, req.Headers[batchRequestHeader])
+			}
 			return &inference.GenerateResponse{
 				RequestID: "srv-123",
 				Response:  []byte(`{"result":"ok"}`),
@@ -591,6 +594,9 @@ func TestExecuteOneRequest_FairnessHeader(t *testing.T) {
 		}
 		if gotHeaders[fairnessIDHeader] != "tenant-x" {
 			t.Fatalf("fairness header: got %q, want %q", gotHeaders[fairnessIDHeader], "tenant-x")
+		}
+		if gotHeaders[batchRequestHeader] != "true" {
+			t.Fatalf("batch request header: got %q, want \"true\"", gotHeaders[batchRequestHeader])
 		}
 	})
 


### PR DESCRIPTION
## Why is this PR needed?

Downstream inference gateways currently have no way to distinguish batch traffic from real-time requests. This makes it difficult to apply differentiated policies (e.g. scheduling priority, rate limiting, resource allocation) based on request origin.

## What does this PR do?

Adds an unconditional `x-batch-request: true` header to every outgoing inference request from the batch processor. This allows downstream gateways to identify and handle batch traffic differently from real-time traffic.

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->