### PR TITLE
feat: support image digest references in helm chart

### DIFF
--- a/charts/batch-gateway/templates/_helpers.tpl
+++ b/charts/batch-gateway/templates/_helpers.tpl
@@ -121,8 +121,12 @@ API Server service account name
 API Server image string
 */}}
 {{- define "batch-gateway.apiserver.image" -}}
+{{- if .Values.apiserver.image.digest -}}
+{{- printf "%s@%s" .Values.apiserver.image.repository .Values.apiserver.image.digest }}
+{{- else -}}
 {{- $tag := .Values.apiserver.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s:%s" .Values.apiserver.image.repository $tag }}
+{{- end -}}
 {{- end }}
 
 {{/* ========== Processor Helpers ========== */}}
@@ -177,8 +181,12 @@ Processor service account name
 Processor image string
 */}}
 {{- define "batch-gateway.processor.image" -}}
+{{- if .Values.processor.image.digest -}}
+{{- printf "%s@%s" .Values.processor.image.repository .Values.processor.image.digest }}
+{{- else -}}
 {{- $tag := .Values.processor.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s:%s" .Values.processor.image.repository $tag }}
+{{- end -}}
 {{- end }}
 
 {{/* ========== Garbage Collector Helpers ========== */}}
@@ -228,6 +236,10 @@ GC service account name
 GC image string
 */}}
 {{- define "batch-gateway.gc.image" -}}
+{{- if .Values.gc.image.digest -}}
+{{- printf "%s@%s" .Values.gc.image.repository .Values.gc.image.digest }}
+{{- else -}}
 {{- $tag := .Values.gc.image.tag | default .Chart.AppVersion -}}
 {{- printf "%s:%s" .Values.gc.image.repository $tag }}
+{{- end -}}
 {{- end }}

--- a/charts/batch-gateway/tests/deployment_test.yaml
+++ b/charts/batch-gateway/tests/deployment_test.yaml
@@ -289,6 +289,60 @@ tests:
             name: POD_NAME
           any: true
 
+  # --- Image digest ---
+
+  - it: should use tag by default for all images
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^.+:.+$"
+        template: templates/apiserver-deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^.+:.+$"
+        template: templates/processor-deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^.+:.+$"
+        template: templates/gc-deployment.yaml
+
+  - it: should use digest when set for apiserver
+    set:
+      apiserver.image.digest: "sha256:abc123"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256:abc123"
+        template: templates/apiserver-deployment.yaml
+
+  - it: should use digest when set for processor
+    set:
+      processor.image.digest: "sha256:def456"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/llm-d-incubation/batch-gateway-processor@sha256:def456"
+        template: templates/processor-deployment.yaml
+
+  - it: should use digest when set for gc
+    set:
+      gc.image.digest: "sha256:789ghi"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/llm-d-incubation/batch-gateway-gc@sha256:789ghi"
+        template: templates/gc-deployment.yaml
+
+  - it: should prefer digest over tag when both are set
+    set:
+      apiserver.image.tag: "v1.0.0"
+      apiserver.image.digest: "sha256:abc123"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/llm-d-incubation/batch-gateway-apiserver@sha256:abc123"
+        template: templates/apiserver-deployment.yaml
+
   # --- Fail guards ---
 
   - it: should fail when fs pvcName is empty

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -103,6 +103,7 @@ apiserver:
     repository: ghcr.io/llm-d-incubation/batch-gateway-apiserver
     pullPolicy: Always
     tag: "latest"
+    digest: ""
 
   nameOverride: ""
   fullnameOverride: ""
@@ -240,6 +241,7 @@ processor:
     repository: ghcr.io/llm-d-incubation/batch-gateway-processor
     pullPolicy: Always
     tag: "latest"
+    digest: ""
 
   nameOverride: ""
   fullnameOverride: ""
@@ -428,6 +430,7 @@ gc:
     repository: ghcr.io/llm-d-incubation/batch-gateway-gc
     pullPolicy: IfNotPresent
     tag: "latest"
+    digest: ""
 
   serviceAccount:
     create: true


### PR DESCRIPTION
## Why is this PR needed?

The Helm chart image helpers always join repo and tag with `:`, which cannot produce `repo@sha256:digest` references. This breaks digest-pinned image deployments.

Fixes https://github.com/opendatahub-io/llm-d-batch-gateway-operator/issues/3

## What does this PR do?

- Adds `digest` field to all three component image configs (apiserver, processor, gc) in `values.yaml`
- Adds Helm unit tests for digest support

## How was this tested?

- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes https://github.com/opendatahub-io/llm-d-batch-gateway-operator/issues/3