### PR TITLE
fix(e2e): make cancel-in-progress test deterministic

### DIFF
--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -1255,6 +1255,7 @@ func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
 	}
 	if counts == nil {
 		t.Fatal("expected non-nil counts")
+		return
 	}
 	if counts.Total != 1 || counts.Completed != 1 {
 		t.Fatalf("counts = {Total:%d, Completed:%d, Failed:%d}, want {1,1,0}",

--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -86,8 +86,10 @@ func doTestBatchCancel(t *testing.T) {
 	// Wait for the processor to pick up the batch and start inference.
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 
-	// Give fast requests time to complete before cancelling.
-	time.Sleep(2 * time.Second)
+	// Wait for at least one fast request to complete before cancelling.
+	// This replaces a fixed sleep, making the test deterministic regardless
+	// of request-path latency (e.g. with GIE: processor → Envoy → EPP → vllm-sim).
+	waitForCompletedRequests(t, batchID, 1, 2*time.Minute)
 
 	// Cancel the batch while slow requests are still in-flight.
 	batch, err := newClient().Batches.Cancel(context.Background(), batchID)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -245,6 +245,37 @@ func waitForBatchStatus(t *testing.T, batchID string, timeout time.Duration, tar
 	return nil, nil // unreachable
 }
 
+// waitForCompletedRequests polls a batch until at least minCompleted requests
+// have completed. This is used instead of a fixed sleep to make tests
+// deterministic regardless of request-path latency.
+func waitForCompletedRequests(t *testing.T, batchID string, minCompleted int64, timeout time.Duration) {
+	t.Helper()
+
+	client := newClient()
+	const pollInterval = 500 * time.Millisecond
+
+	deadline := time.Now().Add(timeout)
+	if d, ok := t.Deadline(); ok && d.Before(deadline) {
+		deadline = d.Add(-5 * time.Second)
+	}
+	for time.Now().Before(deadline) {
+		b, err := client.Batches.Get(context.Background(), batchID)
+		if err != nil {
+			t.Fatalf("retrieve batch failed: %v", err)
+		}
+		if b.RequestCounts.Completed >= minCompleted {
+			t.Logf("batch %s has %d completed request(s), proceeding", batchID, b.RequestCounts.Completed)
+			return
+		}
+		if terminalBatchStatuses[b.Status] {
+			t.Fatalf("batch %s reached terminal status %q with only %d completed (need %d)",
+				batchID, b.Status, b.RequestCounts.Completed, minCompleted)
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Fatalf("batch %s did not reach %d completed requests within %v", batchID, minCompleted, timeout)
+}
+
 // waitForIngestionFailure polls a batch until it reaches "failed" status.
 // Unlike waitForBatchStatus, it skips validateBatchResults (which rejects
 // Total==0 for non-cancelled batches) and result-file fetching, since


### PR DESCRIPTION
## Summary

- Replaces the fixed `time.Sleep(2s)` in `doTestBatchCancel` with a poll (`waitForCompletedRequests`) that waits for at least one request to complete before issuing the cancel.
- Adds `waitForCompletedRequests` helper to `helpers_test.go` — polls batch status until `completed >= minCompleted`, with deadline awareness and terminal-status detection.
- Fixes the GIE-only flake: the extra latency from `processor → Envoy → EPP → vllm-sim` meant fast requests didn't complete within the 2s window, causing `completed=0, failed=25`.

Fixes #418

## Test plan

- [x] GIE e2e variant (`s3, postgresql, redis, gie`) passes `TestE2E/Batches/Cancel/InProgress`
- [x] Non-GIE e2e variants continue to pass (no behavioral change — the poll resolves faster than the old 2s sleep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)