### PR TITLE
chore: add AIMD to typos false positives

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -18,5 +18,6 @@ goimports = "goimports"
 # Go linter
 golangci = "golangci"
 
-# Add repo-specific false positives here:
-# word = "word"
+# Additive Increase Multiplicative Decrease (congestion control algorithm)
+AIMD = "AIMD"
+aimd = "aimd"


### PR DESCRIPTION
## Why is this PR needed?

The nightly typo scanner (#426) flags `AIMD` as a misspelling of `aimed`. AIMD (Additive Increase Multiplicative Decrease) is a well-known congestion control algorithm used throughout the batch processor — not a typo.

## What does this PR do?

Adds `AIMD`/`aimd` to `_typos.toml` as known words.

## How was this tested?

- [x] Verified `_typos.toml` syntax

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)

## Related Issues

Fixes #426