### PR TITLE
feat: add async dispatch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin/
 .vscode
 .claude
+.cursor

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -358,24 +358,6 @@ func (c *ProcessorConfig) Validate() error {
 		return fmt.Errorf("e2e_latency_bucket must satisfy: start > 0, factor > 1, count > 0")
 	}
 
-	if c.GlobalInferenceGateway == nil && len(c.ModelGateways) == 0 {
-		return fmt.Errorf("either global_inference_gateway or model_gateways must be configured")
-	}
-	if c.GlobalInferenceGateway != nil && len(c.ModelGateways) > 0 {
-		return fmt.Errorf("global_inference_gateway and model_gateways are mutually exclusive")
-	}
-
-	if c.GlobalInferenceGateway != nil {
-		if err := validateGatewayConfig("global_inference_gateway", *c.GlobalInferenceGateway); err != nil {
-			return err
-		}
-	}
-	for model, gw := range c.ModelGateways {
-		if err := validateGatewayConfig(fmt.Sprintf("model_gateways[%s]", model), gw); err != nil {
-			return err
-		}
-	}
-
 	if err := c.FileClientCfg.Retry.Validate(); err != nil {
 		return fmt.Errorf("file_client.retry: %w", err)
 	}
@@ -394,12 +376,34 @@ func (c *ProcessorConfig) Validate() error {
 func (c *ProcessorConfig) validateDispatchMode() error {
 	switch c.DispatchMode {
 	case DispatchModeSync, DispatchMode(""):
-		return nil
+		c.DispatchMode = DispatchModeSync
+		return c.validateSyncConfig()
 	case DispatchModeAsync:
 		return c.AsyncConfig.validate()
 	default:
 		return fmt.Errorf("dispatch_mode must be %q or %q, got %q", DispatchModeSync, DispatchModeAsync, c.DispatchMode)
 	}
+}
+
+func (c *ProcessorConfig) validateSyncConfig() error {
+	if c.GlobalInferenceGateway == nil && len(c.ModelGateways) == 0 {
+		return fmt.Errorf("either global_inference_gateway or model_gateways must be configured")
+	}
+	if c.GlobalInferenceGateway != nil && len(c.ModelGateways) > 0 {
+		return fmt.Errorf("global_inference_gateway and model_gateways are mutually exclusive")
+	}
+
+	if c.GlobalInferenceGateway != nil {
+		if err := validateGatewayConfig("global_inference_gateway", *c.GlobalInferenceGateway); err != nil {
+			return err
+		}
+	}
+	for model, gw := range c.ModelGateways {
+		if err := validateGatewayConfig(fmt.Sprintf("model_gateways[%s]", model), gw); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (ac *AsyncDispatchConfig) validate() error {

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -73,18 +73,21 @@ type AIMDConfig struct {
 	AdditiveIncrease int `yaml:"additive_increase"`
 }
 
-// DispatchMode constants control which inference dispatch backend is used.
+// DispatchMode selects the inference dispatch backend.
+type DispatchMode string
+
 const (
-	DispatchModeSync  = "sync"
-	DispatchModeAsync = "async"
+	DispatchModeSync  DispatchMode = "sync"
+	DispatchModeAsync DispatchMode = "async"
 )
 
 // AsyncDispatchConfig holds configuration for the llm-d-async dispatch backend.
 // Only used when DispatchMode == "async".
 type AsyncDispatchConfig struct {
 	// RedisURL is the full Redis connection URL (e.g. "redis://host:6379",
-	// "rediss://user:pass@host:6379" for TLS). TLS is encoded in the URL scheme.
-	RedisURL string `yaml:"redis_url"`
+	// "rediss://user:pass@host:6379" for TLS). Read from the mounted secret
+	// at runtime (SecretKeyRedisURL)
+	RedisURL string `yaml:"-"`
 
 	// RequestQueueName is the Redis sorted-set name for request submission.
 	// Must match the llm-d-async processor's --redis.ss.request-queue-name.
@@ -97,11 +100,6 @@ type AsyncDispatchConfig struct {
 	// ResultPollTimeout is the timeout per GetResult poll cycle.
 	// Controls how long each blocking poll waits before retrying.
 	ResultPollTimeout time.Duration `yaml:"result_poll_timeout"`
-
-	// PerRequestTimeout is the maximum time to wait for a single request's
-	// result before marking it as failed. Should be significantly larger than
-	// expected inference latency to avoid false positives.
-	PerRequestTimeout time.Duration `yaml:"per_request_timeout"`
 }
 
 type ProcessorConfig struct {
@@ -180,7 +178,7 @@ type ProcessorConfig struct {
 	// DispatchMode selects the inference dispatch backend.
 	// "sync" (default): direct HTTP via InferenceClient.
 	// "async": submit via llm-d-async producer, collect from result queue.
-	DispatchMode string `yaml:"dispatch_mode"`
+	DispatchMode DispatchMode `yaml:"dispatch_mode"`
 
 	// AsyncConfig holds llm-d-async dispatch settings. Only used when DispatchMode == "async".
 	AsyncConfig AsyncDispatchConfig `yaml:"async"`
@@ -318,7 +316,6 @@ func NewConfig() *ProcessorConfig {
 		DispatchMode: DispatchModeSync,
 		AsyncConfig: AsyncDispatchConfig{
 			ResultPollTimeout: 5 * time.Second,
-			PerRequestTimeout: 60 * time.Minute,
 		},
 	}
 }
@@ -396,7 +393,7 @@ func (c *ProcessorConfig) Validate() error {
 
 func (c *ProcessorConfig) validateDispatchMode() error {
 	switch c.DispatchMode {
-	case DispatchModeSync, "":
+	case DispatchModeSync, DispatchMode(""):
 		return nil
 	case DispatchModeAsync:
 		return c.AsyncConfig.validate()
@@ -406,9 +403,6 @@ func (c *ProcessorConfig) validateDispatchMode() error {
 }
 
 func (ac *AsyncDispatchConfig) validate() error {
-	if ac.RedisURL == "" {
-		return fmt.Errorf("async.redis_url must be set when dispatch_mode is %q", DispatchModeAsync)
-	}
 	if ac.RequestQueueName == "" {
 		return fmt.Errorf("async.request_queue_name must be set when dispatch_mode is %q", DispatchModeAsync)
 	}
@@ -417,13 +411,6 @@ func (ac *AsyncDispatchConfig) validate() error {
 	}
 	if ac.ResultPollTimeout <= 0 {
 		return fmt.Errorf("async.result_poll_timeout must be > 0")
-	}
-	if ac.PerRequestTimeout <= 0 {
-		return fmt.Errorf("async.per_request_timeout must be > 0")
-	}
-	if ac.PerRequestTimeout <= ac.ResultPollTimeout {
-		return fmt.Errorf("async.per_request_timeout (%v) must be > async.result_poll_timeout (%v)",
-			ac.PerRequestTimeout, ac.ResultPollTimeout)
 	}
 	return nil
 }

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -73,6 +73,37 @@ type AIMDConfig struct {
 	AdditiveIncrease int `yaml:"additive_increase"`
 }
 
+// DispatchMode constants control which inference dispatch backend is used.
+const (
+	DispatchModeSync  = "sync"
+	DispatchModeAsync = "async"
+)
+
+// AsyncDispatchConfig holds configuration for the llm-d-async dispatch backend.
+// Only used when DispatchMode == "async".
+type AsyncDispatchConfig struct {
+	// RedisURL is the full Redis connection URL (e.g. "redis://host:6379",
+	// "rediss://user:pass@host:6379" for TLS). TLS is encoded in the URL scheme.
+	RedisURL string `yaml:"redis_url"`
+
+	// RequestQueueName is the Redis sorted-set name for request submission.
+	// Must match the llm-d-async processor's --redis.ss.request-queue-name.
+	RequestQueueName string `yaml:"request_queue_name"`
+
+	// ResultQueueName is the Redis list name for result collection.
+	// Must match the llm-d-async processor's --redis.ss.result-queue-name.
+	ResultQueueName string `yaml:"result_queue_name"`
+
+	// ResultPollTimeout is the timeout per GetResult poll cycle.
+	// Controls how long each blocking poll waits before retrying.
+	ResultPollTimeout time.Duration `yaml:"result_poll_timeout"`
+
+	// PerRequestTimeout is the maximum time to wait for a single request's
+	// result before marking it as failed. Should be significantly larger than
+	// expected inference latency to avoid false positives.
+	PerRequestTimeout time.Duration `yaml:"per_request_timeout"`
+}
+
 type ProcessorConfig struct {
 	// TaskWaitTime is the timeout parameter used when dequeueing from the priority queue
 	// This should be shorter than PollInterval
@@ -145,6 +176,14 @@ type ProcessorConfig struct {
 
 	// FileClient holds configuration for the shared file storage client (fs or s3).
 	FileClientCfg sharedcfg.FileClientConfig `yaml:"file_client"`
+
+	// DispatchMode selects the inference dispatch backend.
+	// "sync" (default): direct HTTP via InferenceClient.
+	// "async": submit via llm-d-async producer, collect from result queue.
+	DispatchMode string `yaml:"dispatch_mode"`
+
+	// AsyncConfig holds llm-d-async dispatch settings. Only used when DispatchMode == "async".
+	AsyncConfig AsyncDispatchConfig `yaml:"async"`
 }
 
 // ModelGatewayConfig describes the full gateway and HTTP/TLS settings for one
@@ -187,6 +226,11 @@ type BucketConfig struct {
 	BucketStart  float64 `yaml:"start"`
 	BucketFactor float64 `yaml:"factor"`
 	BucketCount  int     `yaml:"count"`
+}
+
+// IsAsync returns true when the processor is configured for async dispatch.
+func (c *ProcessorConfig) IsAsync() bool {
+	return c.DispatchMode == DispatchModeAsync
 }
 
 // InferenceObjectiveFor returns the inference objective configured on the
@@ -270,6 +314,12 @@ func NewConfig() *ProcessorConfig {
 		},
 		DefaultOutputExpirationSeconds: 90 * 24 * 60 * 60, // 90 days
 		ProgressTTLSeconds:             24 * 60 * 60,      // 24 hours
+
+		DispatchMode: DispatchModeSync,
+		AsyncConfig: AsyncDispatchConfig{
+			ResultPollTimeout: 5 * time.Second,
+			PerRequestTimeout: 60 * time.Minute,
+		},
 	}
 }
 
@@ -337,6 +387,44 @@ func (c *ProcessorConfig) Validate() error {
 		return fmt.Errorf("progress_ttl_seconds must be > 0")
 	}
 
+	if err := c.validateDispatchMode(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *ProcessorConfig) validateDispatchMode() error {
+	switch c.DispatchMode {
+	case DispatchModeSync, "":
+		return nil
+	case DispatchModeAsync:
+		return c.AsyncConfig.validate()
+	default:
+		return fmt.Errorf("dispatch_mode must be %q or %q, got %q", DispatchModeSync, DispatchModeAsync, c.DispatchMode)
+	}
+}
+
+func (ac *AsyncDispatchConfig) validate() error {
+	if ac.RedisURL == "" {
+		return fmt.Errorf("async.redis_url must be set when dispatch_mode is %q", DispatchModeAsync)
+	}
+	if ac.RequestQueueName == "" {
+		return fmt.Errorf("async.request_queue_name must be set when dispatch_mode is %q", DispatchModeAsync)
+	}
+	if ac.ResultQueueName == "" {
+		return fmt.Errorf("async.result_queue_name must be set when dispatch_mode is %q", DispatchModeAsync)
+	}
+	if ac.ResultPollTimeout <= 0 {
+		return fmt.Errorf("async.result_poll_timeout must be > 0")
+	}
+	if ac.PerRequestTimeout <= 0 {
+		return fmt.Errorf("async.per_request_timeout must be > 0")
+	}
+	if ac.PerRequestTimeout <= ac.ResultPollTimeout {
+		return fmt.Errorf("async.per_request_timeout (%v) must be > async.result_poll_timeout (%v)",
+			ac.PerRequestTimeout, ac.ResultPollTimeout)
+	}
 	return nil
 }
 

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -226,12 +226,12 @@ const asyncTenantID = "$batch"
 
 // RequestQueueName returns the Redis sorted-set name for submitting async requests to the given pool.
 func RequestQueueName(poolName string) string {
-	return "requests:" + poolName
+	return "llm-d-async:requests:" + poolName
 }
 
 // ResultQueueName returns the Redis list name for collecting async results from the given pool.
 func ResultQueueName(poolName string) string {
-	return "results:" + asyncTenantID + ":" + poolName
+	return "llm-d-async:results:" + asyncTenantID + ":" + poolName
 }
 
 // IsAsync returns true when the processor is configured for async dispatch.

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -172,8 +172,8 @@ type ProcessorConfig struct {
 	// "async": submit via llm-d-async producer, collect from result queue.
 	DispatchMode DispatchMode `yaml:"dispatch_mode"`
 
-	// AsyncConfig holds llm-d-async dispatch settings. Only used when DispatchMode == "async".
-	AsyncConfig AsyncDispatchConfig `yaml:"async"`
+	// AsyncDispatchConfig holds llm-d-async dispatch settings. Only used when DispatchMode == "async".
+	AsyncDispatchConfig AsyncDispatchConfig `yaml:"async_dispatch"`
 }
 
 // ModelGatewayConfig describes the full gateway and HTTP/TLS settings for one
@@ -211,10 +211,9 @@ type ModelGatewayConfig struct {
 	TLSClientCertFile     string `yaml:"tls_client_cert_file,omitempty"`
 	TLSClientKeyFile      string `yaml:"tls_client_key_file,omitempty"`
 
-	// PoolName identifies the async dispatch pool for this model/gateway.
-	// Queue names are derived as "requests:{PoolName}" / "results:{tenant}:{PoolName}".
+	// InferencePoolName identifies the async dispatch pool for this model/gateway.
 	// Required when dispatch_mode is "async". Ignored in sync mode.
-	PoolName string `yaml:"pool_name"`
+	InferencePoolName string `yaml:"inference_pool_name"`
 }
 
 type BucketConfig struct {
@@ -323,7 +322,7 @@ func NewConfig() *ProcessorConfig {
 		ProgressTTLSeconds:             24 * 60 * 60,      // 24 hours
 
 		DispatchMode: DispatchModeSync,
-		AsyncConfig: AsyncDispatchConfig{
+		AsyncDispatchConfig: AsyncDispatchConfig{
 			ResultPollTimeout: 5 * time.Second,
 		},
 	}
@@ -386,9 +385,9 @@ func (c *ProcessorConfig) validateDispatchMode() error {
 	switch c.DispatchMode {
 	case DispatchModeSync, DispatchMode(""):
 		c.DispatchMode = DispatchModeSync
-		return c.validateSyncConfig()
+		return c.validateSyncDispatchConfig()
 	case DispatchModeAsync:
-		return c.validateAsyncConfig()
+		return c.validateAsyncDispatchConfig()
 	default:
 		return fmt.Errorf("dispatch_mode must be %q or %q, got %q", DispatchModeSync, DispatchModeAsync, c.DispatchMode)
 	}
@@ -404,7 +403,7 @@ func (c *ProcessorConfig) validateGateways() error {
 	return nil
 }
 
-func (c *ProcessorConfig) validateSyncConfig() error {
+func (c *ProcessorConfig) validateSyncDispatchConfig() error {
 	if err := c.validateGateways(); err != nil {
 		return err
 	}
@@ -422,21 +421,21 @@ func (c *ProcessorConfig) validateSyncConfig() error {
 	return nil
 }
 
-func (c *ProcessorConfig) validateAsyncConfig() error {
-	if c.AsyncConfig.ResultPollTimeout <= 0 {
+func (c *ProcessorConfig) validateAsyncDispatchConfig() error {
+	if c.AsyncDispatchConfig.ResultPollTimeout <= 0 {
 		return fmt.Errorf("async.result_poll_timeout must be > 0")
 	}
 	if err := c.validateGateways(); err != nil {
 		return err
 	}
 	if c.GlobalInferenceGateway != nil {
-		if c.GlobalInferenceGateway.PoolName == "" {
-			return fmt.Errorf("global_inference_gateway.pool_name must be set when dispatch_mode is %q", DispatchModeAsync)
+		if c.GlobalInferenceGateway.InferencePoolName == "" {
+			return fmt.Errorf("global_inference_gateway.inference_pool_name must be set when dispatch_mode is %q", DispatchModeAsync)
 		}
 	}
 	for model, gw := range c.ModelGateways {
-		if gw.PoolName == "" {
-			return fmt.Errorf("model_gateways[%s].pool_name must be set when dispatch_mode is %q", model, DispatchModeAsync)
+		if gw.InferencePoolName == "" {
+			return fmt.Errorf("model_gateways[%s].inference_pool_name must be set when dispatch_mode is %q", model, DispatchModeAsync)
 		}
 	}
 	return nil

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -89,14 +89,6 @@ type AsyncDispatchConfig struct {
 	// at runtime (SecretKeyRedisURL)
 	RedisURL string `yaml:"-"`
 
-	// RequestQueueName is the Redis sorted-set name for request submission.
-	// Must match the llm-d-async processor's --redis.ss.request-queue-name.
-	RequestQueueName string `yaml:"request_queue_name"`
-
-	// ResultQueueName is the Redis list name for result collection.
-	// Must match the llm-d-async processor's --redis.ss.result-queue-name.
-	ResultQueueName string `yaml:"result_queue_name"`
-
 	// ResultPollTimeout is the timeout per GetResult poll cycle.
 	// Controls how long each blocking poll waits before retrying.
 	ResultPollTimeout time.Duration `yaml:"result_poll_timeout"`
@@ -218,12 +210,29 @@ type ModelGatewayConfig struct {
 	TLSCACertFile         string `yaml:"tls_ca_cert_file,omitempty"`
 	TLSClientCertFile     string `yaml:"tls_client_cert_file,omitempty"`
 	TLSClientKeyFile      string `yaml:"tls_client_key_file,omitempty"`
+
+	// PoolName identifies the async dispatch pool for this model/gateway.
+	// Queue names are derived as "request:{PoolName}" / "result:{PoolName}".
+	// Required when dispatch_mode is "async". Ignored in sync mode.
+	PoolName string `yaml:"pool_name"`
 }
 
 type BucketConfig struct {
 	BucketStart  float64 `yaml:"start"`
 	BucketFactor float64 `yaml:"factor"`
 	BucketCount  int     `yaml:"count"`
+}
+
+const asyncTenantID = "batch-gateway"
+
+// RequestQueueName returns the Redis sorted-set name for submitting async requests to the given pool.
+func RequestQueueName(poolName string) string {
+	return "request:" + poolName
+}
+
+// ResultQueueName returns the Redis list name for collecting async results from the given pool.
+func ResultQueueName(poolName string) string {
+	return "result:" + asyncTenantID + ":" + poolName
 }
 
 // IsAsync returns true when the processor is configured for async dispatch.
@@ -379,18 +388,25 @@ func (c *ProcessorConfig) validateDispatchMode() error {
 		c.DispatchMode = DispatchModeSync
 		return c.validateSyncConfig()
 	case DispatchModeAsync:
-		return c.AsyncConfig.validate()
+		return c.validateAsyncConfig()
 	default:
 		return fmt.Errorf("dispatch_mode must be %q or %q, got %q", DispatchModeSync, DispatchModeAsync, c.DispatchMode)
 	}
 }
 
-func (c *ProcessorConfig) validateSyncConfig() error {
+func (c *ProcessorConfig) validateGateways() error {
 	if c.GlobalInferenceGateway == nil && len(c.ModelGateways) == 0 {
 		return fmt.Errorf("either global_inference_gateway or model_gateways must be configured")
 	}
 	if c.GlobalInferenceGateway != nil && len(c.ModelGateways) > 0 {
 		return fmt.Errorf("global_inference_gateway and model_gateways are mutually exclusive")
+	}
+	return nil
+}
+
+func (c *ProcessorConfig) validateSyncConfig() error {
+	if err := c.validateGateways(); err != nil {
+		return err
 	}
 
 	if c.GlobalInferenceGateway != nil {
@@ -406,15 +422,22 @@ func (c *ProcessorConfig) validateSyncConfig() error {
 	return nil
 }
 
-func (ac *AsyncDispatchConfig) validate() error {
-	if ac.RequestQueueName == "" {
-		return fmt.Errorf("async.request_queue_name must be set when dispatch_mode is %q", DispatchModeAsync)
-	}
-	if ac.ResultQueueName == "" {
-		return fmt.Errorf("async.result_queue_name must be set when dispatch_mode is %q", DispatchModeAsync)
-	}
-	if ac.ResultPollTimeout <= 0 {
+func (c *ProcessorConfig) validateAsyncConfig() error {
+	if c.AsyncConfig.ResultPollTimeout <= 0 {
 		return fmt.Errorf("async.result_poll_timeout must be > 0")
+	}
+	if err := c.validateGateways(); err != nil {
+		return err
+	}
+	if c.GlobalInferenceGateway != nil {
+		if c.GlobalInferenceGateway.PoolName == "" {
+			return fmt.Errorf("global_inference_gateway.pool_name must be set when dispatch_mode is %q", DispatchModeAsync)
+		}
+	}
+	for model, gw := range c.ModelGateways {
+		if gw.PoolName == "" {
+			return fmt.Errorf("model_gateways[%s].pool_name must be set when dispatch_mode is %q", model, DispatchModeAsync)
+		}
 	}
 	return nil
 }

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -231,7 +231,7 @@ func RequestQueueName(poolName string) string {
 
 // ResultQueueName returns the Redis list name for collecting async results from the given pool.
 func ResultQueueName(poolName string) string {
-	return "llm-d-async:results:" + asyncTenantID + ":" + poolName
+	return "llm-d-async:results:" + poolName + ":" + asyncTenantID
 }
 
 // IsAsync returns true when the processor is configured for async dispatch.

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -212,7 +212,7 @@ type ModelGatewayConfig struct {
 	TLSClientKeyFile      string `yaml:"tls_client_key_file,omitempty"`
 
 	// PoolName identifies the async dispatch pool for this model/gateway.
-	// Queue names are derived as "request:{PoolName}" / "result:{PoolName}".
+	// Queue names are derived as "requests:{PoolName}" / "results:{tenant}:{PoolName}".
 	// Required when dispatch_mode is "async". Ignored in sync mode.
 	PoolName string `yaml:"pool_name"`
 }
@@ -223,16 +223,16 @@ type BucketConfig struct {
 	BucketCount  int     `yaml:"count"`
 }
 
-const asyncTenantID = "batch-gateway"
+const asyncTenantID = "$batch"
 
 // RequestQueueName returns the Redis sorted-set name for submitting async requests to the given pool.
 func RequestQueueName(poolName string) string {
-	return "request:" + poolName
+	return "requests:" + poolName
 }
 
 // ResultQueueName returns the Redis list name for collecting async results from the given pool.
 func ResultQueueName(poolName string) string {
-	return "result:" + asyncTenantID + ":" + poolName
+	return "results:" + asyncTenantID + ":" + poolName
 }
 
 // IsAsync returns true when the processor is configured for async dispatch.

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -100,8 +100,8 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if c.DispatchMode != DispatchModeSync {
 		t.Fatalf("DispatchMode = %q, want %q", c.DispatchMode, DispatchModeSync)
 	}
-	if c.AsyncConfig.ResultPollTimeout != 5*time.Second {
-		t.Fatalf("AsyncConfig.ResultPollTimeout = %v, want %v", c.AsyncConfig.ResultPollTimeout, 5*time.Second)
+	if c.AsyncDispatchConfig.ResultPollTimeout != 5*time.Second {
+		t.Fatalf("AsyncDispatchConfig.ResultPollTimeout = %v, want %v", c.AsyncDispatchConfig.ResultPollTimeout, 5*time.Second)
 	}
 }
 
@@ -646,16 +646,16 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		c := NewConfig()
 		c.ModelGateways = map[string]ModelGatewayConfig{
 			"llama-3": {
-				URL:            "http://llama-gw:8000",
-				RequestTimeout: ptr.To(5 * time.Minute),
-				MaxRetries:     ptr.To(3),
-				InitialBackoff: ptr.To(1 * time.Second),
-				MaxBackoff:     ptr.To(60 * time.Second),
-				PoolName:       "pool-a",
+				URL:               "http://llama-gw:8000",
+				RequestTimeout:    ptr.To(5 * time.Minute),
+				MaxRetries:        ptr.To(3),
+				InitialBackoff:    ptr.To(1 * time.Second),
+				MaxBackoff:        ptr.To(60 * time.Second),
+				InferencePoolName: "pool-a",
 			},
 		}
 		c.DispatchMode = DispatchModeAsync
-		c.AsyncConfig = AsyncDispatchConfig{
+		c.AsyncDispatchConfig = AsyncDispatchConfig{
 			ResultPollTimeout: 5 * time.Second,
 		}
 		return c
@@ -672,13 +672,19 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "sync mode ignores async fields",
-			mutate:  func(c *ProcessorConfig) { c.DispatchMode = DispatchModeSync; c.AsyncConfig = AsyncDispatchConfig{} },
+			name: "sync mode ignores async fields",
+			mutate: func(c *ProcessorConfig) {
+				c.DispatchMode = DispatchModeSync
+				c.AsyncDispatchConfig = AsyncDispatchConfig{}
+			},
 			wantErr: false,
 		},
 		{
-			name:    "empty dispatch_mode treated as sync",
-			mutate:  func(c *ProcessorConfig) { c.DispatchMode = DispatchMode(""); c.AsyncConfig = AsyncDispatchConfig{} },
+			name: "empty dispatch_mode treated as sync",
+			mutate: func(c *ProcessorConfig) {
+				c.DispatchMode = DispatchMode("")
+				c.AsyncDispatchConfig = AsyncDispatchConfig{}
+			},
 			wantErr: false,
 		},
 		{
@@ -688,11 +694,11 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		},
 		{
 			name:    "async zero result_poll_timeout",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = 0 },
+			mutate:  func(c *ProcessorConfig) { c.AsyncDispatchConfig.ResultPollTimeout = 0 },
 			wantErr: true,
 		},
 		{
-			name: "async missing pool_name on model gateway",
+			name: "async missing inference_pool_name on model gateway",
 			mutate: func(c *ProcessorConfig) {
 				c.ModelGateways = map[string]ModelGatewayConfig{
 					"llama-3": {URL: "http://llama-gw:8000"},
@@ -701,7 +707,7 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "async missing pool_name on global gateway",
+			name: "async missing inference_pool_name on global gateway",
 			mutate: func(c *ProcessorConfig) {
 				c.ModelGateways = nil
 				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000"}
@@ -709,10 +715,10 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "async valid global gateway with pool_name",
+			name: "async valid global gateway with inference_pool_name",
 			mutate: func(c *ProcessorConfig) {
 				c.ModelGateways = nil
-				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", PoolName: "default-pool"}
+				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", InferencePoolName: "default-pool"}
 			},
 			wantErr: false,
 		},
@@ -727,12 +733,12 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		{
 			name: "async global and per-model mutually exclusive",
 			mutate: func(c *ProcessorConfig) {
-				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", PoolName: "default-pool"}
+				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", InferencePoolName: "default-pool"}
 			},
 			wantErr: true,
 		},
 		{
-			name: "pool_name ignored in sync mode",
+			name: "inference_pool_name ignored in sync mode",
 			mutate: func(c *ProcessorConfig) {
 				c.DispatchMode = DispatchModeSync
 				c.ModelGateways = validPerModelConfig()
@@ -741,24 +747,24 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		},
 		{
 			name:    "async negative result_poll_timeout",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = -1 * time.Second },
+			mutate:  func(c *ProcessorConfig) { c.AsyncDispatchConfig.ResultPollTimeout = -1 * time.Second },
 			wantErr: true,
 		},
 		{
 			name: "async multiple models all valid",
 			mutate: func(c *ProcessorConfig) {
 				c.ModelGateways = map[string]ModelGatewayConfig{
-					"llama-3": {URL: "http://gw-a:8000", PoolName: "pool-a"},
-					"mistral": {URL: "http://gw-b:8000", PoolName: "pool-b"},
+					"llama-3": {URL: "http://gw-a:8000", InferencePoolName: "pool-a"},
+					"mistral": {URL: "http://gw-b:8000", InferencePoolName: "pool-b"},
 				}
 			},
 			wantErr: false,
 		},
 		{
-			name: "async one model missing pool_name among multiple",
+			name: "async one model missing inference_pool_name among multiple",
 			mutate: func(c *ProcessorConfig) {
 				c.ModelGateways = map[string]ModelGatewayConfig{
-					"llama-3": {URL: "http://gw-a:8000", PoolName: "pool-a"},
+					"llama-3": {URL: "http://gw-a:8000", InferencePoolName: "pool-a"},
 					"mistral": {URL: "http://gw-b:8000"},
 				}
 			},

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -103,9 +103,6 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if c.AsyncConfig.ResultPollTimeout != 5*time.Second {
 		t.Fatalf("AsyncConfig.ResultPollTimeout = %v, want %v", c.AsyncConfig.ResultPollTimeout, 5*time.Second)
 	}
-	if c.AsyncConfig.PerRequestTimeout != 60*time.Minute {
-		t.Fatalf("AsyncConfig.PerRequestTimeout = %v, want %v", c.AsyncConfig.PerRequestTimeout, 60*time.Minute)
-	}
 }
 
 func TestProcessorConfig_Validate_WorkDirEmpty(t *testing.T) {
@@ -650,11 +647,9 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		c.ModelGateways = validPerModelConfig()
 		c.DispatchMode = DispatchModeAsync
 		c.AsyncConfig = AsyncDispatchConfig{
-			RedisURL:          "redis://localhost:6379",
 			RequestQueueName:  "requests",
 			ResultQueueName:   "results",
 			ResultPollTimeout: 5 * time.Second,
-			PerRequestTimeout: 60 * time.Minute,
 		}
 		return c
 	}
@@ -676,17 +671,12 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 		},
 		{
 			name:    "empty dispatch_mode treated as sync",
-			mutate:  func(c *ProcessorConfig) { c.DispatchMode = ""; c.AsyncConfig = AsyncDispatchConfig{} },
+			mutate:  func(c *ProcessorConfig) { c.DispatchMode = DispatchMode(""); c.AsyncConfig = AsyncDispatchConfig{} },
 			wantErr: false,
 		},
 		{
 			name:    "invalid dispatch_mode rejected",
-			mutate:  func(c *ProcessorConfig) { c.DispatchMode = "invalid" },
-			wantErr: true,
-		},
-		{
-			name:    "async missing redis_url",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RedisURL = "" },
+			mutate:  func(c *ProcessorConfig) { c.DispatchMode = DispatchMode("invalid") },
 			wantErr: true,
 		},
 		{
@@ -703,32 +693,6 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 			name:    "async zero result_poll_timeout",
 			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = 0 },
 			wantErr: true,
-		},
-		{
-			name:    "async zero per_request_timeout",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.PerRequestTimeout = 0 },
-			wantErr: true,
-		},
-		{
-			name: "async per_request_timeout must exceed result_poll_timeout",
-			mutate: func(c *ProcessorConfig) {
-				c.AsyncConfig.ResultPollTimeout = 10 * time.Minute
-				c.AsyncConfig.PerRequestTimeout = 5 * time.Minute
-			},
-			wantErr: true,
-		},
-		{
-			name: "async per_request_timeout equal to result_poll_timeout rejected",
-			mutate: func(c *ProcessorConfig) {
-				c.AsyncConfig.ResultPollTimeout = 5 * time.Second
-				c.AsyncConfig.PerRequestTimeout = 5 * time.Second
-			},
-			wantErr: true,
-		},
-		{
-			name:    "async with rediss URL for TLS",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RedisURL = "rediss://user:pass@host:6380" },
-			wantErr: false,
 		},
 	}
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -779,11 +779,11 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 }
 
 func TestQueueNameHelpers(t *testing.T) {
-	if got := RequestQueueName("pool-a"); got != "request:pool-a" {
-		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "request:pool-a")
+	if got := RequestQueueName("pool-a"); got != "requests:pool-a" {
+		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "requests:pool-a")
 	}
-	if got := ResultQueueName("pool-a"); got != "result:batch-gateway:pool-a" {
-		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "result:batch-gateway:pool-a")
+	if got := ResultQueueName("pool-a"); got != "results:$batch:pool-a" {
+		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "results:$batch:pool-a")
 	}
 }
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -788,8 +788,8 @@ func TestQueueNameHelpers(t *testing.T) {
 	if got := RequestQueueName("pool-a"); got != "llm-d-async:requests:pool-a" {
 		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "llm-d-async:requests:pool-a")
 	}
-	if got := ResultQueueName("pool-a"); got != "llm-d-async:results:$batch:pool-a" {
-		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "llm-d-async:results:$batch:pool-a")
+	if got := ResultQueueName("pool-a"); got != "llm-d-async:results:pool-a:$batch" {
+		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "llm-d-async:results:pool-a:$batch")
 	}
 }
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -97,6 +97,15 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if c.ProgressTTLSeconds != 86400 {
 		t.Fatalf("ProgressTTLSeconds = %d, want %d", c.ProgressTTLSeconds, 86400)
 	}
+	if c.DispatchMode != DispatchModeSync {
+		t.Fatalf("DispatchMode = %q, want %q", c.DispatchMode, DispatchModeSync)
+	}
+	if c.AsyncConfig.ResultPollTimeout != 5*time.Second {
+		t.Fatalf("AsyncConfig.ResultPollTimeout = %v, want %v", c.AsyncConfig.ResultPollTimeout, 5*time.Second)
+	}
+	if c.AsyncConfig.PerRequestTimeout != 60*time.Minute {
+		t.Fatalf("AsyncConfig.PerRequestTimeout = %v, want %v", c.AsyncConfig.PerRequestTimeout, 60*time.Minute)
+	}
 }
 
 func TestProcessorConfig_Validate_WorkDirEmpty(t *testing.T) {
@@ -632,6 +641,117 @@ send_fairness_header: true
 	}
 	if !c.SendFairnessHeader {
 		t.Fatalf("SendFairnessHeader = false, want true")
+	}
+}
+
+func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
+	validAsyncConfig := func() *ProcessorConfig {
+		c := NewConfig()
+		c.ModelGateways = validPerModelConfig()
+		c.DispatchMode = DispatchModeAsync
+		c.AsyncConfig = AsyncDispatchConfig{
+			RedisURL:          "redis://localhost:6379",
+			RequestQueueName:  "requests",
+			ResultQueueName:   "results",
+			ResultPollTimeout: 5 * time.Second,
+			PerRequestTimeout: 60 * time.Minute,
+		}
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*ProcessorConfig)
+		wantErr bool
+	}{
+		{
+			name:    "valid async config",
+			mutate:  func(_ *ProcessorConfig) {},
+			wantErr: false,
+		},
+		{
+			name:    "sync mode ignores async fields",
+			mutate:  func(c *ProcessorConfig) { c.DispatchMode = DispatchModeSync; c.AsyncConfig = AsyncDispatchConfig{} },
+			wantErr: false,
+		},
+		{
+			name:    "empty dispatch_mode treated as sync",
+			mutate:  func(c *ProcessorConfig) { c.DispatchMode = ""; c.AsyncConfig = AsyncDispatchConfig{} },
+			wantErr: false,
+		},
+		{
+			name:    "invalid dispatch_mode rejected",
+			mutate:  func(c *ProcessorConfig) { c.DispatchMode = "invalid" },
+			wantErr: true,
+		},
+		{
+			name:    "async missing redis_url",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RedisURL = "" },
+			wantErr: true,
+		},
+		{
+			name:    "async missing request_queue_name",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RequestQueueName = "" },
+			wantErr: true,
+		},
+		{
+			name:    "async missing result_queue_name",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultQueueName = "" },
+			wantErr: true,
+		},
+		{
+			name:    "async zero result_poll_timeout",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "async zero per_request_timeout",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.PerRequestTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name: "async per_request_timeout must exceed result_poll_timeout",
+			mutate: func(c *ProcessorConfig) {
+				c.AsyncConfig.ResultPollTimeout = 10 * time.Minute
+				c.AsyncConfig.PerRequestTimeout = 5 * time.Minute
+			},
+			wantErr: true,
+		},
+		{
+			name: "async per_request_timeout equal to result_poll_timeout rejected",
+			mutate: func(c *ProcessorConfig) {
+				c.AsyncConfig.ResultPollTimeout = 5 * time.Second
+				c.AsyncConfig.PerRequestTimeout = 5 * time.Second
+			},
+			wantErr: true,
+		},
+		{
+			name:    "async with rediss URL for TLS",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RedisURL = "rediss://user:pass@host:6380" },
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validAsyncConfig()
+			tt.mutate(c)
+			err := c.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProcessorConfig_IsAsync(t *testing.T) {
+	c := NewConfig()
+	if c.IsAsync() {
+		t.Fatal("IsAsync() = true for default config, want false")
+	}
+	c.DispatchMode = DispatchModeAsync
+	if !c.IsAsync() {
+		t.Fatal("IsAsync() = false when DispatchMode is async, want true")
 	}
 }
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -785,11 +785,11 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 }
 
 func TestQueueNameHelpers(t *testing.T) {
-	if got := RequestQueueName("pool-a"); got != "requests:pool-a" {
-		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "requests:pool-a")
+	if got := RequestQueueName("pool-a"); got != "llm-d-async:requests:pool-a" {
+		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "llm-d-async:requests:pool-a")
 	}
-	if got := ResultQueueName("pool-a"); got != "results:$batch:pool-a" {
-		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "results:$batch:pool-a")
+	if got := ResultQueueName("pool-a"); got != "llm-d-async:results:$batch:pool-a" {
+		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "llm-d-async:results:$batch:pool-a")
 	}
 }
 

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -644,11 +644,18 @@ send_fairness_header: true
 func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 	validAsyncConfig := func() *ProcessorConfig {
 		c := NewConfig()
-		c.ModelGateways = validPerModelConfig()
+		c.ModelGateways = map[string]ModelGatewayConfig{
+			"llama-3": {
+				URL:            "http://llama-gw:8000",
+				RequestTimeout: ptr.To(5 * time.Minute),
+				MaxRetries:     ptr.To(3),
+				InitialBackoff: ptr.To(1 * time.Second),
+				MaxBackoff:     ptr.To(60 * time.Second),
+				PoolName:       "pool-a",
+			},
+		}
 		c.DispatchMode = DispatchModeAsync
 		c.AsyncConfig = AsyncDispatchConfig{
-			RequestQueueName:  "requests",
-			ResultQueueName:   "results",
 			ResultPollTimeout: 5 * time.Second,
 		}
 		return c
@@ -680,18 +687,81 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "async missing request_queue_name",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.RequestQueueName = "" },
-			wantErr: true,
-		},
-		{
-			name:    "async missing result_queue_name",
-			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultQueueName = "" },
-			wantErr: true,
-		},
-		{
 			name:    "async zero result_poll_timeout",
 			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			name: "async missing pool_name on model gateway",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = map[string]ModelGatewayConfig{
+					"llama-3": {URL: "http://llama-gw:8000"},
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "async missing pool_name on global gateway",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = nil
+				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "async valid global gateway with pool_name",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = nil
+				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", PoolName: "default-pool"}
+			},
+			wantErr: false,
+		},
+		{
+			name: "async no gateways configured",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = nil
+				c.GlobalInferenceGateway = nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "async global and per-model mutually exclusive",
+			mutate: func(c *ProcessorConfig) {
+				c.GlobalInferenceGateway = &ModelGatewayConfig{URL: "http://gw:8000", PoolName: "default-pool"}
+			},
+			wantErr: true,
+		},
+		{
+			name: "pool_name ignored in sync mode",
+			mutate: func(c *ProcessorConfig) {
+				c.DispatchMode = DispatchModeSync
+				c.ModelGateways = validPerModelConfig()
+			},
+			wantErr: false,
+		},
+		{
+			name:    "async negative result_poll_timeout",
+			mutate:  func(c *ProcessorConfig) { c.AsyncConfig.ResultPollTimeout = -1 * time.Second },
+			wantErr: true,
+		},
+		{
+			name: "async multiple models all valid",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = map[string]ModelGatewayConfig{
+					"llama-3": {URL: "http://gw-a:8000", PoolName: "pool-a"},
+					"mistral": {URL: "http://gw-b:8000", PoolName: "pool-b"},
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "async one model missing pool_name among multiple",
+			mutate: func(c *ProcessorConfig) {
+				c.ModelGateways = map[string]ModelGatewayConfig{
+					"llama-3": {URL: "http://gw-a:8000", PoolName: "pool-a"},
+					"mistral": {URL: "http://gw-b:8000"},
+				}
+			},
 			wantErr: true,
 		},
 	}
@@ -705,6 +775,27 @@ func TestProcessorConfig_Validate_AsyncDispatch(t *testing.T) {
 				t.Fatalf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestQueueNameHelpers(t *testing.T) {
+	if got := RequestQueueName("pool-a"); got != "request:pool-a" {
+		t.Fatalf("RequestQueueName(\"pool-a\") = %q, want %q", got, "request:pool-a")
+	}
+	if got := ResultQueueName("pool-a"); got != "result:batch-gateway:pool-a" {
+		t.Fatalf("ResultQueueName(\"pool-a\") = %q, want %q", got, "result:batch-gateway:pool-a")
+	}
+}
+
+func TestValidate_NormalizesEmptyDispatchMode(t *testing.T) {
+	c := NewConfig()
+	c.ModelGateways = validPerModelConfig()
+	c.DispatchMode = DispatchMode("")
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+	if c.DispatchMode != DispatchModeSync {
+		t.Fatalf("DispatchMode = %q after Validate(), want %q", c.DispatchMode, DispatchModeSync)
 	}
 }
 


### PR DESCRIPTION
## Why is this PR needed?

The batch-gateway currently only supports synchronous HTTP dispatch for inference requests. To enable integration with [llm-d-async](https://github.com/llm-d-incubation/llm-d-async) as an alternative asynchronous dispatch backend, the processor needs configuration plumbing before implementation can begin. This PR lays the config groundwork so the follow-up implementation PR can wire up the async dispatch path cleanly.

## What does this PR do?

- **Adds `AsyncDispatchConfig` struct** with fields for Redis connection (`redis_url`), queue names (`request_queue_name`, `result_queue_name`), result poll timeout, and per-request timeout (default: 60 minutes).
- **Adds `DispatchMode` field to `ProcessorConfig`** with constants `sync` (default) and `async` to select the inference dispatch backend.
- **Adds `IsAsync()` helper** on `ProcessorConfig` for convenient dispatch mode checks.
- **Adds validation** for async config fields: required fields when mode is `async`, positive timeouts, and `per_request_timeout > result_poll_timeout`. Sync mode and empty dispatch mode skip async validation.
- **Adds defaults** in `NewConfig()`: `DispatchMode` defaults to `sync`, `ResultPollTimeout` to 5s, `PerRequestTimeout` to 60m.
- **Adds unit tests** for all new validation cases (12 table-driven subtests), default value assertions, and `IsAsync()` behavior.
- **Adds `.cursor` to `.gitignore`**.

No runtime behaviour changes — async dispatch implementation will follow in a separate PR.

## Item for follow up PR

The per-pool queue design (`request:{pool_name}` / `result:{pool_name}`) from #432 would need per model queue routing, and the current single global `request_queue_name`/`result_queue_name` in `AsyncDispatchConfig` won't cover that. Plan to extend `ModelGatewayConfig` with a `pool_name` and adjust AsyncDispatchConfig accordingly. 

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Pre-requisite for https://github.com/llm-d-incubation/batch-gateway/issues/431
