### PR TITLE
feat: handle x-llm-d-request-dropped-reason header from GIE

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -852,6 +852,14 @@ func (p *Processor) executeOneRequest(
 	if inferErr != nil {
 		logger.V(logging.DEBUG).Info("Inference request failed", "error", inferErr.Message)
 		if inferErr.StatusCode > 0 {
+			if inferErr.DroppedReason == httpclient.DroppedReasonTTLExpired {
+				result.Error = &outputError{
+					Code:    string(batch_types.ErrCodeBatchExpired),
+					Message: batch_types.ErrCodeBatchExpired.Message(),
+				}
+				metrics.RecordRequestError(modelID)
+				return result, nil
+			}
 			// HTTP error (4xx/5xx) — populate response with status code and original body
 			// per OpenAI spec, error field is only for non-HTTP errors
 			// Ensure body is always a non-nil object to satisfy the OpenAI schema (type: object).

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -560,6 +560,101 @@ func TestExecuteOneRequest_SLOExpiredDuringExecution(t *testing.T) {
 	}
 }
 
+func TestExecuteOneRequest_DroppedReasonTTLExpired(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return nil, &inference.ClientError{
+				Category:      httpclient.ErrCategoryRateLimit,
+				Message:       "HTTP 429: Rate limit exceeded",
+				StatusCode:    429,
+				ResponseBody:  []byte(`{"error":{"message":"Rate limit exceeded"}}`),
+				DroppedReason: httpclient.DroppedReasonTTLExpired,
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-ttl", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
+	defer sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error == nil {
+		t.Fatalf("expected error for TTL-expired dropped reason")
+	}
+	if result.Error.Code != string(batch_types.ErrCodeBatchExpired) {
+		t.Fatalf("error code = %q, want %q", result.Error.Code, batch_types.ErrCodeBatchExpired)
+	}
+	if result.Error.Message != batch_types.ErrCodeBatchExpired.Message() {
+		t.Fatalf("error message = %q, want %q", result.Error.Message, batch_types.ErrCodeBatchExpired.Message())
+	}
+	if result.Response != nil {
+		t.Fatalf("expected nil response for TTL-expired, got: %+v", result.Response)
+	}
+}
+
+func TestExecuteOneRequest_DroppedReasonOther(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return nil, &inference.ClientError{
+				Category:      httpclient.ErrCategoryRateLimit,
+				Message:       "HTTP 429: Rate limit exceeded",
+				StatusCode:    429,
+				ResponseBody:  []byte(`{"error":{"message":"Rate limit exceeded"}}`),
+				DroppedReason: "rejected-saturated",
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-saturated", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
+	defer sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("expected nil error field for non-TTL dropped reason (HTTP error goes to response), got: %+v", result.Error)
+	}
+	if result.Response == nil {
+		t.Fatalf("expected response field for HTTP 429 with non-TTL dropped reason")
+	}
+	if result.Response.StatusCode != 429 {
+		t.Fatalf("status_code = %d, want 429", result.Response.StatusCode)
+	}
+}
+
 func TestExecuteOneRequest_FairnessHeader(t *testing.T) {
 	requests := []batch_types.Request{
 		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},

--- a/pkg/clients/http/http_client.go
+++ b/pkg/clients/http/http_client.go
@@ -39,6 +39,9 @@ import (
 const (
 	HeaderNameReqID       string = "X-Request-ID"
 	HeaderNameContentType string = "Content-Type"
+	HeaderDroppedReason   string = "x-llm-d-request-dropped-reason"
+
+	DroppedReasonTTLExpired = "rejected-ttl-expired"
 
 	// rateLimitBackoffMultiplier scales the initial backoff for 429 responses.
 	// A 429 means the server explicitly asks the client to slow down, so we
@@ -57,6 +60,21 @@ var capacityRetryCtxKey capacityRetryKeyType
 func NewCapacityRetryContext(ctx context.Context) (context.Context, func() bool) {
 	var flag atomic.Bool
 	return context.WithValue(ctx, capacityRetryCtxKey, &flag), flag.Load
+}
+
+type droppedReasonKeyType struct{}
+
+var droppedReasonCtxKey droppedReasonKeyType
+
+// NewDroppedReasonContext returns a child context that captures the value of the
+// x-llm-d-request-dropped-reason response header from the final HTTP response.
+// Call the returned function after the request completes to read the result.
+func NewDroppedReasonContext(ctx context.Context) (context.Context, func() string) {
+	var reason atomic.Value
+	return context.WithValue(ctx, droppedReasonCtxKey, &reason), func() string {
+		v, _ := reason.Load().(string)
+		return v
+	}
 }
 
 // HTTPClient implements HTTP client with retry, TLS, and observability support
@@ -160,15 +178,19 @@ func NewHTTPClient(config Config, logger logr.Logger) (*HTTPClient, error) {
 			SetRetryMaxWaitTime(config.MaxBackoff).                                    // Max wait time between retries
 			SetRetryAfter(newRetryAfterFunc(config.InitialBackoff, config.MaxBackoff)) // Status-code-aware backoff
 
-		// Retry condition: retry on server errors, rate limits, and network errors
+		// Retry condition: retry on server errors, rate limits, and network errors.
+		// Exception: 429 with x-llm-d-request-dropped-reason: rejected-ttl-expired
+		// is not retried because the SLO already expired on the server side.
 		client.AddRetryCondition(func(r *resty.Response, err error) bool {
 			if err != nil {
 				return true // Retry on network errors
 			}
 
 			statusCode := r.StatusCode()
-			// Retry on 429 (rate limit) and 5xx (server errors)
-			return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+			if statusCode == http.StatusTooManyRequests {
+				return r.Header().Get(HeaderDroppedReason) != DroppedReasonTTLExpired
+			}
+			return statusCode >= http.StatusInternalServerError
 		})
 
 		// Add retry hook for logging and capacity-retry tracking
@@ -240,6 +262,12 @@ func (c *HTTPClient) Post(ctx context.Context, endpoint string, body interface{}
 	// Handle request-level errors (network, timeout, etc.)
 	if err != nil {
 		return nil, 0, err
+	}
+
+	if reason := resp.Header().Get(HeaderDroppedReason); reason != "" {
+		if ptr, ok := ctx.Value(droppedReasonCtxKey).(*atomic.Value); ok {
+			ptr.Store(reason)
+		}
 	}
 
 	retries := resp.Request.Attempt - 1

--- a/pkg/clients/http/http_client.go
+++ b/pkg/clients/http/http_client.go
@@ -179,7 +179,7 @@ func NewHTTPClient(config Config, logger logr.Logger) (*HTTPClient, error) {
 			SetRetryAfter(newRetryAfterFunc(config.InitialBackoff, config.MaxBackoff)) // Status-code-aware backoff
 
 		// Retry condition: retry on server errors, rate limits, and network errors.
-		// Exception: 429 with x-llm-d-request-dropped-reason: rejected-ttl-expired
+		// Exception: 429/503 with x-llm-d-request-dropped-reason: rejected-ttl-expired
 		// is not retried because the SLO already expired on the server side.
 		client.AddRetryCondition(func(r *resty.Response, err error) bool {
 			if err != nil {
@@ -187,7 +187,7 @@ func NewHTTPClient(config Config, logger logr.Logger) (*HTTPClient, error) {
 			}
 
 			statusCode := r.StatusCode()
-			if statusCode == http.StatusTooManyRequests {
+			if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
 				return r.Header().Get(HeaderDroppedReason) != DroppedReasonTTLExpired
 			}
 			return statusCode >= http.StatusInternalServerError

--- a/pkg/clients/http/http_client_errors.go
+++ b/pkg/clients/http/http_client_errors.go
@@ -30,11 +30,12 @@ const (
 
 // ClientError represents an HTTP client error with category and context
 type ClientError struct {
-	Category     ErrorCategory
-	Message      string
-	RawError     error  // original error message
-	StatusCode   int    // HTTP status code (0 for non-HTTP errors like network/timeout)
-	ResponseBody []byte // raw HTTP response body (nil for non-HTTP errors)
+	Category      ErrorCategory
+	Message       string
+	RawError      error  // original error message
+	StatusCode    int    // HTTP status code (0 for non-HTTP errors like network/timeout)
+	ResponseBody  []byte // raw HTTP response body (nil for non-HTTP errors)
+	DroppedReason string // value of x-llm-d-request-dropped-reason header, if present
 }
 
 func (e *ClientError) Error() string {

--- a/pkg/clients/http/http_client_test.go
+++ b/pkg/clients/http/http_client_test.go
@@ -1326,6 +1326,128 @@ func TestCapacityRetryTracking(t *testing.T) {
 	})
 }
 
+func TestDroppedReasonHandling(t *testing.T) {
+	t.Run("429 with rejected-ttl-expired is not retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			w.Header().Set(HeaderDroppedReason, DroppedReasonTTLExpired)
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"ttl expired"}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusTooManyRequests {
+			t.Fatalf("status = %d, want 429", statusCode)
+		}
+		if attempts.Load() != 1 {
+			t.Fatalf("expected 1 attempt (no retries), got %d", attempts.Load())
+		}
+	})
+
+	t.Run("429 with other dropped reason is retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			count := attempts.Add(1)
+			if count < 3 {
+				w.Header().Set(HeaderDroppedReason, "rejected-saturated")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", statusCode)
+		}
+		if attempts.Load() != 3 {
+			t.Fatalf("expected 3 attempts, got %d", attempts.Load())
+		}
+	})
+
+	t.Run("dropped reason captured via context", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(HeaderDroppedReason, DroppedReasonTTLExpired)
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"ttl expired"}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     1,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, droppedReason := NewDroppedReasonContext(context.Background())
+		_, _, err = client.Post(ctx, "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if droppedReason() != DroppedReasonTTLExpired {
+			t.Fatalf("droppedReason = %q, want %q", droppedReason(), DroppedReasonTTLExpired)
+		}
+	})
+
+	t.Run("no dropped reason header leaves context empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL: server.URL,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, droppedReason := NewDroppedReasonContext(context.Background())
+		_, _, err = client.Post(ctx, "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if droppedReason() != "" {
+			t.Fatalf("droppedReason = %q, want empty", droppedReason())
+		}
+	})
+}
+
 func pemEncodeCert(derBytes []byte) []byte {
 	return pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",

--- a/pkg/clients/http/http_client_test.go
+++ b/pkg/clients/http/http_client_test.go
@@ -1327,6 +1327,38 @@ func TestCapacityRetryTracking(t *testing.T) {
 }
 
 func TestDroppedReasonHandling(t *testing.T) {
+	t.Run("503 with rejected-ttl-expired is not retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			w.Header().Set(HeaderDroppedReason, DroppedReasonTTLExpired)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"ttl expired"}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", statusCode)
+		}
+		if attempts.Load() != 1 {
+			t.Fatalf("expected 1 attempt (no retries), got %d", attempts.Load())
+		}
+	})
+
 	t.Run("429 with rejected-ttl-expired is not retried", func(t *testing.T) {
 		var attempts atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -1366,6 +1398,42 @@ func TestDroppedReasonHandling(t *testing.T) {
 			if count < 3 {
 				w.Header().Set(HeaderDroppedReason, "rejected-saturated")
 				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		defer server.Close()
+
+		client, err := NewHTTPClient(Config{
+			BaseURL:        server.URL,
+			MaxRetries:     3,
+			InitialBackoff: time.Millisecond,
+			MaxBackoff:     10 * time.Millisecond,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, statusCode, err := client.Post(context.Background(), "/test", nil, nil, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if statusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", statusCode)
+		}
+		if attempts.Load() != 3 {
+			t.Fatalf("expected 3 attempts, got %d", attempts.Load())
+		}
+	})
+
+	t.Run("503 with other dropped reason is retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			count := attempts.Add(1)
+			if count < 3 {
+				w.Header().Set(HeaderDroppedReason, "rejected-saturated")
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 			w.WriteHeader(http.StatusOK)

--- a/pkg/clients/inference/inference_client_impl.go
+++ b/pkg/clients/inference/inference_client_impl.go
@@ -78,6 +78,7 @@ func (c *InferenceHTTPClient) Generate(ctx context.Context, req *GenerateRequest
 	// Track whether any retry was caused by capacity pressure (429/5xx)
 	// vs network errors, so the caller can make precise AIMD decisions.
 	trackingCtx, hadCapacityRetry := httpclient.NewCapacityRetryContext(ctx)
+	trackingCtx, droppedReason := httpclient.NewDroppedReasonContext(trackingCtx)
 
 	// Execute HTTP POST request using the underlying http client
 	resp, statusCode, err := c.client.Post(trackingCtx, endpoint, req.Params, req.Headers, req.RequestID)
@@ -90,6 +91,7 @@ func (c *InferenceHTTPClient) Generate(ctx context.Context, req *GenerateRequest
 	// Check for non-retryable errors after all retries exhausted
 	if statusCode != http.StatusOK {
 		clientErr := c.client.HandleErrorResponse(ctx, statusCode, resp)
+		clientErr.DroppedReason = droppedReason()
 		return nil, clientErr
 	}
 

--- a/pkg/clients/inference/inference_client_test.go
+++ b/pkg/clients/inference/inference_client_test.go
@@ -46,6 +46,7 @@ func TestInferenceClient(t *testing.T) {
 	t.Run("Generate", testGenerate)
 	t.Run("ErrorHandling", testErrorHandling)
 	t.Run("RetryLogic", testRetryLogic)
+	t.Run("DroppedReason", testDroppedReason)
 	t.Run("TLSConfiguration", testTLSConfiguration)
 	t.Run("Authentication", testAuthentication)
 	t.Run("NetworkErrors", testNetworkErrors)
@@ -818,6 +819,71 @@ func testRetryLogic(t *testing.T) {
 			t.Errorf("got attemptCount %v, want %v", attemptCount, 1)
 		}
 	})
+}
+
+func testDroppedReason(t *testing.T) {
+	tests := []struct {
+		name              string
+		headerValue       string
+		wantDroppedReason string
+	}{
+		{
+			name:              "should populate DroppedReason from response header",
+			headerValue:       httpclient.DroppedReasonTTLExpired,
+			wantDroppedReason: httpclient.DroppedReasonTTLExpired,
+		},
+		{
+			name:              "should capture non-TTL dropped reason",
+			headerValue:       "rejected-saturated",
+			wantDroppedReason: "rejected-saturated",
+		},
+		{
+			name:              "should leave DroppedReason empty when header is absent",
+			headerValue:       "",
+			wantDroppedReason: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.headerValue != "" {
+					w.Header().Set(httpclient.HeaderDroppedReason, tt.headerValue)
+				}
+				w.WriteHeader(http.StatusTooManyRequests)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"error": map[string]interface{}{
+						"code":    429,
+						"message": "Rate limit exceeded",
+					},
+				})
+			}))
+			t.Cleanup(testServer.Close)
+
+			client, err := NewInferenceClient(&HTTPClientConfig{
+				BaseURL:        testServer.URL,
+				MaxRetries:     1,
+				InitialBackoff: 10 * time.Millisecond,
+			}, testLogger(t))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			req := &GenerateRequest{
+				RequestID: "test-dropped",
+				Endpoint:  "/v1/chat/completions",
+				Params:    map[string]interface{}{"model": "gpt-4"},
+			}
+
+			_, genErr := client.Generate(context.Background(), req)
+			if genErr == nil {
+				t.Fatal("expected non-nil error for 429 response")
+			}
+			if genErr.DroppedReason != tt.wantDroppedReason {
+				t.Errorf("DroppedReason = %q, want %q", genErr.DroppedReason, tt.wantDroppedReason)
+			}
+		})
+	}
 }
 
 // generateTestCerts creates test certificates in a temporary directory


### PR DESCRIPTION
## Summary

- When GIE returns 429 with `x-llm-d-request-dropped-reason: rejected-ttl-expired`, skip retry and write the request as `batch_expired` instead of surfacing an HTTP 429 error
- For all other dropped reasons (e.g. `rejected-saturated`), retry behavior is unchanged
- Uses context-value pattern (same as existing `NewCapacityRetryContext`) to propagate the header value out of `Post()` without changing its signature

## Changes

| File | Change |
|------|--------|
| `pkg/clients/http/http_client.go` | Header/reason constants, `NewDroppedReasonContext`, retry condition update, header capture in `Post()` |
| `pkg/clients/http/http_client_errors.go` | `DroppedReason` field on `ClientError` |
| `pkg/clients/inference/inference_client_impl.go` | Create dropped-reason context, populate `DroppedReason` on error |
| `internal/processor/worker/executor.go` | Map `rejected-ttl-expired` to `batch_expired` |
| `pkg/clients/http/http_client_test.go` | Retry-skip tests, context tracking tests |
| `pkg/clients/inference/inference_client_test.go` | `DroppedReason` propagation test |
| `internal/processor/worker/executor_test.go` | TTL-expired → `batch_expired` test, non-TTL 429 test |

## Backwards compatibility

All new code paths are no-ops when the header is absent — existing behavior is preserved for inference backends that don't send the header.

## Depends on

- [llm-d/llm-d-inference-scheduler#1027](https://github.com/llm-d/llm-d-inference-scheduler/pull/1027) (merged) — adds the `x-llm-d-request-dropped-reason` header to GIE responses

Closes #311

## Test plan

- [x] `TestDroppedReasonHandling` — 429 + `rejected-ttl-expired` is not retried (1 attempt); 429 + other reasons are retried; context captures header value
- [x] `TestInferenceClient/DroppedReason` — `Generate()` populates `ClientError.DroppedReason` from the response header
- [x] `TestExecuteOneRequest_DroppedReasonTTLExpired` — writes `batch_expired` error
- [x] `TestExecuteOneRequest_DroppedReasonOther` — non-TTL 429 produces normal HTTP error response
- [x] `make pre-commit` passes (formatting, vet, lint, unit tests, security scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)