### PR TITLE
fix(test): avoid typed-nil failure in HTTP client integration test (#438)

### DIFF
--- a/pkg/clients/inference/inference_client_integration_test.go
+++ b/pkg/clients/inference/inference_client_integration_test.go
@@ -142,7 +142,7 @@ func testHTTPClientBasicInference(t *testing.T) {
 	t.Run("should handle concurrent requests correctly", func(t *testing.T) {
 		// Verifies connection pooling and thread safety
 		const numRequests = 10
-		results := make(chan error, numRequests)
+		results := make(chan *ClientError, numRequests)
 
 		for i := 0; i < numRequests; i++ {
 			go func(id int) {


### PR DESCRIPTION
## Why is this PR needed?

The concurrent `TestHTTPClientIntegration` subtest was always failing because it sent `*ClientError` values through a `chan error`. When `Generate()` succeeded, the typed-nil `*ClientError` was boxed into the `error` interface and no longer compared equal to `nil`, so the test reported a failure even though the request succeeded.

## What does this PR do?

- changes the concurrent integration test to use `chan *ClientError` instead of `chan error`
- keeps the test aligned with the `Generate()` signature and avoids the typed-nil interface trap

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

Manual / targeted verification:
- `go test -tags=integration ./pkg/clients/inference -run 'TestHTTPClientIntegration/BasicInference/should_handle_concurrent_requests_correctly'`
- `pre-commit run -a`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #438