### PR TITLE
fix(test): use chan *ClientError to avoid nil-interface false positive

### DIFF
--- a/pkg/clients/inference/inference_client_integration_test.go
+++ b/pkg/clients/inference/inference_client_integration_test.go
@@ -140,9 +140,15 @@ func testHTTPClientBasicInference(t *testing.T) {
 	})
 
 	t.Run("should handle concurrent requests correctly", func(t *testing.T) {
-		// Verifies connection pooling and thread safety
+		// Verifies connection pooling and thread safety.
+		//
+		// Channel is typed *ClientError (the concrete return type of Generate)
+		// rather than the error interface: assigning a nil concrete pointer
+		// (*ClientError)(nil) into an interface produces a non-nil interface
+		// value with a nil underlying pointer, so `inferr != nil` on the
+		// receiving side would always be true. See #438.
 		const numRequests = 10
-		results := make(chan error, numRequests)
+		results := make(chan *ClientError, numRequests)
 
 		for i := 0; i < numRequests; i++ {
 			go func(id int) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`TestHTTPClientIntegration/BasicInference/should_handle_concurrent_requests_correctly` fails **deterministically** on `main` — 5/5 runs — even though every request actually succeeds. Classic Go nil-interface gotcha.

### Root cause

```go
results := make(chan error, numRequests)     // channel typed as error (interface)
...
_, inferr := client.Generate(ctx, req)        // returns (*ClientError, nil)
results <- inferr                             // (*ClientError)(nil) → non-nil interface
```

`Generate` returns `*ClientError`. When a concrete nil pointer is assigned to an interface, Go wraps it in a **non-nil interface value** (type info present, value nil). The receiving side's `inferr != nil` check is therefore always true. Log output confirms: `concurrent request X failed: <nil>`.

### Fix

Type the channel as `*ClientError` (the concrete return type of `Generate`). The `!= nil` check on the receiving side then works correctly on the concrete pointer.

```diff
-		results := make(chan error, numRequests)
+		results := make(chan *ClientError, numRequests)
```

Surgical one-line change. Added an inline comment so a future contributor doesn't reintroduce the same gotcha.

### How this regressed

Likely since commit `8887e84` (`chore: remove testify dependency`, #210), which rewrote testify assertions to stdlib `!= nil` checks. testify handles the wrapped-nil case; stdlib doesn't.

### Verification

- `make test` — 885 passed, 0 failed
- `go vet -tags=integration ./pkg/clients/inference/` — clean
- `make pre-commit` — all hooks pass
- **Integration test itself**: requires Docker to start the mock server (`docker exec`). Local dev setup is podman-only on Apple Silicon, so couldn't run the previously-failing test end-to-end. Relying on CI to confirm the previously-5/5-failing test now passes 5/5.

**Which issue(s) this PR fixes**:
Fixes #438
