### PR TITLE
fix(e2e): Disable flaky RetryOn429 E2E and keep retry coverage in deterministic tests

### DIFF
--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -95,6 +95,56 @@ func TestExecuteOneRequest_Success(t *testing.T) {
 	}
 }
 
+func TestExecuteOneRequest_SuccessWithCapacityRetry(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	mock := &mockInferenceClient{
+		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			return &inference.GenerateResponse{
+				RequestID:        "srv-123",
+				Response:         []byte(`{"result":"ok"}`),
+				HadCapacityRetry: true,
+			}, nil
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "req-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1", "prompt": "hi"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, err := os.Open(inputPath)
+	if err != nil {
+		t.Fatalf("open input: %v", err)
+	}
+	defer inputFile.Close()
+
+	jobRootDir, _ := env.p.jobRootDir(jobInfo.JobID, jobInfo.TenantID)
+	entries := planEntriesFromLines(mustReadFile(t, filepath.Join(jobRootDir, "input.jsonl")))
+
+	ctx := testLoggerCtx(t)
+	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(1*time.Second))
+	defer sloCancel()
+	result, err := env.p.executeOneRequest(ctx, sloCtx, inputFile, entries[0], "m1", nil, "")
+	if err != nil {
+		t.Fatalf("executeOneRequest error: %v", err)
+	}
+	if result.Error != nil {
+		t.Fatalf("expected no error in output line, got %+v", result.Error)
+	}
+	if result.Response == nil {
+		t.Fatal("expected response in output line")
+	}
+	if result.Response.StatusCode != 200 {
+		t.Fatalf("StatusCode = %d, want 200", result.Response.StatusCode)
+	}
+	if !result.hadCapacityRetry {
+		t.Fatal("expected hadCapacityRetry=true on successful retried response")
+	}
+}
+
 func TestExecuteOneRequest_NonHTTPError(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()

--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -49,7 +49,9 @@ func testFlowControl(t *testing.T) {
 		}
 		t.Run("InferenceObjectiveHeader", doTestInferenceObjectiveHeader)
 		t.Run("SLOHeader", doTestSLOHeader)
-		t.Run("RetryOn429", doTestRetryOn429)
+		t.Run("RetryOn429", func(t *testing.T) {
+			t.Skip("#445: disabled until llm-d-inference-sim supports deterministic 429 injection; retry coverage lives in lower-level deterministic tests")
+		})
 		t.Run("RetryExhaustion", doTestRetryExhaustion)
 	})
 
@@ -127,59 +129,6 @@ func doTestSLOHeader(t *testing.T) {
 	}
 
 	t.Logf("batch completed within 10m SLO window (x-slo-ttft-ms header propagation unit-tested)")
-}
-
-// doTestRetryOn429 submits a batch targeting a simulator with 50% failure
-// injection (rate_limit → HTTP 429). The processor should retry failed
-// requests and eventually complete the batch. After completion, the test
-// checks processor logs for "Retrying request" entries to verify that
-// retries actually occurred.
-//
-// With 5 requests at 50% failure and maxRetries=20, the probability of any
-// single request exhausting all retries is (0.5)^21 ≈ 5e-7, and the
-// probability of zero retries across all requests is (0.5)^5 ≈ 3%.
-func doTestRetryOn429(t *testing.T) {
-	t.Helper()
-
-	const numRequests = 5
-	sinceTime := time.Now().UTC().Format(time.RFC3339Nano)
-
-	lines := make([]string, numRequests)
-	for i := range lines {
-		lines[i] = fmt.Sprintf(
-			`{"custom_id":"r429-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Hello %d"}]}}`,
-			i+1, testModel429, i+1,
-		)
-	}
-	jsonl := strings.Join(lines, "\n")
-
-	fileID := mustCreateFile(t, fmt.Sprintf("test-retry-429-%s.jsonl", testRunID), jsonl)
-	batchID := mustCreateBatch(t, fileID)
-
-	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
-		openai.BatchStatusCompleted, openai.BatchStatusFailed)
-
-	if finalBatch.Status != openai.BatchStatusCompleted {
-		t.Fatalf("expected batch to complete despite 429s, got status %s", finalBatch.Status)
-	}
-	if finalBatch.RequestCounts.Completed != int64(numRequests) {
-		t.Errorf("expected %d completed (after retries), got %d", numRequests, finalBatch.RequestCounts.Completed)
-	}
-	if finalBatch.RequestCounts.Failed != 0 {
-		t.Errorf("expected 0 failed (retries should succeed), got %d", finalBatch.RequestCounts.Failed)
-	}
-
-	t.Logf("429 retry test: completed=%d failed=%d total=%d",
-		finalBatch.RequestCounts.Completed, finalBatch.RequestCounts.Failed, finalBatch.RequestCounts.Total)
-
-	assertNoRequestErrors(t, testModel429)
-
-	procLogs := getProcessorLogsSince(t, sinceTime)
-	retries := strings.Count(procLogs, "Retrying request")
-	t.Logf("processor retried %d request(s) for %d original", retries, numRequests)
-	if retries == 0 {
-		t.Errorf("expected at least one retry (50%% failure injection on %d requests), but processor logs show 0 retries", numRequests)
-	}
 }
 
 // doTestRetryExhaustion submits a batch targeting a simulator with 100%


### PR DESCRIPTION
## Why is this PR needed?

The current `RetryOn429` E2E depends on probabilistic 429 injection from the simulator, so it cannot reliably guarantee that the retry path is exercised. That makes it a flaky CI signal.

## What does this PR do?

This PR disables the flaky `RetryOn429` E2E for now and points to deterministic lower-level coverage instead.

Specifically:
- skips the `RetryOn429` E2E with a `#445` reference and a clear re-enable condition,
- keeps retry behavior covered in the HTTP client tests, and
- adds worker-level coverage to verify that a successful response with `HadCapacityRetry=true` is preserved correctly.

The existing `RetryExhaustion` E2E remains enabled.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #445
Related #448