### PR TITLE
chore: update .gitignore to use trailing slashes and add .codegraph/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
-.vscode
-.claude
-.cursor
+.vscode/
+.claude/
+.cursor/
+.codegraph/


### PR DESCRIPTION
Add trailing `/` to `.vscode`, `.claude`, `.cursor` entries (match directories only) and add `.codegraph/`.