### PR TITLE
docs: upgrade llm-d to v0.7.0 and use standalone helm charts

### DIFF
--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -36,11 +36,14 @@ BATCH_INTERNAL_GATEWAY_NAME="${BATCH_INTERNAL_GATEWAY_NAME:-batch-internal-gatew
 BATCH_INTERNAL_GATEWAY_NAMESPACE="${BATCH_INTERNAL_GATEWAY_NAMESPACE:-${GATEWAY_NAMESPACE}}"
 GATEWAY_LOCAL_PORT="${GATEWAY_LOCAL_PORT:-8080}"
 
-LLMD_VERSION="${LLMD_VERSION:-v0.6.0}"
+LLMD_VERSION="${LLMD_VERSION:-v0.7.0}"
 LLMD_GIT_DIR="/tmp/llm-d-${LLMD_VERSION}"
 LLMD_RELEASE_POSTFIX="${LLMD_RELEASE_POSTFIX:-llmd}"
 
-# Model name matches the simulated-accelerators helmfile default ("random")
+GAIE_CHART_VERSION="${GAIE_CHART_VERSION:-v1.5.0}"
+MODELSERVICE_CHART_VERSION="${MODELSERVICE_CHART_VERSION:-v0.4.12}"
+
+# Model name matches the simulated model default ("random")
 MODEL_NAME="${MODEL_NAME:-random}"
 LLMD_POOL_NAME="gaie-${LLMD_RELEASE_POSTFIX}"
 
@@ -429,20 +432,29 @@ install_llmd_deps() {
 deploy_llmd_model() {
     step "Deploying model with llm-d..."
 
-    local llmd_dir="${LLMD_GIT_DIR}"
-    local sim_dir="${llmd_dir}/guides/simulated-accelerators"
+    local sim_dir="${SCRIPT_DIR}/llmd-sim"
+    local pool_name="${LLMD_POOL_NAME}"
+    local epp_host="${pool_name}-epp.${LLM_NAMESPACE}.svc.cluster.local"
 
-    # Reduce resource requests — defaults (4 CPU) exceed demo/CI cluster capacity.
-    local istio_config="${llmd_dir}/guides/prereq/gateway-provider/common-configurations/istio.yaml"
-    # Disable llm-d's own gateway — we use our own istio-gateway with AuthPolicy
-    yq -i '.gateway.enabled = false' "${istio_config}"
-    yq -i '.inferenceExtension.resources = {"requests": {"cpu": "500m", "memory": "512Mi"}, "limits": {"cpu": "2", "memory": "1Gi"}}' \
-        "${sim_dir}/gaie-sim/values.yaml"
-    RELEASE_NAME_POSTFIX="${LLMD_RELEASE_POSTFIX}" \
-        helmfile apply -f "${sim_dir}/helmfile.yaml.gotmpl" -e istio -n "${LLM_NAMESPACE}"
+    # Install InferencePool (GAIE EPP)
+    step "Installing InferencePool chart ${GAIE_CHART_VERSION}..."
+    helm upgrade --install "${pool_name}" \
+        oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+        --version "${GAIE_CHART_VERSION}" \
+        --namespace "${LLM_NAMESPACE}" \
+        -f "${sim_dir}/gaie-sim-values.yaml" \
+        --set "provider.istio.destinationRule.host=${epp_host}"
+
+    # Install ModelService (vllm-sim)
+    step "Installing ModelService chart ${MODELSERVICE_CHART_VERSION}..."
+    helm repo add llm-d-modelservice https://llm-d-incubation.github.io/llm-d-modelservice/ --force-update
+    helm upgrade --install "ms-${LLMD_RELEASE_POSTFIX}" llm-d-modelservice/llm-d-modelservice \
+        --version "${MODELSERVICE_CHART_VERSION}" \
+        --namespace "${LLM_NAMESPACE}" \
+        -f "${sim_dir}/ms-sim-values.yaml"
 
     # Wait for llm-d deployments
-    wait_for_deployment "${LLMD_POOL_NAME}-epp" "${LLM_NAMESPACE}" 300s
+    wait_for_deployment "${pool_name}-epp" "${LLM_NAMESPACE}" 300s
     wait_for_deployment "ms-${LLMD_RELEASE_POSTFIX}-llm-d-modelservice-decode" "${LLM_NAMESPACE}" 300s
 
     log "llm-d model deployed."
@@ -451,16 +463,8 @@ deploy_llmd_model() {
 uninstall_llmd() {
     step "Removing llm-d stack (${LLM_NAMESPACE})..."
     timeout_delete 30s httproute --all -n "${LLM_NAMESPACE}" || true
-    local sim_helmfile="${LLMD_GIT_DIR}/guides/simulated-accelerators/helmfile.yaml.gotmpl"
-    if [ -f "${sim_helmfile}" ]; then
-        RELEASE_NAME_POSTFIX="${LLMD_RELEASE_POSTFIX}" \
-            helmfile destroy -f "${sim_helmfile}" -e istio -n "${LLM_NAMESPACE}" 2>/dev/null \
-            || warn "helmfile destroy failed"
-    else
-        helm uninstall "ms-${LLMD_RELEASE_POSTFIX}" -n "${LLM_NAMESPACE}" --timeout 60s 2>/dev/null || true
-        helm uninstall "${LLMD_POOL_NAME}" -n "${LLM_NAMESPACE}" --timeout 60s 2>/dev/null || true
-        helm uninstall "infra-${LLMD_RELEASE_POSTFIX}" -n "${LLM_NAMESPACE}" --timeout 60s 2>/dev/null || true
-    fi
+    helm uninstall "ms-${LLMD_RELEASE_POSTFIX}" -n "${LLM_NAMESPACE}" --timeout 60s 2>/dev/null || true
+    helm uninstall "${LLMD_POOL_NAME}" -n "${LLM_NAMESPACE}" --timeout 60s 2>/dev/null || true
     timeout_delete 30s inferencepool --all -n "${LLM_NAMESPACE}" || true
 }
 
@@ -875,7 +879,7 @@ usage() {
     echo ""
     echo "Examples:"
     echo "  $0 install"
-    echo "  MODEL_NAME=my-model LLMD_VERSION=v0.5.0 $0 install"
+    echo "  MODEL_NAME=my-model LLMD_VERSION=v0.7.0 $0 install"
     exit "${1:-0}"
 }
 

--- a/examples/deploy-demo/llmd-sim/gaie-sim-values.yaml
+++ b/examples/deploy-demo/llmd-sim/gaie-sim-values.yaml
@@ -1,0 +1,59 @@
+# InferencePool chart values for simulated-accelerators demo.
+# Used with: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool v1.5.0
+#
+# Equivalent to the former guides/simulated-accelerators/gaie-sim/values.yaml
+# in the llm-d repo, which was removed after v0.6.0.
+
+inferenceExtension:
+  replicas: 1
+  image:
+    registry: ghcr.io
+    repository: llm-d/llm-d-inference-scheduler
+    tag: v0.8.0
+    pullPolicy: Always
+  extProcPort: 9002
+  pluginsConfigFile: "default-plugins.yaml"
+  tracing:
+    enabled: false
+  monitoring:
+    interval: "10s"
+    prometheus:
+      enabled: true
+      auth:
+        enabled: true
+        secretName: sim-gateway-sa-metrics-reader-secret
+  # Reduced for demo — defaults (4 CPU) exceed demo/CI cluster capacity.
+  resources:
+    requests:
+      cpu: "500m"
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
+
+inferencePool:
+  targetPorts:
+    - number: 8000
+  modelServerType: vllm
+  modelServers:
+    matchLabels:
+      llm-d.ai/inference-serving: "true"
+      llm-d.ai/guide: "simulated-accelerators"
+      llm-d.ai/accelerator-variant: "cpu"
+      llm-d.ai/model: "random"
+
+provider:
+  name: istio
+  istio:
+    destinationRule:
+      trafficPolicy:
+        connectionPool:
+          http:
+            http1MaxPendingRequests: 256000
+            maxRequestsPerConnection: 256000
+            http2MaxRequests: 256000
+            idleTimeout: "900s"
+          tcp:
+            maxConnections: 256000
+            maxConnectionDuration: "1800s"
+            connectTimeout: "900s"

--- a/examples/deploy-demo/llmd-sim/ms-sim-values.yaml
+++ b/examples/deploy-demo/llmd-sim/ms-sim-values.yaml
@@ -1,0 +1,182 @@
+# ModelService chart values for simulated-accelerators demo.
+# Used with: llm-d-modelservice/llm-d-modelservice v0.4.12
+#
+# Equivalent to the former guides/simulated-accelerators/ms-sim/values.yaml
+# in the llm-d repo, which was removed after v0.6.0.
+
+multinode: false
+
+modelArtifacts:
+  uri: "hf://random"
+  name: random
+  size: 5Mi
+  labels:
+    llm-d.ai/inference-serving: "true"
+    llm-d.ai/guide: "simulated-accelerators"
+    llm-d.ai/accelerator-variant: "cpu"
+    llm-d.ai/model: "random"
+
+routing:
+  servicePort: 8000
+  proxy:
+    image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.8.0
+    connector: nixlv2
+    secure: false
+
+decode:
+  create: true
+  replicas: 3
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"
+      path: "/metrics"
+      interval: "30s"
+  initContainers:
+    - name: uds-tokenizer
+      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.8.0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      env:
+      - name: LOG_LEVEL
+        value: "DEBUG"
+      - name: PROBE_PORT
+        value: "8082"
+      ports:
+      - name: health
+        containerPort: 8082
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8082
+        initialDelaySeconds: 10
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 8082
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      volumeMounts:
+      - name: uds-socket
+        mountPath: /tmp/tokenizer
+  containers:
+    - name: "vllm"
+      image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
+      modelCommand: imageDefault
+      ports:
+        - containerPort: 8200
+          name: vllm
+          protocol: TCP
+      mountModelVolume: true
+      volumeMounts:
+      - name: metrics-volume
+        mountPath: /.config
+      - name: uds-socket
+        mountPath: /tmp/tokenizer
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+  volumes:
+    - name: metrics-volume
+      emptyDir: {}
+    - name: uds-socket
+      emptyDir: {}
+
+prefill:
+  create: true
+  replicas: 1
+  monitoring:
+    podmonitor:
+      enabled: true
+      portName: "vllm"
+      path: "/metrics"
+      interval: "30s"
+  initContainers:
+    - name: uds-tokenizer
+      image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.8.0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      env:
+      - name: LOG_LEVEL
+        value: "DEBUG"
+      - name: PROBE_PORT
+        value: "8082"
+      ports:
+      - name: health
+        containerPort: 8082
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 8082
+        initialDelaySeconds: 10
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 8082
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      volumeMounts:
+      - name: uds-socket
+        mountPath: /tmp/tokenizer
+  containers:
+    - name: "vllm"
+      image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
+      modelCommand: imageDefault
+      ports:
+        - containerPort: 8000
+          name: vllm
+          protocol: TCP
+      mountModelVolume: true
+      volumeMounts:
+      - name: metrics-volume
+        mountPath: /.config
+      - name: uds-socket
+        mountPath: /tmp/tokenizer
+      startupProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        initialDelaySeconds: 15
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 60
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: vllm
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        httpGet:
+          path: /v1/models
+          port: vllm
+        periodSeconds: 5
+        timeoutSeconds: 2
+        failureThreshold: 3
+  volumes:
+    - name: metrics-volume
+      emptyDir: {}
+    - name: uds-socket
+      emptyDir: {}


### PR DESCRIPTION
## Why is this PR needed?

The deploy-demo script depends on llm-d repo's `simulated-accelerators` helmfile, which was removed in llm-d v0.7.0.

## What does this PR do?

- Upgrades llm-d from v0.6.0 to v0.7.0
- Ships values files locally under `llmd-sim/` to decouple from upstream layout changes

## How was this tested?

- [x] Manual testing performed
- [x] Full deploy + 13/13 tests passed on OpenShift cluster

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)