### PR TITLE
refactor(gc): group collector settings under collector config

### DIFF
--- a/charts/batch-gateway/templates/gc-configmap.yaml
+++ b/charts/batch-gateway/templates/gc-configmap.yaml
@@ -9,8 +9,9 @@ data:
   config.yaml: |
     # Garbage Collector configuration
     dry_run: {{ .Values.gc.config.dryRun }}
-    interval: {{ .Values.gc.config.interval | quote }}
-    max_concurrency: {{ .Values.gc.config.maxConcurrency }}
+    collector:
+      interval: {{ .Values.gc.config.collector.interval | quote }}
+      max_concurrency: {{ .Values.gc.config.collector.maxConcurrency }}
     db_client:
       type: {{ .Values.global.dbClient.type | quote }}
       redis:

--- a/charts/batch-gateway/tests/gc-configmap_test.yaml
+++ b/charts/batch-gateway/tests/gc-configmap_test.yaml
@@ -11,7 +11,7 @@ tests:
           pattern: 'dry_run: false'
       - matchRegex:
           path: data["config.yaml"]
-          pattern: 'interval: "30m"'
+          pattern: 'collector:\n\s+interval: "30m"'
       - matchRegex:
           path: data["config.yaml"]
           pattern: 'db_client:\n\s+type: "postgresql"'
@@ -21,7 +21,7 @@ tests:
 
   - it: should render custom maxConcurrency
     set:
-      gc.config.maxConcurrency: 20
+      gc.config.collector.maxConcurrency: 20
     asserts:
       - matchRegex:
           path: data["config.yaml"]
@@ -37,7 +37,7 @@ tests:
 
   - it: should render custom interval
     set:
-      gc.config.interval: "1h"
+      gc.config.collector.interval: "1h"
     asserts:
       - matchRegex:
           path: data["config.yaml"]

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -462,10 +462,11 @@ gc:
   # GC application config (rendered into a ConfigMap and mounted as config.yaml)
   config:
     dryRun: false
-    # Interval between garbage collection cycles (Go duration format)
-    interval: "30m"
-    # Maximum number of concurrent item deletions per GC cycle
-    maxConcurrency: 10
+    collector:
+      # Interval between garbage collection cycles (Go duration format)
+      interval: "30m"
+      # Maximum number of concurrent item deletions per GC cycle
+      maxConcurrency: 10
 
   # Per-component podSecurityContext override (optional).
   # If not set, inherits global.podSecurityContext.

--- a/cmd/batch-gc/config.yaml
+++ b/cmd/batch-gc/config.yaml
@@ -3,11 +3,12 @@
 # If true, only log what would be deleted without actually deleting
 dry_run: false
 
-# Interval between garbage collection cycles
-interval: 1h
-
-# Maximum number of concurrent item deletions per GC cycle (default: 10)
-max_concurrency: 10
+# Collector-specific settings
+collector:
+  # Interval between garbage collection cycles
+  interval: 1h
+  # Maximum number of concurrent item deletions per GC cycle (default: 10)
+  max_concurrency: 10
 
 # Database client configuration
 db_client:

--- a/cmd/batch-gc/main.go
+++ b/cmd/batch-gc/main.go
@@ -62,7 +62,7 @@ func run() error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 
-	logger.Info("Starting batch garbage collector", "dryRun", cfg.DryRun, "interval", cfg.Interval)
+	logger.Info("Starting batch garbage collector", "dryRun", cfg.DryRun, "interval", cfg.Collector.Interval)
 
 	ctx, cancel := interrupt.ContextWithSignal(ctx)
 	defer cancel()
@@ -83,7 +83,7 @@ func run() error {
 	}
 	defer func() { _ = clients.Close() }()
 
-	gc := collector.NewGarbageCollector(clients.BatchDB, clients.FileDB, clients.File, cfg.DryRun, cfg.Interval, cfg.MaxConcurrency, nil)
+	gc := collector.NewGarbageCollector(clients.BatchDB, clients.FileDB, clients.File, cfg.DryRun, cfg.Collector.Interval, cfg.Collector.MaxConcurrency, nil)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error { return gc.RunLoop(gCtx) })

--- a/internal/gc/config/config.go
+++ b/internal/gc/config/config.go
@@ -42,11 +42,18 @@ type ReconcilerConfig struct {
 	Interval time.Duration `yaml:"interval"`
 }
 
-// Config holds the garbage collector configuration.
-type Config struct {
-	DryRun         bool          `yaml:"dry_run"`
+// CollectorConfig holds collector-specific settings (interval and concurrency).
+type CollectorConfig struct {
 	Interval       time.Duration `yaml:"interval"`
 	MaxConcurrency int           `yaml:"max_concurrency"`
+}
+
+// Config holds the garbage collector configuration.
+type Config struct {
+	DryRun bool `yaml:"dry_run"`
+
+	// Collector holds the collector-specific configuration (interval, concurrency).
+	Collector CollectorConfig `yaml:"collector"`
 
 	// Reconciler configures the orphan reconciler that detects and recovers
 	// batch jobs stuck in non-terminal states.
@@ -67,8 +74,10 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg := &Config{
-		Interval:       1 * time.Hour,
-		MaxConcurrency: DefaultMaxConcurrency,
+		Collector: CollectorConfig{
+			Interval:       1 * time.Hour,
+			MaxConcurrency: DefaultMaxConcurrency,
+		},
 		Reconciler: ReconcilerConfig{
 			Enabled:  true,
 			Interval: DefaultReconcilerInterval,
@@ -78,12 +87,12 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
-	if cfg.MaxConcurrency <= 0 {
-		return nil, fmt.Errorf("max_concurrency must be positive, got %d", cfg.MaxConcurrency)
+	if cfg.Collector.MaxConcurrency <= 0 {
+		return nil, fmt.Errorf("collector.max_concurrency must be positive, got %d", cfg.Collector.MaxConcurrency)
 	}
 
-	if cfg.Interval <= 0 {
-		return nil, fmt.Errorf("interval must be positive, got %v", cfg.Interval)
+	if cfg.Collector.Interval <= 0 {
+		return nil, fmt.Errorf("collector.interval must be positive, got %v", cfg.Collector.Interval)
 	}
 
 	if cfg.Reconciler.Enabled && cfg.Reconciler.Interval <= 0 {

--- a/internal/gc/config/config_test.go
+++ b/internal/gc/config/config_test.go
@@ -35,7 +35,8 @@ func writeTempConfig(t *testing.T, content string) string {
 func TestLoad_FilesystemBackend(t *testing.T) {
 	path := writeTempConfig(t, `
 dry_run: true
-interval: 30m
+collector:
+  interval: 30m
 db_client:
   type: "postgresql"
 file_client:
@@ -50,8 +51,8 @@ file_client:
 	if !cfg.DryRun {
 		t.Error("expected dry_run to be true")
 	}
-	if cfg.Interval != 30*time.Minute {
-		t.Errorf("expected interval 30m, got %v", cfg.Interval)
+	if cfg.Collector.Interval != 30*time.Minute {
+		t.Errorf("expected interval 30m, got %v", cfg.Collector.Interval)
 	}
 	if cfg.FileClientCfg.Type != "fs" {
 		t.Errorf("expected file_client.type fs, got %s", cfg.FileClientCfg.Type)
@@ -213,11 +214,11 @@ file_client:
 	if cfg.DryRun {
 		t.Error("expected dry_run to default to false")
 	}
-	if cfg.Interval != 1*time.Hour {
-		t.Errorf("expected default interval 1h, got %v", cfg.Interval)
+	if cfg.Collector.Interval != 1*time.Hour {
+		t.Errorf("expected default interval 1h, got %v", cfg.Collector.Interval)
 	}
-	if cfg.MaxConcurrency != DefaultMaxConcurrency {
-		t.Errorf("expected default max_concurrency %d, got %d", DefaultMaxConcurrency, cfg.MaxConcurrency)
+	if cfg.Collector.MaxConcurrency != DefaultMaxConcurrency {
+		t.Errorf("expected default max_concurrency %d, got %d", DefaultMaxConcurrency, cfg.Collector.MaxConcurrency)
 	}
 }
 
@@ -225,7 +226,8 @@ func TestLoad_CustomMaxConcurrency(t *testing.T) {
 	path := writeTempConfig(t, `
 db_client:
   type: "postgresql"
-max_concurrency: 20
+collector:
+  max_concurrency: 20
 file_client:
   type: "fs"
   fs:
@@ -235,8 +237,8 @@ file_client:
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.MaxConcurrency != 20 {
-		t.Errorf("expected max_concurrency 20, got %d", cfg.MaxConcurrency)
+	if cfg.Collector.MaxConcurrency != 20 {
+		t.Errorf("expected max_concurrency 20, got %d", cfg.Collector.MaxConcurrency)
 	}
 }
 
@@ -244,7 +246,8 @@ func TestLoad_ErrorZeroMaxConcurrency(t *testing.T) {
 	path := writeTempConfig(t, `
 db_client:
   type: "postgresql"
-max_concurrency: 0
+collector:
+  max_concurrency: 0
 file_client:
   type: "fs"
   fs:
@@ -260,7 +263,8 @@ func TestLoad_ErrorNegativeMaxConcurrency(t *testing.T) {
 	path := writeTempConfig(t, `
 db_client:
   type: "postgresql"
-max_concurrency: -5
+collector:
+  max_concurrency: -5
 file_client:
   type: "fs"
   fs:
@@ -341,7 +345,8 @@ func TestLoad_ErrorInvalidYAML(t *testing.T) {
 
 func TestLoad_ErrorZeroInterval(t *testing.T) {
 	path := writeTempConfig(t, `
-interval: 0s
+collector:
+  interval: 0s
 db_client:
   type: "postgresql"
 file_client:
@@ -357,7 +362,8 @@ file_client:
 
 func TestLoad_ErrorNegativeInterval(t *testing.T) {
 	path := writeTempConfig(t, `
-interval: -5m
+collector:
+  interval: -5m
 db_client:
   type: "postgresql"
 file_client:

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -1075,7 +1075,7 @@ install_batch_gateway() {
         --set "gc.image.repository=${GC_IMG%:*}"
         --set "gc.image.pullPolicy=IfNotPresent"
         --set "gc.image.tag=${IMAGE_TAG}"
-        --set "gc.config.interval=5s"
+        --set "gc.config.collector.interval=5s"
         --namespace "${NAMESPACE}"
     )
 


### PR DESCRIPTION
## Why is this PR needed?

The GC config mixed collector-specific settings with top-level fields, which made the structure harder to extend as more GC-specific configuration was added.
This change groups collector-only fields under a dedicated `collector` section so the config shape is clearer and more consistent across code, sample config, and Helm values.

## What does this PR do?

- add `CollectorConfig` and move GC `interval` / `max_concurrency` under `collector`
- update `batch-gc` config loading, validation, and runtime field references
- update unit tests and the sample GC config to use the new schema
- update Helm values, rendered GC config, helm tests, and `dev-deploy.sh` override path

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #456