### PR TITLE
feat(gc): add Prometheus metrics, health endpoint, and observability

### DIFF
--- a/charts/batch-gateway/dashboards/gc.json
+++ b/charts/batch-gateway/dashboards/gc.json
@@ -1,0 +1,106 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["batch-gateway", "gc", "reconciler"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "default", "value": "default" },
+        "datasource": { "type": "prometheus" },
+        "definition": "label_values(batch_reconciler_cycle_duration_seconds_count, namespace)",
+        "name": "namespace",
+        "type": "query",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "title": "Batch Gateway — GC Reconciler",
+  "uid": "batch-gateway-gc",
+  "panels": [
+    {
+      "title": "Orphans Recovered (rate)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(rate(batch_reconciler_orphans_recovered_total{namespace=\"$namespace\"}[5m])) by (action)",
+          "legendFormat": "{{action}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "title": "Cycle Duration (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(batch_reconciler_cycle_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
+      "title": "Errors & CAS Conflicts (rate)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(batch_reconciler_errors_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "errors"
+        },
+        {
+          "expr": "rate(batch_reconciler_cas_conflicts_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "CAS conflicts"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "title": "Stale In-Flight Cleanup (rate)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "rate(batch_reconciler_stale_cleanup_total{namespace=\"$namespace\"}[5m])",
+          "legendFormat": "stale cleanup"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "ops" }
+      }
+    },
+    {
+      "title": "Orphans Recovered (cumulative)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 16, "w": 24, "h": 6 },
+      "targets": [
+        {
+          "expr": "sum(batch_reconciler_orphans_recovered_total{namespace=\"$namespace\"}) by (action)",
+          "legendFormat": "{{action}}"
+        }
+      ]
+    }
+  ]
+}

--- a/charts/batch-gateway/templates/gc-configmap.yaml
+++ b/charts/batch-gateway/templates/gc-configmap.yaml
@@ -12,6 +12,7 @@ data:
     collector:
       interval: {{ .Values.gc.config.collector.interval | quote }}
       max_concurrency: {{ .Values.gc.config.collector.maxConcurrency }}
+    metrics_addr: {{ .Values.gc.config.metricsAddr | quote }}
     db_client:
       type: {{ .Values.global.dbClient.type | quote }}
       redis:

--- a/charts/batch-gateway/templates/gc-deployment.yaml
+++ b/charts/batch-gateway/templates/gc-deployment.yaml
@@ -37,6 +37,29 @@ spec:
         args:
         - --config=/etc/batch-gc/config.yaml
         - --v={{ .Values.gc.logging.verbosity }}
+        {{- $metricsAddr := .Values.gc.config.metricsAddr }}
+        {{- if not (hasPrefix ":" $metricsAddr) }}
+        {{- fail (printf "gc.config.metricsAddr must be in \":PORT\" format (e.g. \":9091\"), got %q" $metricsAddr) }}
+        {{- end }}
+        {{- $metricsPort := trimPrefix ":" $metricsAddr | int }}
+        {{- if or (le $metricsPort 0) (gt $metricsPort 65535) }}
+        {{- fail (printf "gc.config.metricsAddr port must be 1-65535, got %d" $metricsPort) }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: {{ $metricsPort }}
+          protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /health
+            port: metrics
+          periodSeconds: 5
+          failureThreshold: 60
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: metrics
+          periodSeconds: 30
         resources:
           {{- toYaml .Values.gc.resources | nindent 12 }}
         volumeMounts:

--- a/charts/batch-gateway/templates/gc-podmonitor.yaml
+++ b/charts/batch-gateway/templates/gc-podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.gc.enabled .Values.gc.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "batch-gateway.gc.fullname" . }}
+  labels:
+    {{- include "batch-gateway.gc.labels" . | nindent 4 }}
+    {{- with .Values.gc.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "batch-gateway.gc.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.gc.podMonitor.interval | quote }}
+{{- end }}

--- a/charts/batch-gateway/templates/prometheus-rule.yaml
+++ b/charts/batch-gateway/templates/prometheus-rule.yaml
@@ -71,13 +71,13 @@ spec:
         {{- if .Values.prometheusRule.rules.reconcilerErrors.enabled }}
         - alert: BatchReconcilerErrors
           expr: |
-            rate(batch_reconciler_errors_total{namespace="{{ .Release.Namespace }}"}[10m])
-            > {{ .Values.prometheusRule.rules.reconcilerErrors.thresholdRate }}
+            increase(batch_reconciler_errors_total{namespace="{{ .Release.Namespace }}"}[{{ .Values.prometheusRule.rules.reconcilerErrors.window }}])
+            > 0
           for: {{ .Values.prometheusRule.rules.reconcilerErrors.for | quote }}
           labels:
             severity: warning
           annotations:
             summary: Batch reconciler is encountering errors
-            description: The GC orphan reconciler error rate has been above {{ .Values.prometheusRule.rules.reconcilerErrors.thresholdRate }}/s for {{ .Values.prometheusRule.rules.reconcilerErrors.for }}.
+            description: The GC orphan reconciler encountered errors in the last {{ .Values.prometheusRule.rules.reconcilerErrors.window }}.
         {{- end }}
 {{- end }}

--- a/charts/batch-gateway/templates/prometheus-rule.yaml
+++ b/charts/batch-gateway/templates/prometheus-rule.yaml
@@ -68,4 +68,16 @@ spec:
             summary: Batch Gateway workers are saturated
             description: Worker utilization has been above {{ .Values.prometheusRule.rules.workersSaturated.thresholdRatio }} for {{ .Values.prometheusRule.rules.workersSaturated.for }}.
         {{- end }}
+        {{- if .Values.prometheusRule.rules.reconcilerErrors.enabled }}
+        - alert: BatchReconcilerErrors
+          expr: |
+            rate(batch_reconciler_errors_total{namespace="{{ .Release.Namespace }}"}[10m])
+            > {{ .Values.prometheusRule.rules.reconcilerErrors.thresholdRate }}
+          for: {{ .Values.prometheusRule.rules.reconcilerErrors.for | quote }}
+          labels:
+            severity: warning
+          annotations:
+            summary: Batch reconciler is encountering errors
+            description: The GC orphan reconciler error rate has been above {{ .Values.prometheusRule.rules.reconcilerErrors.thresholdRate }}/s for {{ .Values.prometheusRule.rules.reconcilerErrors.for }}.
+        {{- end }}
 {{- end }}

--- a/charts/batch-gateway/tests/gc-configmap_test.yaml
+++ b/charts/batch-gateway/tests/gc-configmap_test.yaml
@@ -18,6 +18,9 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: 'max_concurrency: 10'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'metrics_addr: ":9091"'
 
   - it: should render custom maxConcurrency
     set:

--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -4,6 +4,7 @@ templates:
   - templates/apiserver-configmap.yaml
   - templates/processor-podmonitor.yaml
   - templates/processor-configmap.yaml
+  - templates/gc-podmonitor.yaml
   - templates/prometheus-rule.yaml
   - templates/grafana-dashboards-configmap.yaml
 # Required: fs file client (the default) needs a pvcName to pass template validation.
@@ -86,6 +87,39 @@ tests:
           count: 0
         template: templates/processor-podmonitor.yaml
 
+  # --- GC PodMonitor ---
+
+  - it: should not render GC PodMonitor when disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/gc-podmonitor.yaml
+
+  - it: should render GC PodMonitor when enabled
+    set:
+      gc.podMonitor.enabled: true
+    asserts:
+      - isKind:
+          of: PodMonitor
+        template: templates/gc-podmonitor.yaml
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+        template: templates/gc-podmonitor.yaml
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: "30s"
+        template: templates/gc-podmonitor.yaml
+
+  - it: should not render GC PodMonitor when gc is disabled
+    set:
+      gc.enabled: false
+      gc.podMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/gc-podmonitor.yaml
+
   # --- PrometheusRule ---
 
   - it: should not render PrometheusRule when disabled (default)
@@ -106,7 +140,7 @@ tests:
           value: batch-gateway.rules
         template: templates/prometheus-rule.yaml
 
-  - it: should render all four alert rules when enabled
+  - it: should render all five alert rules when enabled
     set:
       prometheusRule.enabled: true
     asserts:
@@ -132,6 +166,12 @@ tests:
           path: spec.groups[0].rules
           content:
             alert: BatchGatewayWorkersSaturated
+          any: true
+        template: templates/prometheus-rule.yaml
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: BatchReconcilerErrors
           any: true
         template: templates/prometheus-rule.yaml
 
@@ -175,6 +215,15 @@ tests:
       - matchRegex:
           path: spec.groups[0].rules[3].expr
           pattern: total_workers
+        template: templates/prometheus-rule.yaml
+
+  - it: should use batch_reconciler_errors_total in ReconcilerErrors expr
+    set:
+      prometheusRule.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.groups[0].rules[4].expr
+          pattern: batch_reconciler_errors_total
         template: templates/prometheus-rule.yaml
 
   - it: should not reference tenantID in any PrometheusRule expr
@@ -256,6 +305,31 @@ tests:
       - notMatchRegex:
           path: data["processor.json"]
           pattern: tenantID
+        template: templates/grafana-dashboards-configmap.yaml
+
+  - it: should reference expected GC reconciler metric names in dashboard JSON
+    set:
+      grafana.dashboards.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["gc.json"]
+          pattern: batch_reconciler_orphans_recovered_total
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["gc.json"]
+          pattern: batch_reconciler_cycle_duration_seconds_bucket
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["gc.json"]
+          pattern: batch_reconciler_errors_total
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["gc.json"]
+          pattern: batch_reconciler_cas_conflicts_total
+        template: templates/grafana-dashboards-configmap.yaml
+      - matchRegex:
+          path: data["gc.json"]
+          pattern: batch_reconciler_stale_cleanup_total
         template: templates/grafana-dashboards-configmap.yaml
 
   - it: should reference expected apiserver metric names in dashboard JSON

--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -246,6 +246,10 @@ tests:
           path: spec.groups[0].rules[3].expr
           pattern: tenantID
         template: templates/prometheus-rule.yaml
+      - notMatchRegex:
+          path: spec.groups[0].rules[4].expr
+          pattern: tenantID
+        template: templates/prometheus-rule.yaml
 
   # --- Grafana Dashboards ConfigMap ---
 

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -440,6 +440,10 @@ prometheusRule:
       enabled: true
       thresholdRatio: 0.9
       for: "15m"
+    reconcilerErrors:
+      enabled: true
+      thresholdRate: 0.01
+      for: "10m"
 
 # Garbage Collector configuration
 gc:
@@ -467,6 +471,8 @@ gc:
       interval: "30m"
       # Maximum number of concurrent item deletions per GC cycle
       maxConcurrency: 10
+    # Metrics HTTP server listen address (must be ":PORT" format, e.g. ":9091")
+    metricsAddr: ":9091"
 
   # Per-component podSecurityContext override (optional).
   # If not set, inherits global.podSecurityContext.
@@ -489,6 +495,13 @@ gc:
 
   logging:
     verbosity: 2
+
+  # PodMonitor for Prometheus Operator scraping of GC metrics.
+  podMonitor:
+    enabled: false
+    interval: "30s"
+    # Extra labels to match Prometheus Operator's podMonitorSelector.
+    labels: {}
 
   nodeSelector: {}
   tolerations: []

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -442,8 +442,11 @@ prometheusRule:
       for: "15m"
     reconcilerErrors:
       enabled: true
-      thresholdRate: 0.01
-      for: "10m"
+      # window must be >= reconciler interval (default 60m in gc config) + ~5m scrape buffer.
+      # Uses increase(), not rate(), because errors arrive at most once per cycle.
+      window: "65m"
+      # Suppress brief eval/scrape jitter once the condition is true.
+      for: "5m"
 
 # Garbage Collector configuration
 gc:

--- a/cmd/batch-gc/config.yaml
+++ b/cmd/batch-gc/config.yaml
@@ -10,6 +10,9 @@ collector:
   # Maximum number of concurrent item deletions per GC cycle (default: 10)
   max_concurrency: 10
 
+# Metrics HTTP server listen address (default: ":9091")
+metrics_addr: ":9091"
+
 # Database client configuration
 db_client:
   # Type selects the database backend: "redis" or "postgresql".

--- a/cmd/batch-gc/main.go
+++ b/cmd/batch-gc/main.go
@@ -24,15 +24,21 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 
 	"golang.org/x/sync/errgroup"
 
 	"github.com/llm-d-incubation/batch-gateway/internal/gc/collector"
 	gcconfig "github.com/llm-d-incubation/batch-gateway/internal/gc/config"
+	gcmetrics "github.com/llm-d-incubation/batch-gateway/internal/gc/metrics"
 	"github.com/llm-d-incubation/batch-gateway/internal/gc/reconciler"
 	"github.com/llm-d-incubation/batch-gateway/internal/util/clientset"
 	ucom "github.com/llm-d-incubation/batch-gateway/internal/util/com"
@@ -64,6 +70,10 @@ func run() error {
 
 	logger.Info("Starting batch garbage collector", "dryRun", cfg.DryRun, "interval", cfg.Collector.Interval)
 
+	if err := gcmetrics.InitMetrics(); err != nil {
+		return fmt.Errorf("failed to initialize metrics: %w", err)
+	}
+
 	ctx, cancel := interrupt.ContextWithSignal(ctx)
 	defer cancel()
 
@@ -83,23 +93,85 @@ func run() error {
 	}
 	defer func() { _ = clients.Close() }()
 
+	var ready atomic.Bool
+	if err := startMetricsServer(ctx, cfg.MetricsAddr, logger, &ready); err != nil {
+		return err
+	}
+
 	gc := collector.NewGarbageCollector(clients.BatchDB, clients.FileDB, clients.File, cfg.DryRun, cfg.Collector.Interval, cfg.Collector.MaxConcurrency, nil)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error { return gc.RunLoop(gCtx) })
 
 	if cfg.Reconciler.Enabled {
-		rec, err := reconciler.NewReconciler(clients.BatchDB, clients.Queue, clients.InFlight, cfg.Reconciler.Interval, cfg.DryRun, nil)
+		onCycle := func(r *reconciler.Result) {
+			gcmetrics.RecordCycleDuration(r.Duration)
+			if !cfg.DryRun {
+				gcmetrics.RecordOrphansRecovered(gcmetrics.ActionCancelled, r.Cancelled)
+				gcmetrics.RecordOrphansRecovered(gcmetrics.ActionExpired, r.Expired)
+				gcmetrics.RecordOrphansRecovered(gcmetrics.ActionReEnqueued, r.ReEnqueued)
+				gcmetrics.RecordOrphansRecovered(gcmetrics.ActionFailed, r.Failed)
+				gcmetrics.RecordStaleCleanup(r.StaleCleanup)
+			}
+			gcmetrics.RecordCASConflicts(r.Conflicts)
+			gcmetrics.RecordErrors(r.Errors)
+		}
+		rec, err := reconciler.NewReconciler(clients.BatchDB, clients.Queue, clients.InFlight, cfg.Reconciler.Interval, cfg.DryRun, onCycle)
 		if err != nil {
 			return fmt.Errorf("failed to create reconciler: %w", err)
 		}
 		g.Go(func() error { return rec.RunLoop(gCtx) })
 	}
 
+	ready.Store(true)
+	logger.Info("GC workers started, marking ready")
+
 	if err := g.Wait(); err != nil && ctx.Err() == nil {
 		return fmt.Errorf("gc/reconciler failed: %w", err)
 	}
 
 	logger.Info("Garbage collector shut down gracefully")
+	return nil
+}
+
+func startMetricsServer(ctx context.Context, addr string, logger logr.Logger, ready *atomic.Bool) error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		if !ready.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("metrics server listen on %s: %w", addr, err)
+	}
+
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			logger.Error(err, "Metrics server shutdown failed")
+		}
+	}()
+
+	go func() {
+		logger.Info("Metrics server listening", "addr", ln.Addr())
+		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.Error(err, "Metrics server failed")
+		}
+	}()
+
 	return nil
 }

--- a/cmd/batch-gc/main.go
+++ b/cmd/batch-gc/main.go
@@ -94,13 +94,22 @@ func run() error {
 	defer func() { _ = clients.Close() }()
 
 	var ready atomic.Bool
-	if err := startMetricsServer(ctx, cfg.MetricsAddr, logger, &ready); err != nil {
+	metricsErrCh, err := startMetricsServer(ctx, cfg.MetricsAddr, logger, &ready)
+	if err != nil {
 		return err
 	}
 
 	gc := collector.NewGarbageCollector(clients.BatchDB, clients.FileDB, clients.File, cfg.DryRun, cfg.Collector.Interval, cfg.Collector.MaxConcurrency, nil)
 
 	g, gCtx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		select {
+		case err := <-metricsErrCh:
+			return err
+		case <-gCtx.Done():
+			return gCtx.Err()
+		}
+	})
 	g.Go(func() error { return gc.RunLoop(gCtx) })
 
 	if cfg.Reconciler.Enabled {
@@ -134,7 +143,7 @@ func run() error {
 	return nil
 }
 
-func startMetricsServer(ctx context.Context, addr string, logger logr.Logger, ready *atomic.Bool) error {
+func startMetricsServer(ctx context.Context, addr string, logger logr.Logger, ready *atomic.Bool) (<-chan error, error) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -149,7 +158,7 @@ func startMetricsServer(ctx context.Context, addr string, logger logr.Logger, re
 
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("metrics server listen on %s: %w", addr, err)
+		return nil, fmt.Errorf("metrics server listen on %s: %w", addr, err)
 	}
 
 	server := &http.Server{
@@ -166,12 +175,14 @@ func startMetricsServer(ctx context.Context, addr string, logger logr.Logger, re
 		}
 	}()
 
+	errCh := make(chan error, 1)
 	go func() {
 		logger.Info("Metrics server listening", "addr", ln.Addr())
 		if err := server.Serve(ln); err != nil && err != http.ErrServerClosed {
 			logger.Error(err, "Metrics server failed")
+			errCh <- fmt.Errorf("metrics server: %w", err)
 		}
 	}()
 
-	return nil
+	return errCh, nil
 }

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -73,6 +73,26 @@ Processor metrics intentionally omit unbounded identifiers such as tenant IDs. P
 
 - `batch_startup_recovery_total{status,action}` (Counter) - Jobs recovered during processor startup after a container restart. `status` is the recovered job status (common values: `in_progress`, `finalizing`, `cancelling`, `validating`, `unknown`). `action` is the recovery action taken (common values: `re_enqueued`, `failed`, `finalized`, `cancelled`, `expired`, `cleaned_up`, `error`). Non-zero values indicate prior container-level crashes (OOM, panic) or stale on-disk artifacts from a prior processor instance.
 
+## Garbage Collector — Reconciler
+
+The GC reconciler exposes the following Prometheus metrics (`internal/gc/metrics/metrics.go`) on port 9091 (configurable via `metrics_addr`):
+
+**Orphan Recovery:**
+
+- `batch_reconciler_orphans_recovered_total{action}` (Counter) - Orphans recovered by action type. `action` values: `cancelled`, `expired`, `re_enqueued`, `failed`. Not incremented when `dry_run: true` (no actual state change occurs).
+
+**Cycle Metrics:**
+
+- `batch_reconciler_cycle_duration_seconds` (Histogram) - Wall-clock time per reconciliation cycle. Uses exponential buckets from 100ms to ~30min (`ExponentialBuckets(0.1, 3, 10)`). Recorded for all cycles including failed ones (early-return error paths).
+
+**Conflict & Error Metrics:**
+
+- `batch_reconciler_cas_conflicts_total` (Counter) - CAS conflicts where another actor won the race during orphan transition.
+
+- `batch_reconciler_stale_cleanup_total` (Counter) - Stale in-flight entries cleaned up (entries for jobs no longer in a non-terminal state). Not incremented when `dry_run: true`.
+
+- `batch_reconciler_errors_total` (Counter) - Errors encountered during a reconciliation cycle (DB fetch failures, transition errors, etc.).
+
 ## Shared (file storage retry client)
 
 Used by components that wrap file storage with retries (`internal/files_store/retryclient/metrics.go`):

--- a/docs/guides/metrics.md
+++ b/docs/guides/metrics.md
@@ -1,7 +1,7 @@
 # Metrics
 
-**Revision:** 1.3
-**Last Modified:** 2026-03-30
+**Revision:** 1.4
+**Last Modified:** 2026-05-29
 
 Metric names below match `internal/*/metrics/metrics.go` (and related packages). Deployments may add a namespace/subsystem prefix when registering; check `/metrics` on the running binary for the exact series name.
 
@@ -92,6 +92,20 @@ The GC reconciler exposes the following Prometheus metrics (`internal/gc/metrics
 - `batch_reconciler_stale_cleanup_total` (Counter) - Stale in-flight entries cleaned up (entries for jobs no longer in a non-terminal state). Not incremented when `dry_run: true`.
 
 - `batch_reconciler_errors_total` (Counter) - Errors encountered during a reconciliation cycle (DB fetch failures, transition errors, etc.).
+
+**Alerting (`BatchReconcilerErrors`):**
+
+The Helm chart ships a PrometheusRule (`prometheusRule.rules.reconcilerErrors`) that fires when:
+
+```promql
+increase(batch_reconciler_errors_total{namespace="<release namespace>"}[<window>]) > 0
+```
+
+**Why `increase`, not `rate`:** the reconciler runs on a long interval (default 60 minutes). A cycle-level failure such as a DB fetch error increments the counter once per cycle, which is too sparse for a meaningful `rate()` threshold.
+
+**Tuning `window`:** set it to at least one full reconciler scan interval plus a small buffer for Prometheus scrape/evaluation delay. The default `65m` matches the default reconciler interval of 60 minutes. If you change `reconciler.interval` in the GC config, increase `window` to match (for example, interval `90m` → window `95m`). A window shorter than the interval can miss once-per-cycle failures; a much longer window keeps the alert firing longer after an error ages out of the window.
+
+**Tuning `for`:** default `5m` avoids paging on a single brief evaluation blip. It does not need to track the reconciler interval.
 
 ## Shared (file storage retry client)
 

--- a/internal/gc/config/config.go
+++ b/internal/gc/config/config.go
@@ -19,7 +19,9 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -48,9 +50,13 @@ type CollectorConfig struct {
 	MaxConcurrency int           `yaml:"max_concurrency"`
 }
 
+// DefaultMetricsAddr is the default listen address for the metrics HTTP server.
+const DefaultMetricsAddr = ":9091"
+
 // Config holds the garbage collector configuration.
 type Config struct {
-	DryRun bool `yaml:"dry_run"`
+	DryRun      bool   `yaml:"dry_run"`
+	MetricsAddr string `yaml:"metrics_addr"`
 
 	// Collector holds the collector-specific configuration (interval, concurrency).
 	Collector CollectorConfig `yaml:"collector"`
@@ -78,6 +84,7 @@ func Load(path string) (*Config, error) {
 			Interval:       1 * time.Hour,
 			MaxConcurrency: DefaultMaxConcurrency,
 		},
+		MetricsAddr: DefaultMetricsAddr,
 		Reconciler: ReconcilerConfig{
 			Enabled:  true,
 			Interval: DefaultReconcilerInterval,
@@ -97,6 +104,10 @@ func Load(path string) (*Config, error) {
 
 	if cfg.Reconciler.Enabled && cfg.Reconciler.Interval <= 0 {
 		return nil, fmt.Errorf("reconciler.interval must be positive when enabled, got %v", cfg.Reconciler.Interval)
+	}
+
+	if err := validateMetricsAddr(cfg.MetricsAddr); err != nil {
+		return nil, fmt.Errorf("metrics_addr: %w", err)
 	}
 
 	switch cfg.DBClientCfg.Type {
@@ -122,4 +133,22 @@ func Load(path string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// validateMetricsAddr ensures addr is in ":PORT" format (e.g. ":9091").
+// The Helm chart derives the containerPort by trimming the leading colon,
+// so host:port forms like "0.0.0.0:9091" are intentionally rejected.
+func validateMetricsAddr(addr string) error {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return fmt.Errorf("must be :PORT format (e.g. \":9091\"), got %q", addr)
+	}
+	if host != "" {
+		return fmt.Errorf("must be :PORT format (e.g. \":9091\"), got %q; host part is not supported", addr)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return fmt.Errorf("port must be 1-65535, got %q", portStr)
+	}
+	return nil
 }

--- a/internal/gc/config/config_test.go
+++ b/internal/gc/config/config_test.go
@@ -479,6 +479,49 @@ file_client:
 	}
 }
 
+func TestLoad_MetricsAddr(t *testing.T) {
+	valid := []string{":9091", ":8080", ":1", ":65535"}
+	for _, addr := range valid {
+		t.Run("valid_"+addr, func(t *testing.T) {
+			path := writeTempConfig(t, `
+metrics_addr: "`+addr+`"
+db_client:
+  type: "postgresql"
+file_client:
+  type: "fs"
+  fs:
+    base_path: "/tmp/files"
+`)
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", addr, err)
+			}
+			if cfg.MetricsAddr != addr {
+				t.Fatalf("metrics_addr=%q, want %q", cfg.MetricsAddr, addr)
+			}
+		})
+	}
+
+	invalid := []string{"9091", "0.0.0.0:9091", "localhost:9091", "example.com:9091", ":0", ":99999"}
+	for _, addr := range invalid {
+		t.Run("invalid_"+addr, func(t *testing.T) {
+			path := writeTempConfig(t, `
+metrics_addr: "`+addr+`"
+db_client:
+  type: "postgresql"
+file_client:
+  type: "fs"
+  fs:
+    base_path: "/tmp/files"
+`)
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("expected error for metrics_addr %q", addr)
+			}
+		})
+	}
+}
+
 func TestLoad_RedisConfigTuning(t *testing.T) {
 	path := writeTempConfig(t, `
 db_client:

--- a/internal/gc/metrics/metrics.go
+++ b/internal/gc/metrics/metrics.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics provides Prometheus instrumentation for the GC reconciler.
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	initOnce              sync.Once
+	initErr               error
+	orphansRecoveredTotal *prometheus.CounterVec
+	cycleDuration         prometheus.Histogram
+	casConflictsTotal     prometheus.Counter
+	staleCleanupTotal     prometheus.Counter
+	errorsTotal           prometheus.Counter
+)
+
+// InitMetrics creates and registers all reconciler Prometheus metrics.
+// It is safe to call multiple times; only the first call has effect.
+func InitMetrics() error {
+	initOnce.Do(func() {
+		initErr = initMetrics()
+	})
+	return initErr
+}
+
+func initMetrics() error {
+	orphansRecoveredTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "batch_reconciler_orphans_recovered_total",
+			Help: "Orphans recovered by action type",
+		},
+		[]string{"action"},
+	)
+
+	cycleDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "batch_reconciler_cycle_duration_seconds",
+			Help:    "Time taken per reconciliation cycle",
+			Buckets: prometheus.ExponentialBuckets(0.1, 3, 10),
+		},
+	)
+
+	casConflictsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "batch_reconciler_cas_conflicts_total",
+			Help: "CAS conflicts (another actor won the race)",
+		},
+	)
+
+	staleCleanupTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "batch_reconciler_stale_cleanup_total",
+			Help: "Stale in-flight entries cleaned up",
+		},
+	)
+
+	errorsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "batch_reconciler_errors_total",
+			Help: "Errors encountered during a reconciliation cycle",
+		},
+	)
+
+	for _, c := range []prometheus.Collector{
+		orphansRecoveredTotal,
+		cycleDuration,
+		casConflictsTotal,
+		staleCleanupTotal,
+		errorsTotal,
+	} {
+		if err := prometheus.Register(c); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Action labels for orphans_recovered_total.
+const (
+	ActionCancelled  = "cancelled"
+	ActionExpired    = "expired"
+	ActionReEnqueued = "re_enqueued"
+	ActionFailed     = "failed"
+)
+
+// RecordOrphansRecovered increments the orphan recovery counter for the given action.
+func RecordOrphansRecovered(action string, count int) {
+	if count > 0 {
+		orphansRecoveredTotal.WithLabelValues(action).Add(float64(count))
+	}
+}
+
+// RecordCycleDuration observes the duration of a reconciliation cycle.
+func RecordCycleDuration(d time.Duration) {
+	cycleDuration.Observe(d.Seconds())
+}
+
+// RecordCASConflicts adds the given count to the CAS conflicts counter.
+func RecordCASConflicts(count int) {
+	if count > 0 {
+		casConflictsTotal.Add(float64(count))
+	}
+}
+
+// RecordStaleCleanup adds the given count to the stale cleanup counter.
+func RecordStaleCleanup(count int) {
+	if count > 0 {
+		staleCleanupTotal.Add(float64(count))
+	}
+}
+
+// RecordErrors adds the given count to the errors counter.
+func RecordErrors(count int) {
+	if count > 0 {
+		errorsTotal.Add(float64(count))
+	}
+}

--- a/internal/gc/metrics/metrics_test.go
+++ b/internal/gc/metrics/metrics_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func withIsolatedPromRegistry(t *testing.T, fn func(reg *prometheus.Registry)) {
+	t.Helper()
+	oldReg, oldGather := prometheus.DefaultRegisterer, prometheus.DefaultGatherer
+	reg := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = reg
+	prometheus.DefaultGatherer = reg
+	initOnce = sync.Once{}
+	initErr = nil
+	t.Cleanup(func() {
+		prometheus.DefaultRegisterer = oldReg
+		prometheus.DefaultGatherer = oldGather
+		initOnce = sync.Once{}
+		initErr = nil
+	})
+	fn(reg)
+}
+
+func collectFamilies(t *testing.T, reg *prometheus.Registry) map[string]*dto.MetricFamily {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	out := make(map[string]*dto.MetricFamily, len(mfs))
+	for _, mf := range mfs {
+		out[mf.GetName()] = mf
+	}
+	return out
+}
+
+func counterValue(mf *dto.MetricFamily) float64 {
+	if mf == nil || len(mf.Metric) == 0 {
+		return -1
+	}
+	return mf.Metric[0].GetCounter().GetValue()
+}
+
+func counterWithLabel(mf *dto.MetricFamily, label, value string) float64 {
+	if mf == nil {
+		return -1
+	}
+	for _, m := range mf.Metric {
+		for _, lp := range m.Label {
+			if lp.GetName() == label && lp.GetValue() == value {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func TestInitMetrics(t *testing.T) {
+	t.Run("registers all metrics", func(t *testing.T) {
+		withIsolatedPromRegistry(t, func(reg *prometheus.Registry) {
+			if err := InitMetrics(); err != nil {
+				t.Fatalf("InitMetrics: %v", err)
+			}
+
+			RecordOrphansRecovered(ActionCancelled, 3)
+			RecordOrphansRecovered(ActionExpired, 1)
+			RecordOrphansRecovered(ActionReEnqueued, 2)
+			RecordOrphansRecovered(ActionFailed, 1)
+			RecordCycleDuration(5 * time.Second)
+			RecordCASConflicts(4)
+			RecordStaleCleanup(2)
+			RecordErrors(1)
+
+			f := collectFamilies(t, reg)
+
+			if v := counterWithLabel(f["batch_reconciler_orphans_recovered_total"], "action", ActionCancelled); v != 3 {
+				t.Fatalf("orphans_recovered{cancelled}=%v, want 3", v)
+			}
+			if v := counterWithLabel(f["batch_reconciler_orphans_recovered_total"], "action", ActionExpired); v != 1 {
+				t.Fatalf("orphans_recovered{expired}=%v, want 1", v)
+			}
+			if v := counterWithLabel(f["batch_reconciler_orphans_recovered_total"], "action", ActionReEnqueued); v != 2 {
+				t.Fatalf("orphans_recovered{re_enqueued}=%v, want 2", v)
+			}
+			if v := counterWithLabel(f["batch_reconciler_orphans_recovered_total"], "action", ActionFailed); v != 1 {
+				t.Fatalf("orphans_recovered{failed}=%v, want 1", v)
+			}
+
+			mf := f["batch_reconciler_cycle_duration_seconds"]
+			if mf == nil || len(mf.Metric) == 0 {
+				t.Fatal("cycle_duration_seconds: missing")
+			}
+			if mf.Metric[0].GetHistogram().GetSampleCount() != 1 {
+				t.Fatalf("cycle_duration_seconds sample_count=%d, want 1", mf.Metric[0].GetHistogram().GetSampleCount())
+			}
+
+			if v := counterValue(f["batch_reconciler_cas_conflicts_total"]); v != 4 {
+				t.Fatalf("cas_conflicts=%v, want 4", v)
+			}
+			if v := counterValue(f["batch_reconciler_stale_cleanup_total"]); v != 2 {
+				t.Fatalf("stale_cleanup=%v, want 2", v)
+			}
+			if v := counterValue(f["batch_reconciler_errors_total"]); v != 1 {
+				t.Fatalf("errors=%v, want 1", v)
+			}
+		})
+	})
+
+	t.Run("zero counts are not recorded", func(t *testing.T) {
+		withIsolatedPromRegistry(t, func(reg *prometheus.Registry) {
+			if err := InitMetrics(); err != nil {
+				t.Fatalf("InitMetrics: %v", err)
+			}
+
+			RecordOrphansRecovered(ActionCancelled, 0)
+			RecordCASConflicts(0)
+			RecordStaleCleanup(0)
+			RecordErrors(0)
+
+			f := collectFamilies(t, reg)
+
+			if _, ok := f["batch_reconciler_orphans_recovered_total"]; ok {
+				t.Fatal("orphans_recovered should not appear for zero-count recording")
+			}
+			if v := counterValue(f["batch_reconciler_cas_conflicts_total"]); v != 0 {
+				t.Fatalf("cas_conflicts=%v, want 0", v)
+			}
+		})
+	})
+
+	t.Run("double init does not error", func(t *testing.T) {
+		withIsolatedPromRegistry(t, func(_ *prometheus.Registry) {
+			if err := InitMetrics(); err != nil {
+				t.Fatalf("first InitMetrics: %v", err)
+			}
+			if err := InitMetrics(); err != nil {
+				t.Fatalf("second InitMetrics: %v", err)
+			}
+		})
+	})
+}

--- a/internal/gc/reconciler/reconciler.go
+++ b/internal/gc/reconciler/reconciler.go
@@ -45,6 +45,7 @@ type Result struct {
 	StaleCleanup int
 	Conflicts    int
 	Errors       int
+	Duration     time.Duration
 }
 
 // Reconciler periodically scans for orphaned batch jobs and recovers them.
@@ -115,13 +116,28 @@ func (r *Reconciler) RunLoop(ctx context.Context) error {
 // run executes a single reconciliation cycle.
 func (r *Reconciler) run(ctx context.Context) {
 	logger := logr.FromContextOrDiscard(ctx)
+	start := time.Now()
 	result := &Result{}
+
+	defer func() {
+		result.Duration = time.Since(start)
+		logger.Info("Reconciler: cycle completed",
+			"cancelled", result.Cancelled,
+			"expired", result.Expired,
+			"reEnqueued", result.ReEnqueued,
+			"failed", result.Failed,
+			"staleCleanup", result.StaleCleanup,
+			"conflicts", result.Conflicts,
+			"errors", result.Errors,
+			"duration", result.Duration,
+		)
+		r.notifyCycle(result)
+	}()
 
 	jobs, err := r.fetchNonTerminalJobs(ctx)
 	if err != nil {
 		logger.Error(err, "Reconciler: failed to fetch non-terminal jobs")
 		result.Errors++
-		r.notifyCycle(result)
 		return
 	}
 
@@ -129,7 +145,6 @@ func (r *Reconciler) run(ctx context.Context) {
 	if err != nil {
 		logger.Error(err, "Reconciler: failed to get in-flight entries")
 		result.Errors++
-		r.notifyCycle(result)
 		return
 	}
 
@@ -140,7 +155,6 @@ func (r *Reconciler) run(ctx context.Context) {
 		if err != nil {
 			logger.Error(err, "Reconciler: failed to get queued job IDs")
 			result.Errors++
-			r.notifyCycle(result)
 			return
 		}
 
@@ -166,18 +180,6 @@ func (r *Reconciler) run(ctx context.Context) {
 	}
 
 	r.cleanupStaleInflight(ctx, inflightEntries, nonTerminalIDs, result)
-
-	logger.Info("Reconciler: cycle completed",
-		"cancelled", result.Cancelled,
-		"expired", result.Expired,
-		"reEnqueued", result.ReEnqueued,
-		"failed", result.Failed,
-		"staleCleanup", result.StaleCleanup,
-		"conflicts", result.Conflicts,
-		"errors", result.Errors,
-	)
-
-	r.notifyCycle(result)
 }
 
 func (r *Reconciler) notifyCycle(result *Result) {

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -34,6 +34,9 @@ LOG_VERBOSITY="${LOG_VERBOSITY:-5}"
 APISERVER_NODE_PORT="${APISERVER_NODE_PORT:-30080}"
 APISERVER_OBS_NODE_PORT="${APISERVER_OBS_NODE_PORT:-30081}"
 PROCESSOR_NODE_PORT="${PROCESSOR_NODE_PORT:-30090}"
+# Metrics ports must match values.yaml defaults (processor.addr / gc.config.metricsAddr)
+PROCESSOR_METRICS_PORT="${PROCESSOR_METRICS_PORT:-9090}"
+GC_METRICS_PORT="${GC_METRICS_PORT:-9091}"
 JAEGER_NODE_PORT="${JAEGER_NODE_PORT:-30086}"
 PROMETHEUS_NODE_PORT="${PROMETHEUS_NODE_PORT:-30091}"
 GRAFANA_NODE_PORT="${GRAFANA_NODE_PORT:-30030}"
@@ -573,9 +576,29 @@ data:
         action: keep
       - source_labels: [__meta_kubernetes_pod_ip]
         target_label: __address__
-        replacement: \$1:9090
+        replacement: \$1:${PROCESSOR_METRICS_PORT}
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: pod
+    - job_name: 'batch-gateway-gc'
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ['${NAMESPACE}']
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+        regex: gc
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        regex: ${HELM_RELEASE}
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_ip]
+        target_label: __address__
+        replacement: \$1:${GC_METRICS_PORT}
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: namespace
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Why is this PR needed?

The GC reconciler (#452) runs periodic cycles to recover orphaned batch jobs, but has no observability. Operators can't tell whether the reconciler is running, how long cycles take, or if errors are occurring.

## What does this PR do?

Adds a Prometheus metrics HTTP server to `batch-gc` and wires end-to-end observability:

**Go (runtime)**
- New `internal/gc/metrics` package: five Prometheus metrics — `orphans_recovered_total` (by action), `cycle_duration_seconds` (histogram), `errors_total`, `cas_conflicts_total`, `stale_cleanup_total`
- Registration guarded by `sync.Once` to prevent duplicate-collector panics
- `/health` endpoint gated by `atomic.Bool` — returns 503 until GC workers are initialized
- `Result.Duration` field + `defer`-based timing in `reconciler.run()` so early-return error paths still report accurate cycle duration
- Dry-run mode skips mutation counters (`orphans_recovered_total`, `stale_cleanup_total`) since no actual changes occur
- Strict `:PORT` validation for `metrics_addr` in config loader (rejects `host:port` to stay consistent with Helm's `trimPrefix` parsing)
- Metrics server bind failure (`net.Listen`) is a startup error, not a silent log

**Helm/Kubernetes**
- `gc-deployment.yaml`: `startupProbe` (5s × 60 = 5min budget) + `livenessProbe` — avoids restart loops during slow client init
- `gc-deployment.yaml`: template-level `fail` validation for `metricsAddr` format and port range
- `gc-podmonitor.yaml`: PodMonitor for Prometheus Operator scraping
- `prometheus-rule.yaml`: `BatchReconcilerErrors` alert (default threshold 0.01/s over 10m)
- `gc.json`: Grafana dashboard with orphan recovery, cycle duration percentiles, errors, CAS conflicts, and stale cleanup panels
- Helm unit tests for PodMonitor, PrometheusRule, and dashboard metric guards

**Local dev**
- `dev-deploy.sh`: GC scrape job uses `GC_METRICS_PORT` variable (not hardcoded) + explicit `namespace` relabel for dashboard compatibility
- `metrics.md`: documents new GC metrics and dry-run semantics

**Design decisions worth noting:**
- `metrics_addr` is restricted to `:PORT` format (not `host:port`) because the Helm template derives `containerPort` via `trimPrefix ":"`. Allowing a host part would silently produce `containerPort: 0`. Both Go config and Helm template enforce this independently.
- `startupProbe` instead of a single `livenessProbe` with long `initialDelaySeconds` — the probe correctly handles variable startup time without masking a stuck process after init.
- Histogram buckets use `ExponentialBuckets(0.1, 3, 10)` (~100ms to 30min) instead of `DefBuckets` (up to 10s), matching real GC cycle durations that can span minutes.


<img width="1155" height="670" alt="Screenshot 2026-05-29 at 3 50 07 PM" src="https://github.com/user-attachments/assets/76ad1949-22e0-46a8-9013-608cdd84e3aa" />


## How was this tested?

- [x] Unit tests added/updated/verified (`go test ./internal/gc/...`)
- [x] Helm unit tests added/updated/verified (`helm unittest`)
- [x] `pre-commit run -a` passes
- [x] Manual testing: `make dev-deploy` → Prometheus scrapes GC target (`batch-gateway-gc: up`) → Grafana dashboard shows cycle duration and counter data with `namespace=default`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #453