### PR TITLE
feat(helm): add RHOAI monitoring label to ServiceMonitor and PodMonitor

### DIFF
--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -34,6 +34,15 @@ tests:
           value: "30s"
         template: templates/apiserver-servicemonitor.yaml
 
+  - it: should include RHOAI monitoring label on ServiceMonitor by default
+    set:
+      apiserver.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["monitoring.opendatahub.io/scrape"]
+          value: "true"
+        template: templates/apiserver-servicemonitor.yaml
+
   - it: should apply custom ServiceMonitor interval
     set:
       apiserver.serviceMonitor.enabled: true
@@ -75,6 +84,15 @@ tests:
       - equal:
           path: spec.podMetricsEndpoints[0].interval
           value: "30s"
+        template: templates/processor-podmonitor.yaml
+
+  - it: should include RHOAI monitoring label on PodMonitor by default
+    set:
+      processor.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["monitoring.opendatahub.io/scrape"]
+          value: "true"
         template: templates/processor-podmonitor.yaml
 
   - it: should not render PodMonitor when processor is disabled

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -221,7 +221,9 @@ apiserver:
     enabled: false
     interval: "30s"
     # Extra labels to match Prometheus Operator's serviceMonitorSelector.
-    labels: {}
+    # The RHOAI monitoring label enables metrics scraping by the ODH observability stack.
+    labels:
+      monitoring.opendatahub.io/scrape: "true"
 
   # Logging configuration
   logging:
@@ -402,7 +404,9 @@ processor:
     enabled: false
     interval: "30s"
     # Extra labels to match Prometheus Operator's podMonitorSelector.
-    labels: {}
+    # The RHOAI monitoring label enables metrics scraping by the ODH observability stack.
+    labels:
+      monitoring.opendatahub.io/scrape: "true"
 
   # Logging configuration
   logging:


### PR DESCRIPTION
## Why is this PR needed?

The ODH/RHOAI observability stack requires `monitoring.opendatahub.io/scrape: "true"` on monitor CRs to discover and scrape metrics. Without it, metrics collection silently fails.

Ref: [ODH-ADR-Operator-0010](https://github.com/opendatahub-io/architecture-decision-records/blob/main/architecture-decision-records/operator/ODH-ADR-Operator-0010-Observability-component%20metrics%20scraping.md)

## What does this PR do?

Adds `monitoring.opendatahub.io/scrape: "true"` as default label for the apiserver ServiceMonitor and processor PodMonitor in `values.yaml`. Both remain disabled by default.

## How was this tested?

- [x] Helm unit tests added/verified (`make test-helm` — 94 passed)
- [x] Unit tests verified (`make test` — 976 passed)

## Related Issues

[RHOAIENG-63967](https://issues.redhat.com/browse/RHOAIENG-63967)