### PR TITLE
test(e2e): restore RetryOn429 and use /admin/config for failure injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,8 +377,6 @@ benchmark-local-teardown:
 test-e2e:
 	@echo "Running E2E tests..."
 	@OUT=$$(mktemp); \
-	export TEST_SIM_SERVICE_429=$${VLLM_SIM_429_NAME:-vllm-sim-429}; \
-	export TEST_SIM_SERVICE_AIMD=$${VLLM_SIM_AIMD_NAME:-vllm-sim-aimd}; \
 	cd test/e2e && $(GO) test -v -count=1 $(if $(TEST_RUN),-run $(TEST_RUN)) ./... 2>&1 | tee $$OUT; \
 	TEST_EXIT=$${PIPESTATUS[0]}; \
 	PASS_COUNT=$$(grep -- '--- PASS:' $$OUT 2>/dev/null | wc -l | tr -d ' '); \

--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,8 @@ benchmark-local-teardown:
 test-e2e:
 	@echo "Running E2E tests..."
 	@OUT=$$(mktemp); \
+	export TEST_SIM_SERVICE_429=$${VLLM_SIM_429_NAME:-vllm-sim-429}; \
+	export TEST_SIM_SERVICE_AIMD=$${VLLM_SIM_AIMD_NAME:-vllm-sim-aimd}; \
 	cd test/e2e && $(GO) test -v -count=1 $(if $(TEST_RUN),-run $(TEST_RUN)) ./... 2>&1 | tee $$OUT; \
 	TEST_EXIT=$${PIPESTATUS[0]}; \
 	PASS_COUNT=$$(grep -- '--- PASS:' $$OUT 2>/dev/null | wc -l | tr -d ' '); \

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -47,6 +47,12 @@ cleanup_kubernetes_resources() {
     kubectl delete deployment,svc "${VLLM_SIM_AIMD_NAME}" -n "${NAMESPACE}" --ignore-not-found=true
     kubectl delete deployment,svc "${MINIO_NAME}" -n "${NAMESPACE}" --ignore-not-found=true
 
+    # Delete e2e helper pods (created by test runs, safe to ignore if absent)
+    kubectl delete pod "batch-gateway-e2e-curl" -n "${NAMESPACE}" --ignore-not-found=true
+    # Legacy pod name from before curl pod consolidation; remove once no
+    # clusters are likely to have it lingering (safe to drop after v0.10+).
+    kubectl delete pod "batch-gateway-epp-metrics-curl" -n "${NAMESPACE}" --ignore-not-found=true
+
     # Delete secrets
     log "Deleting secrets..."
     kubectl delete secret "${APP_SECRET_NAME}" "${TLS_SECRET_NAME}" -n "${NAMESPACE}" --ignore-not-found=true

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -41,7 +41,7 @@ This script:
 | `FILES_PVC_NAME`      | `<HELM_RELEASE>-files`                     | Name of the PVC created for file storage           |
 | `VLLM_SIM_NAME`       | `vllm-sim`                                 | Name of the vLLM simulator deployment              |
 | `VLLM_SIM_MODEL`      | `sim-model`                                | Model name served by the simulator                 |
-| `VLLM_SIM_IMAGE`      | `ghcr.io/llm-d/llm-d-inference-sim:latest` | vLLM simulator image                               |
+| `VLLM_SIM_IMAGE`      | `ghcr.io/llm-d/llm-d-inference-sim:latest` | vLLM simulator image (>= v0.9.1 required for `/admin/config`) |
 
 Example with overrides:
 
@@ -70,6 +70,8 @@ make test-e2e
 | `TEST_POSTGRESQL_RELEASE` | `postgresql`                     | Helm release name for PostgreSQL (used by GC tests)        |
 | `TEST_MODEL`              | `sim-model`                      | Primary model name for batch input                         |
 | `TEST_MODEL_B`            | `sim-model-b`                    | Secondary model name for multi-model tests                 |
+| `TEST_SIM_SERVICE_429`    | `vllm-sim-429`                   | K8s service name for the 429-injecting simulator           |
+| `TEST_SIM_SERVICE_AIMD`   | `vllm-sim-aimd`                  | K8s service name for the AIMD recovery simulator           |
 | `TEST_CHART_PATH`         | `../../charts/batch-gateway`     | Path to the Helm chart (used by HelmUpgrade tests)         |
 
 Example with overrides:

--- a/test/e2e/aimd_test.go
+++ b/test/e2e/aimd_test.go
@@ -21,15 +21,13 @@
 //   - Isolation: sim-model (0% failure) stays at the configured perEndpoint limit while
 //     sim-model-429 decreases independently.
 //   - Recovery: a dedicated sim-model-aimd starts at 100% failure (driving
-//     limit to min), then is patched to 0% failure; subsequent requests
-//     drive the limit back toward the configured perEndpoint limit.
+//     limit to min), then is flipped to 0% failure via /admin/config;
+//     subsequent requests drive the limit back toward the configured perEndpoint limit.
 
 package e2e_test
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -45,6 +43,8 @@ const (
 )
 
 func testAIMD(t *testing.T) {
+	t.Cleanup(func() { deleteE2ECurlPod(t) })
+
 	t.Run("DecreaseAndIsolation", doTestAIMDDecreaseAndIsolation)
 	t.Run("Recovery", doTestAIMDRecovery)
 }
@@ -69,6 +69,28 @@ func doTestAIMDDecreaseAndIsolation(t *testing.T) {
 		num429Requests    = 10
 		numNormalRequests = 2
 	)
+
+	// Snapshot AIMD state before the test. Counters and gauges persist across
+	// runs on a long-lived processor, so we assert on deltas rather than
+	// absolute values.
+	metricsBefore := scrapeProcessorMetrics(t)
+	decreasesBefore := parseCounterByEndpoint(t, metricsBefore, "batch_processor_aimd_decreases_total")
+	limitsBefore := parseGaugeByEndpoint(t, metricsBefore, "batch_processor_aimd_concurrency_limit")
+
+	var decreaseBefore429 float64
+	for endpoint, count := range decreasesBefore {
+		if strings.Contains(endpoint, testSimService429) {
+			decreaseBefore429 = count
+			break
+		}
+	}
+	var limitBeforeHealthy float64
+	for endpoint, limit := range limitsBefore {
+		if isHealthySimEndpoint(endpoint) {
+			limitBeforeHealthy = limit
+			break
+		}
+	}
 
 	lines := make([]string, 0, num429Requests+numNormalRequests)
 	for i := range num429Requests {
@@ -113,16 +135,18 @@ func doTestAIMDDecreaseAndIsolation(t *testing.T) {
 	for endpoint, limit := range aimdLimits {
 		t.Logf("aimd_concurrency_limit{endpoint=%q} = %.0f", endpoint, limit)
 
-		if strings.Contains(endpoint, "vllm-sim-429") {
+		if strings.Contains(endpoint, testSimService429) {
 			found429Endpoint = true
 			if limit >= float64(expectedPerEndpoint) {
 				t.Errorf("429 endpoint limit = %.0f, want < %d (AIMD should have decreased)", limit, expectedPerEndpoint)
 			}
 
 			if count, ok := aimdDecreases[endpoint]; ok {
-				t.Logf("aimd_decreases_total{endpoint=%q} = %.0f", endpoint, count)
-				if count == 0 {
-					t.Errorf("expected AIMD decrease signals > 0 for 429 endpoint")
+				delta := count - decreaseBefore429
+				t.Logf("aimd_decreases_total{endpoint=%q} = %.0f (delta=%.0f)", endpoint, count, delta)
+				if delta == 0 {
+					t.Errorf("expected AIMD decrease delta > 0 for 429 endpoint (before=%.0f, after=%.0f)",
+						decreaseBefore429, count)
 				}
 			} else {
 				t.Errorf("no aimd_decreases_total found for 429 endpoint %q", endpoint)
@@ -131,14 +155,21 @@ func doTestAIMDDecreaseAndIsolation(t *testing.T) {
 
 		if isHealthySimEndpoint(endpoint) {
 			foundNormalEndpoint = true
-			if limit != float64(expectedPerEndpoint) {
-				t.Errorf("healthy endpoint limit = %.0f, want %d (should be unaffected)", limit, expectedPerEndpoint)
+			if limitBeforeHealthy == 0 {
+				if limit != float64(expectedPerEndpoint) {
+					t.Errorf("healthy endpoint limit = %.0f, want %d (first run: should start at max)",
+						limit, expectedPerEndpoint)
+				}
+			} else if limit < limitBeforeHealthy {
+				t.Errorf("healthy endpoint limit decreased during test "+
+					"(before=%.0f, after=%.0f); should be unaffected by 429 traffic",
+					limitBeforeHealthy, limit)
 			}
 		}
 	}
 
 	if !found429Endpoint {
-		t.Error("no AIMD metric found for an endpoint containing 'vllm-sim-429'")
+		t.Errorf("no AIMD metric found for an endpoint containing %q", testSimService429)
 	}
 	if !foundNormalEndpoint {
 		t.Error("no AIMD metric found for a healthy (non-429) endpoint")
@@ -220,7 +251,7 @@ func parseCounterByEndpoint(t *testing.T, metrics, metricName string) map[string
 // backpressure subsides. It uses a dedicated simulator (vllm-sim-aimd) that
 // starts at 100% failure rate. The test:
 //  1. Submits requests to drive the AIMD limit to min (5).
-//  2. Patches the simulator to 0% failure rate and waits for rollout.
+//  2. Flips the simulator to 0% failure rate via /admin/config (no rollout needed).
 //  3. Submits more requests and verifies the limit eventually increases above
 //     its phase-1 baseline.
 //
@@ -236,10 +267,14 @@ func doTestAIMDRecovery(t *testing.T) {
 	}
 
 	const (
-		numFailRequests   = 10
-		numRecovRequests  = 30
-		aimdSimDeployment = "vllm-sim-aimd"
+		numFailRequests  = 10
+		numRecovRequests = 30
 	)
+
+	t.Cleanup(func() {
+		t.Log("cleanup: restoring vllm-sim-aimd to 100% failure rate")
+		setSimAdminConfig(t, testSimServiceAIMD, `{"failure-injection-rate": 100, "failure-types": ["rate_limit"]}`)
+	})
 
 	// Phase 1: Drive AIMD limit to min with 100% failure rate.
 	// The simulator starts with 100% failure, so all requests get 429s
@@ -275,7 +310,7 @@ func doTestAIMDRecovery(t *testing.T) {
 		baselineLimit float64
 	)
 	for endpoint, limit := range aimdLimits {
-		if strings.Contains(endpoint, aimdSimDeployment) {
+		if strings.Contains(endpoint, testSimServiceAIMD) {
 			aimdEndpoint = endpoint
 			baselineLimit = limit
 			t.Logf("phase 1: aimd_concurrency_limit{endpoint=%q} = %.0f", endpoint, limit)
@@ -286,44 +321,14 @@ func doTestAIMDRecovery(t *testing.T) {
 		}
 	}
 	if aimdEndpoint == "" {
-		t.Fatalf("no AIMD metric found for endpoint containing %q", aimdSimDeployment)
+		t.Fatalf("no AIMD metric found for endpoint containing %q", testSimServiceAIMD)
 	}
 
-	// Phase 2: Patch simulator to 0% failure and wait for rollout.
-	t.Log("phase 2: patching simulator to 0% failure rate...")
-	patchSimulatorFailureRate(t, aimdSimDeployment, testModelAIMD, 0)
-	t.Cleanup(func() {
-		t.Log("cleanup: restoring simulator to 100% failure rate")
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		// Timing args (10ms/10ms) must match dev-deploy.sh's install_vllm_sim defaults.
-		patch := fmt.Sprintf(
-			`{"spec":{"template":{"spec":{"containers":[{"name":"vllm-sim","args":["--model","%s","--port","8000","--time-to-first-token=10ms","--inter-token-latency=10ms","--v=5","--failure-injection-rate=100","--failure-types=rate_limit"]}]}}}}`,
-			testModelAIMD,
-		)
-		out, err := exec.CommandContext(ctx, "kubectl", "patch", "deployment", aimdSimDeployment,
-			"-n", testNamespace,
-			"--type=strategic",
-			"-p", patch,
-		).CombinedOutput()
-		if err != nil {
-			t.Errorf("cleanup: failed to restore %s to 100%% failure: %v\n%s\nMANUAL RESTORE REQUIRED: kubectl patch deployment %s -n %s ...",
-				aimdSimDeployment, err, out, aimdSimDeployment, testNamespace)
-			return
-		}
-
-		rollCtx, rollCancel := context.WithTimeout(context.Background(), 120*time.Second)
-		defer rollCancel()
-		out, err = exec.CommandContext(rollCtx, "kubectl", "rollout", "status",
-			"deployment/"+aimdSimDeployment, "-n", testNamespace, "--timeout=90s",
-		).CombinedOutput()
-		if err != nil {
-			t.Errorf("cleanup: rollout wait failed for %s: %v\n%s", aimdSimDeployment, err, out)
-		}
-	})
-	waitForRollout(t, aimdSimDeployment)
-	t.Log("phase 2: simulator rollout complete, now at 0% failure rate")
+	// Phase 2: Flip simulator to 0% failure via /admin/config.
+	// Unlike kubectl patch + rollout, this takes effect immediately without
+	// restarting the pod (~1s vs ~90s).
+	t.Log("phase 2: setting vllm-sim-aimd to 0% failure rate via /admin/config")
+	setSimAdminConfig(t, testSimServiceAIMD, `{"failure-injection-rate": 0}`)
 
 	// Phase 3: Submit requests that all succeed, triggering additive increases.
 	// Each successful window adds +1 to the limit (from aimd.additiveIncrease=1).
@@ -379,40 +384,4 @@ func waitForAIMDLimitIncrease(t *testing.T, endpoint string, baselineLimit float
 
 		time.Sleep(interval)
 	}
-}
-
-// patchSimulatorFailureRate patches the vllm-sim container args in the given
-// deployment to set --failure-injection-rate to the specified value. A rate of
-// 0 removes the failure injection flags entirely.
-//
-// The timing args (10ms/10ms) must match dev-deploy.sh's install_vllm_sim
-// invocation for the AIMD simulator; if those defaults change, update here.
-func patchSimulatorFailureRate(t *testing.T, deployment, model string, rate int) {
-	t.Helper()
-
-	var patch string
-	if rate == 0 {
-		patch = fmt.Sprintf(
-			`{"spec":{"template":{"spec":{"containers":[{"name":"vllm-sim","args":["--model","%s","--port","8000","--time-to-first-token=10ms","--inter-token-latency=10ms","--v=5"]}]}}}}`,
-			model,
-		)
-	} else {
-		patch = fmt.Sprintf(
-			`{"spec":{"template":{"spec":{"containers":[{"name":"vllm-sim","args":["--model","%s","--port","8000","--time-to-first-token=10ms","--inter-token-latency=10ms","--v=5","--failure-injection-rate=%d","--failure-types=rate_limit"]}]}}}}`,
-			model, rate,
-		)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	out, err := exec.CommandContext(ctx, "kubectl", "patch", "deployment", deployment,
-		"-n", testNamespace,
-		"--type=strategic",
-		"-p", patch,
-	).CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to patch %s failure rate to %d%%: %v\n%s", deployment, rate, err, out)
-	}
-	t.Logf("patched %s: failure-injection-rate=%d%%", deployment, rate)
 }

--- a/test/e2e/aimd_test.go
+++ b/test/e2e/aimd_test.go
@@ -273,7 +273,9 @@ func doTestAIMDRecovery(t *testing.T) {
 
 	t.Cleanup(func() {
 		t.Log("cleanup: restoring vllm-sim-aimd to 100% failure rate")
-		setSimAdminConfig(t, testSimServiceAIMD, `{"failure-injection-rate": 100, "failure-types": ["rate_limit"]}`)
+		if err := trySetSimAdminConfig(t, testSimServiceAIMD, `{"failure-injection-rate": 100, "failure-types": ["rate_limit"]}`); err != nil {
+			t.Errorf("cleanup: failed to restore %s to 100%% failure rate: %v", testSimServiceAIMD, err)
+		}
 	})
 
 	// Phase 1: Drive AIMD limit to min with 100% failure rate.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -52,6 +52,11 @@ var (
 	testModelAlwaysFail = getEnvOrDefault("TEST_MODEL_ALWAYS_FAIL", "sim-model-always-fail")
 	testModelAIMD       = getEnvOrDefault("TEST_MODEL_AIMD", "sim-model-aimd")
 
+	// testSimService* hold the Kubernetes service names for the simulators.
+	// Must match VLLM_SIM_*_NAME in dev-common.sh (overridable via env).
+	testSimService429  = getEnvOrDefault("TEST_SIM_SERVICE_429", "vllm-sim-429")
+	testSimServiceAIMD = getEnvOrDefault("TEST_SIM_SERVICE_AIMD", "vllm-sim-aimd")
+
 	// testJSONL is a valid batch input file with two requests.
 	// max_tokens is kept small so batches finish quickly. Default TEST_MODEL (sim-model)
 	// on dev-deploy uses ~100ms inter-token latency (sim-model-b uses ~500ms).

--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -49,9 +49,7 @@ func testFlowControl(t *testing.T) {
 		}
 		t.Run("InferenceObjectiveHeader", doTestInferenceObjectiveHeader)
 		t.Run("SLOHeader", doTestSLOHeader)
-		t.Run("RetryOn429", func(t *testing.T) {
-			t.Skip("#445: disabled until llm-d-inference-sim supports deterministic 429 injection; retry coverage lives in lower-level deterministic tests")
-		})
+		t.Run("RetryOn429", doTestRetryOn429)
 		t.Run("RetryExhaustion", doTestRetryExhaustion)
 	})
 
@@ -129,6 +127,112 @@ func doTestSLOHeader(t *testing.T) {
 	}
 
 	t.Logf("batch completed within 10m SLO window (x-slo-ttft-ms header propagation unit-tested)")
+}
+
+// doTestRetryOn429 verifies the full retry-to-success path:
+//  1. Set sim-model-429 to 100% failure via /admin/config.
+//  2. Submit a batch — all initial attempts receive 429.
+//  3. Flip the simulator to 0% failure — subsequent retries succeed.
+//  4. Assert all requests completed with no failures.
+//  5. Assert AIMD decrease signals were recorded (proves 429s were observed).
+//
+// This exercises the end-to-end contract: transient 429 → retry → success.
+// Requires llm-d-inference-sim >= v0.9.1 for the /admin/config endpoint.
+func doTestRetryOn429(t *testing.T) {
+	t.Helper()
+
+	if !testKubectlAvailable {
+		t.Skip("kubectl not available")
+	}
+
+	const numRequests = 4
+
+	t.Cleanup(func() { deleteE2ECurlPod(t) })
+	t.Cleanup(func() {
+		t.Log("cleanup: restoring sim-model-429 to 50% failure rate")
+		setSimAdminConfig(t, testSimService429, `{"failure-injection-rate": 50, "failure-types": ["rate_limit"]}`)
+	})
+
+	// Snapshot cumulative counters before the test. These are process-wide
+	// counters that persist across test runs on the same processor. We verify
+	// deltas (not absolute values) after batch completion.
+	metricsBefore := scrapeProcessorMetrics(t)
+	decreasesBefore := parseCounterByEndpoint(t, metricsBefore, "batch_processor_aimd_decreases_total")
+	var beforeCount float64
+	for endpoint, count := range decreasesBefore {
+		if strings.Contains(endpoint, testSimService429) {
+			beforeCount = count
+			break
+		}
+	}
+	errorsBefore := getRequestErrors(t, testModel429)
+
+	// Phase 1: Set 100% failure — all initial attempts will get 429.
+	t.Log("phase 1: setting sim-model-429 to 100% failure rate")
+	setSimAdminConfig(t, testSimService429, `{"failure-injection-rate": 100, "failure-types": ["rate_limit"]}`)
+
+	// Phase 2: Submit batch.
+	t.Log("phase 2: submitting batch")
+	lines := make([]string, 0, numRequests)
+	for i := range numRequests {
+		lines = append(lines, fmt.Sprintf(
+			`{"custom_id":"retry429-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"Retry test %d"}]}}`,
+			i+1, testModel429, i+1,
+		))
+	}
+
+	fileID := mustCreateFile(t, fmt.Sprintf("test-retry429-%s.jsonl", testRunID), strings.Join(lines, "\n"))
+	batchID := mustCreateBatch(t, fileID)
+
+	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
+
+	// Phase 3: Wait until the processor has dispatched at least one request
+	// to the sim. model_inflight_requests{model="sim-model-429"} > 0 proves
+	// dispatch happened. Because failure rate is 100%, the first response is
+	// a 429, and the resty client enters its retry loop (Generate blocks
+	// through all retries). The gauge stays elevated for the entire retry
+	// chain (minutes), making it a stable — not transient — signal here.
+	t.Log("phase 3: waiting for model_inflight_requests > 0")
+	waitForModelInflight(t, testModel429, 30*time.Second)
+
+	// Phase 4: Flip to 0% failure — the next retry attempt will succeed.
+	t.Log("phase 4: setting sim-model-429 to 0% failure rate")
+	setSimAdminConfig(t, testSimService429, `{"failure-injection-rate": 0}`)
+
+	// Phase 5: Wait for batch to complete.
+	batch, _ := waitForBatchStatus(t, batchID, 3*time.Minute, openai.BatchStatusCompleted)
+
+	if batch.RequestCounts.Completed != int64(numRequests) {
+		t.Fatalf("expected %d completed, got %d (failed=%d)",
+			numRequests, batch.RequestCounts.Completed, batch.RequestCounts.Failed)
+	}
+	if batch.RequestCounts.Failed != 0 {
+		t.Errorf("expected 0 failed, got %d", batch.RequestCounts.Failed)
+	}
+
+	// Phase 6: Verify AIMD capacity_retry signals were recorded. Each request
+	// hit at least one 429 before succeeding, so hadCapacityRetry=true triggers
+	// an AIMD decrease on completion.
+	metricsAfter := scrapeProcessorMetrics(t)
+	decreasesAfter := parseCounterByEndpoint(t, metricsAfter, "batch_processor_aimd_decreases_total")
+	var afterCount float64
+	for endpoint, count := range decreasesAfter {
+		if strings.Contains(endpoint, testSimService429) {
+			afterCount = count
+			break
+		}
+	}
+
+	if afterCount <= beforeCount {
+		t.Errorf("expected AIMD decreases to increase after retry-on-429 "+
+			"(before=%.0f, after=%.0f); capacity_retry signals not recorded",
+			beforeCount, afterCount)
+	} else {
+		t.Logf("retry-on-429: all %d requests completed after retry "+
+			"(aimd_decreases: %.0f → %.0f)", numRequests, beforeCount, afterCount)
+	}
+
+	assertNoNewRequestErrors(t, testModel429, errorsBefore)
 }
 
 // doTestRetryExhaustion submits a batch targeting a simulator with 100%
@@ -278,7 +382,7 @@ func doTestBatchCompletionThroughEPP(t *testing.T) {
 	t.Helper()
 
 	t.Cleanup(func() {
-		deleteEPPMetricsCurlPod(t)
+		deleteE2ECurlPod(t)
 	})
 
 	eppPrefix := getEnvOrDefault("GIE_EPP_RELEASE", "epp")
@@ -341,10 +445,6 @@ func truncateLog(s string, maxLen int) string {
 	}
 	return s[:maxLen] + "..."
 }
-
-const (
-	eppMetricsCurlPod = "batch-gateway-epp-metrics-curl"
-)
 
 var eppDispatchedCountPattern = regexp.MustCompile(`(?m)^inference_extension_flow_control_request_queue_duration_seconds_count\{([^}]*)\}\s+([0-9.e+-]+)$`)
 
@@ -413,11 +513,11 @@ func getEPPDispatchedCountAndSample(t *testing.T, deployment string) (float64, s
 func scrapeEPPMetrics(t *testing.T, deployment string) string {
 	t.Helper()
 
-	ensureEPPMetricsCurlPod(t)
+	ensureE2ECurlPod(t)
 
 	out, err := exec.Command("kubectl", "exec",
 		"-n", testNamespace,
-		eppMetricsCurlPod,
+		e2eCurlPod,
 		"--",
 		"curl",
 		"-sS",
@@ -427,78 +527,6 @@ func scrapeEPPMetrics(t *testing.T, deployment string) string {
 		t.Fatalf("failed to scrape metrics for %s: %v\n%s", deployment, err, out)
 	}
 	return string(out)
-}
-
-func ensureEPPMetricsCurlPod(t *testing.T) {
-	t.Helper()
-
-	if phaseOut, err := exec.Command("kubectl", "get", "pod",
-		eppMetricsCurlPod,
-		"-n", testNamespace,
-		"-o", "jsonpath={.status.phase}",
-	).CombinedOutput(); err != nil || strings.TrimSpace(string(phaseOut)) == "" {
-		createEPPMetricsCurlPod(t)
-	} else {
-		phase := strings.TrimSpace(string(phaseOut))
-		if phase != "Running" && phase != "Pending" {
-			out, deleteErr := exec.Command("kubectl", "delete", "pod",
-				eppMetricsCurlPod,
-				"-n", testNamespace,
-				"--ignore-not-found",
-			).CombinedOutput()
-			if deleteErr != nil {
-				t.Fatalf("failed to delete stale EPP metrics scrape pod: %v\n%s", deleteErr, out)
-			}
-			createEPPMetricsCurlPod(t)
-		}
-	}
-
-	waitOut, err := exec.Command("kubectl", "wait",
-		"--for=condition=Ready",
-		fmt.Sprintf("pod/%s", eppMetricsCurlPod),
-		"-n", testNamespace,
-		"--timeout=90s",
-	).CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to wait for EPP metrics curl pod: %v\n%s", err, waitOut)
-	}
-}
-
-func createEPPMetricsCurlPod(t *testing.T) {
-	t.Helper()
-
-	manifest := fmt.Sprintf(`apiVersion: v1
-kind: Pod
-metadata:
-  name: %s
-  namespace: %s
-spec:
-  restartPolicy: Never
-  containers:
-  - name: curl
-    image: curlimages/curl:8.8.0
-    command: ["sleep", "3600"]
-`, eppMetricsCurlPod, testNamespace)
-
-	cmd := exec.Command("kubectl", "create", "-f", "-")
-	cmd.Stdin = strings.NewReader(manifest)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to create EPP metrics scrape pod: %v\n%s", err, out)
-	}
-}
-
-func deleteEPPMetricsCurlPod(t *testing.T) {
-	t.Helper()
-
-	out, err := exec.Command("kubectl", "delete", "pod",
-		eppMetricsCurlPod,
-		"-n", testNamespace,
-		"--ignore-not-found",
-	).CombinedOutput()
-	if err != nil {
-		t.Errorf("cleanup: failed to delete EPP metrics scrape pod: %v\n%s", err, out)
-	}
 }
 
 // getProcessorConfigObjective reads the deployed processor ConfigMap and
@@ -583,22 +611,33 @@ func waitForRetryExhaustion(t *testing.T, batchID string, timeout time.Duration)
 	return nil
 }
 
-// assertNoRequestErrors verifies that request_errors_by_model_total for the
-// given model is either absent or zero. When the HTTP client retries 429s
-// transparently and all retries succeed, the executor never records an error.
-func assertNoRequestErrors(t *testing.T, model string) {
+// getRequestErrors returns the current value of request_errors_by_model_total
+// for the given model, or 0 if the metric is not present yet.
+func getRequestErrors(t *testing.T, model string) int {
 	t.Helper()
 
 	metrics := scrapeProcessorMetrics(t)
-
 	pattern := regexp.MustCompile(fmt.Sprintf(`request_errors_by_model_total\{model=%q\}\s+(\d+)`, model))
 	match := pattern.FindStringSubmatch(metrics)
 	if match == nil {
-		t.Logf("request_errors_by_model_total{model=%q} not found in metrics (expected: retries succeeded transparently)", model)
-		return
+		return 0
 	}
-	if match[1] != "0" {
-		t.Errorf("expected request_errors_by_model_total{model=%q} = 0 (retries should succeed), got %s", model, match[1])
+	val, _ := strconv.Atoi(match[1])
+	return val
+}
+
+// assertNoNewRequestErrors verifies that request_errors_by_model_total for the
+// given model did not increase relative to the provided baseline. This is safe
+// to use against long-lived processors where previous test runs may have
+// already incremented the counter.
+func assertNoNewRequestErrors(t *testing.T, model string, baseline int) {
+	t.Helper()
+
+	current := getRequestErrors(t, model)
+	if current > baseline {
+		t.Errorf("request_errors_by_model_total{model=%q} increased during test "+
+			"(before=%d, after=%d); retries should have succeeded transparently",
+			model, baseline, current)
 	}
 }
 

--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -150,7 +150,9 @@ func doTestRetryOn429(t *testing.T) {
 	t.Cleanup(func() { deleteE2ECurlPod(t) })
 	t.Cleanup(func() {
 		t.Log("cleanup: restoring sim-model-429 to 50% failure rate")
-		setSimAdminConfig(t, testSimService429, `{"failure-injection-rate": 50, "failure-types": ["rate_limit"]}`)
+		if err := trySetSimAdminConfig(t, testSimService429, `{"failure-injection-rate": 50, "failure-types": ["rate_limit"]}`); err != nil {
+			t.Errorf("cleanup: failed to restore %s to 50%% failure rate: %v", testSimService429, err)
+		}
 	})
 
 	// Snapshot cumulative counters before the test. These are process-wide
@@ -622,7 +624,10 @@ func getRequestErrors(t *testing.T, model string) int {
 	if match == nil {
 		return 0
 	}
-	val, _ := strconv.Atoi(match[1])
+	val, err := strconv.Atoi(match[1])
+	if err != nil {
+		t.Fatalf("failed to parse request_errors_by_model_total value %q: %v", match[1], err)
+	}
 	return val
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -600,6 +602,135 @@ func validateBatchResults(t *testing.T, batch *openai.Batch, result batchResults
 		t.Errorf("error lines (%d) != failed count (%d)",
 			result.ErrorLines, batch.RequestCounts.Failed)
 	}
+}
+
+// ── Shared E2E curl pod ─────────────────────────────────────────────────
+
+const e2eCurlPod = "batch-gateway-e2e-curl"
+
+func ensureE2ECurlPod(t *testing.T) {
+	t.Helper()
+
+	if phaseOut, err := exec.Command("kubectl", "get", "pod",
+		e2eCurlPod,
+		"-n", testNamespace,
+		"-o", "jsonpath={.status.phase}",
+	).CombinedOutput(); err != nil || strings.TrimSpace(string(phaseOut)) == "" {
+		createE2ECurlPod(t)
+	} else {
+		phase := strings.TrimSpace(string(phaseOut))
+		if phase != "Running" && phase != "Pending" {
+			out, deleteErr := exec.Command("kubectl", "delete", "pod",
+				e2eCurlPod,
+				"-n", testNamespace,
+				"--ignore-not-found",
+			).CombinedOutput()
+			if deleteErr != nil {
+				t.Fatalf("failed to delete stale e2e curl pod: %v\n%s", deleteErr, out)
+			}
+			createE2ECurlPod(t)
+		}
+	}
+
+	waitOut, err := exec.Command("kubectl", "wait",
+		"--for=condition=Ready",
+		fmt.Sprintf("pod/%s", e2eCurlPod),
+		"-n", testNamespace,
+		"--timeout=90s",
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to wait for e2e curl pod: %v\n%s", err, waitOut)
+	}
+}
+
+func createE2ECurlPod(t *testing.T) {
+	t.Helper()
+
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  restartPolicy: Never
+  containers:
+  - name: curl
+    image: curlimages/curl:8.8.0
+    command: ["sleep", "infinity"]
+`, e2eCurlPod, testNamespace)
+
+	cmd := exec.Command("kubectl", "create", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to create e2e curl pod: %v\n%s", err, out)
+	}
+}
+
+func deleteE2ECurlPod(t *testing.T) {
+	t.Helper()
+
+	out, err := exec.Command("kubectl", "delete", "pod",
+		e2eCurlPod,
+		"-n", testNamespace,
+		"--ignore-not-found",
+	).CombinedOutput()
+	if err != nil {
+		t.Errorf("cleanup: failed to delete e2e curl pod: %v\n%s", err, out)
+	}
+}
+
+// ── Simulator admin helpers ──────────────────────────────────────────────
+
+// setSimAdminConfig sends a POST to the simulator's /admin/config endpoint
+// via a curl pod running in the cluster. It is used to dynamically change
+// failure injection at runtime without restarting the simulator deployment.
+func setSimAdminConfig(t *testing.T, simService string, body string) {
+	t.Helper()
+
+	ensureE2ECurlPod(t)
+
+	url := fmt.Sprintf("http://%s.%s.svc.cluster.local:8000/admin/config", simService, testNamespace)
+	out, err := exec.Command("kubectl", "exec",
+		"-n", testNamespace,
+		e2eCurlPod,
+		"--",
+		"curl", "-sS", "-X", "POST",
+		"-H", "Content-Type: application/json",
+		"-d", body,
+		"--fail",
+		url,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("POST %s failed: %v\n%s", url, err, out)
+	}
+	t.Logf("POST %s: %s", url, strings.TrimSpace(string(out)))
+}
+
+// waitForModelInflight polls the processor's model_inflight_requests metric
+// until it reports > 0 for the given model, proving that at least one request
+// has been dispatched. With 100% failure injection, the gauge remains elevated
+// for the full retry chain duration (minutes) because Generate() blocks through
+// all resty retries, making this a stable signal — not transient.
+func waitForModelInflight(t *testing.T, model string, timeout time.Duration) {
+	t.Helper()
+
+	re := regexp.MustCompile(fmt.Sprintf(
+		`model_inflight_requests\{[^}]*model=%q[^}]*\}\s+(\d+)`, model))
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		body := scrapeProcessorMetrics(t)
+		if m := re.FindStringSubmatch(body); m != nil {
+			val, _ := strconv.Atoi(m[1])
+			if val > 0 {
+				t.Logf("model_inflight_requests{model=%q} = %d", model, val)
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for model_inflight_requests{model=%q} > 0", model)
 }
 
 // ── Generic helpers ──────────────────────────────────────────────────────

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -682,10 +682,10 @@ func deleteE2ECurlPod(t *testing.T) {
 
 // ── Simulator admin helpers ──────────────────────────────────────────────
 
-// setSimAdminConfig sends a POST to the simulator's /admin/config endpoint
-// via a curl pod running in the cluster. It is used to dynamically change
-// failure injection at runtime without restarting the simulator deployment.
-func setSimAdminConfig(t *testing.T, simService string, body string) {
+// trySetSimAdminConfig sends a POST to the simulator's /admin/config endpoint
+// via a curl pod running in the cluster. It returns an error so cleanup paths
+// can report restore failures without halting the rest of cleanup.
+func trySetSimAdminConfig(t *testing.T, simService string, body string) error {
 	t.Helper()
 
 	ensureE2ECurlPod(t)
@@ -702,9 +702,21 @@ func setSimAdminConfig(t *testing.T, simService string, body string) {
 		url,
 	).CombinedOutput()
 	if err != nil {
-		t.Fatalf("POST %s failed: %v\n%s", url, err, out)
+		return fmt.Errorf("POST %s failed: %w\n%s", url, err, out)
 	}
 	t.Logf("POST %s: %s", url, strings.TrimSpace(string(out)))
+	return nil
+}
+
+// setSimAdminConfig sends a POST to the simulator's /admin/config endpoint
+// via a curl pod running in the cluster. It is used to dynamically change
+// failure injection at runtime without restarting the simulator deployment.
+func setSimAdminConfig(t *testing.T, simService string, body string) {
+	t.Helper()
+
+	if err := trySetSimAdminConfig(t, simService, body); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // waitForModelInflight polls the processor's model_inflight_requests metric
@@ -722,7 +734,10 @@ func waitForModelInflight(t *testing.T, model string, timeout time.Duration) {
 	for time.Now().Before(deadline) {
 		body := scrapeProcessorMetrics(t)
 		if m := re.FindStringSubmatch(body); m != nil {
-			val, _ := strconv.Atoi(m[1])
+			val, err := strconv.Atoi(m[1])
+			if err != nil {
+				t.Fatalf("failed to parse model_inflight_requests value %q: %v", m[1], err)
+			}
 			if val > 0 {
 				t.Logf("model_inflight_requests{model=%q} = %d", model, val)
 				return


### PR DESCRIPTION
## Why is this PR needed?

The AIMD and RetryOn429 E2E tests relied on `kubectl patch deployment` + rollout wait to change simulator failure rates, taking ~90s per toggle and introducing timing-based flakiness. The `RetryOn429` test was skipped entirely due to lack of deterministic failure injection. Additionally, metric assertions used absolute counter values, causing false failures on repeated runs against a long-lived processor.

## What does this PR do?

- **Use `/admin/config` for runtime failure injection** (requires `llm-d-inference-sim` >= v0.9.1): replaces `kubectl patch` + rollout with a direct HTTP POST that takes effect immediately (~1s, no pod restart).
- **Restore `RetryOn429` test**: deterministically sets 100% failure, waits for `model_inflight_requests > 0` to prove dispatch happened, then flips to 0% and asserts all requests complete with AIMD decrease signals.
- **Delta-based metric assertions**: all cumulative counters (`aimd_decreases_total`, `request_errors_by_model_total`) and the healthy endpoint's AIMD gauge are now validated as deltas from a pre-test snapshot, making tests safe to rerun on the same processor.
- **Consolidate curl pods**: merged `batch-gateway-epp-metrics-curl` and sim-admin curl pod into a single `batch-gateway-e2e-curl` with `sleep infinity`.
- **Propagate `TEST_SIM_SERVICE_*` env vars** in the Makefile so custom simulator service names from `dev-deploy` reach the test binary.

## How was this tested?

- [x] Unit tests pass (`make pre-commit`)
- [x] Full `make test-e2e` passes

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #448