### PR TITLE
fix(chart): add default RHOAI scrape label to gc podmonitor

### DIFF
--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -129,6 +129,15 @@ tests:
           value: "30s"
         template: templates/gc-podmonitor.yaml
 
+  - it: should include RHOAI monitoring label on GC PodMonitor by default
+    set:
+      gc.podMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels["monitoring.opendatahub.io/scrape"]
+          value: "true"
+        template: templates/gc-podmonitor.yaml
+
   - it: should not render GC PodMonitor when gc is disabled
     set:
       gc.enabled: false

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -508,7 +508,9 @@ gc:
     enabled: false
     interval: "30s"
     # Extra labels to match Prometheus Operator's podMonitorSelector.
-    labels: {}
+    # The RHOAI monitoring label enables metrics scraping by the ODH observability stack.
+    labels:
+      monitoring.opendatahub.io/scrape: "true"
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## Why is this PR needed?
PR #462 added `monitoring.opendatahub.io/scrape: "true"` to the apiserver ServiceMonitor and processor PodMonitor, but the GC PodMonitor (introduced in #460, merged after #462) was missing this label. Without it, the ODH observability stack won't scrape GC metrics.
Per [RHOAIENG-63967](https://redhat.atlassian.net/browse/RHOAIENG-63967) and the [RHOAI component metrics scraping ADR](https://github.com/opendatahub-io/architecture-decision-records/blob/main/architecture-decision-records/operator/ODH-ADR-Operator-0010-Observability-component%20metrics%20scraping.md), all PodMonitor/ServiceMonitor CRs must carry this label.
Ref: https://github.com/llm-d-incubation/batch-gateway/pull/460#issuecomment-4595009320

## What does this PR do?
- Adds `monitoring.opendatahub.io/scrape: "true"` to the GC PodMonitor
  default labels in `values.yaml`
- Adds a Helm unit test asserting the label is present
 
## How was this tested?
- [x] Helm unit tests pass (`helm unittest`)
- [x] `helm template` renders the label correctly
- [x] `pre-commit run -a` passes


## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)


## Related Issues
Follow-up to #460, #462
Related to https://redhat.atlassian.net/browse/RHOAIENG-63967