### PR TITLE
revert: remove RHOAI monitoring label from upstream chart defaults

### DIFF
--- a/charts/batch-gateway/tests/observability_test.yaml
+++ b/charts/batch-gateway/tests/observability_test.yaml
@@ -35,15 +35,6 @@ tests:
           value: "30s"
         template: templates/apiserver-servicemonitor.yaml
 
-  - it: should include RHOAI monitoring label on ServiceMonitor by default
-    set:
-      apiserver.serviceMonitor.enabled: true
-    asserts:
-      - equal:
-          path: metadata.labels["monitoring.opendatahub.io/scrape"]
-          value: "true"
-        template: templates/apiserver-servicemonitor.yaml
-
   - it: should apply custom ServiceMonitor interval
     set:
       apiserver.serviceMonitor.enabled: true
@@ -85,15 +76,6 @@ tests:
       - equal:
           path: spec.podMetricsEndpoints[0].interval
           value: "30s"
-        template: templates/processor-podmonitor.yaml
-
-  - it: should include RHOAI monitoring label on PodMonitor by default
-    set:
-      processor.podMonitor.enabled: true
-    asserts:
-      - equal:
-          path: metadata.labels["monitoring.opendatahub.io/scrape"]
-          value: "true"
         template: templates/processor-podmonitor.yaml
 
   - it: should not render PodMonitor when processor is disabled

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -221,9 +221,7 @@ apiserver:
     enabled: false
     interval: "30s"
     # Extra labels to match Prometheus Operator's serviceMonitorSelector.
-    # The RHOAI monitoring label enables metrics scraping by the ODH observability stack.
-    labels:
-      monitoring.opendatahub.io/scrape: "true"
+    labels: {}
 
   # Logging configuration
   logging:
@@ -404,9 +402,7 @@ processor:
     enabled: false
     interval: "30s"
     # Extra labels to match Prometheus Operator's podMonitorSelector.
-    # The RHOAI monitoring label enables metrics scraping by the ODH observability stack.
-    labels:
-      monitoring.opendatahub.io/scrape: "true"
+    labels: {}
 
   # Logging configuration
   logging:


### PR DESCRIPTION
## Why is this PR needed?

The `monitoring.opendatahub.io/scrape: "true"` label added in #462 is RHOAI-specific and should not be in upstream chart defaults. The midstream operator (llm-d-batch-gateway-operator) should add it at deploy time via `--set` or a values overlay. This keeps the upstream chart platform-neutral and avoids sync conflicts between upstream and
midstream.

## What does this PR do?

Reverts #462: resets `labels:` back to `{}` for apiserver ServiceMonitor and processor PodMonitor. Removes the corresponding Helm unit tests.

## How was this tested?

- [x] Helm unit tests pass (`helm unittest`)
- [x] `pre-commit run -a` passes

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Pre-commit checks pass (`make pre-commit`)

## Related Issues

Reverts #462, supersedes #469