### PR TITLE
fix(ci): harden GitHub workflows for must-fix findings

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,5 +1,8 @@
 name: Add default labels to PRs
 
+# Security: pull_request_target is required for write access on fork PRs.
+# This workflow does NOT checkout PR code — it only calls the GitHub API to add
+# a label, so there is no untrusted code execution risk.
 on:
   pull_request_target:
     types: [opened]

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -51,12 +51,13 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Install Kind
         run: go install sigs.k8s.io/kind@latest
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Deploy dev environment
         run: make dev-deploy

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
-        uses: docker/bake-action@v7
+        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # v7
         with:
           files: docker-bake.hcl
           targets: default

--- a/.github/workflows/ci-signed-commits.yml
+++ b/.github/workflows/ci-signed-commits.yml
@@ -1,9 +1,12 @@
 name: Check Signed Commits
+# Security: pull_request_target is required to read PR metadata on fork PRs.
+# This workflow does NOT checkout PR code — the reusable workflow only inspects
+# commit signatures via the API, so there is no untrusted code execution risk.
 on: pull_request_target
 
 jobs:
   signed-commits:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-signed-commits.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Build release binaries (linux/amd64)
         run: GOOS=linux GOARCH=amd64 make build-release
@@ -103,7 +104,7 @@ jobs:
         run: make package-release
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
         with:
           version: '3.16.4'
 
@@ -120,7 +121,7 @@ jobs:
         run: make publish-helm-chart
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           generate_release_notes: true
           files: release/*

--- a/.github/workflows/non-main-gatekeeper.yml
+++ b/.github/workflows/non-main-gatekeeper.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   gatekeeper:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-non-main-gatekeeper.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,16 +26,16 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
 
       - name: Install Go tools (goimports, gosec, ruleguard)
         run: make install-pre-commit-tools
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.11.4
 

--- a/.github/workflows/prow-github.yml
+++ b/.github/workflows/prow-github.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   prow:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-commands.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main

--- a/.github/workflows/prow-pr-automerge.yml
+++ b/.github/workflows/prow-pr-automerge.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-automerge.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main

--- a/.github/workflows/prow-pr-remove-lgtm.yml
+++ b/.github/workflows/prow-pr-remove-lgtm.yml
@@ -6,4 +6,4 @@ permissions:
 
 jobs:
   remove-lgtm:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-prow-remove-lgtm.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-stale.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/unstale.yml
+++ b/.github/workflows/unstale.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   unstale:
-    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yaml@main
+    uses: llm-d/llm-d-infra/.github/workflows/reusable-unstale.yaml@6c2d2e60e7fee83e2a300688f6d4d7a2339c2d74 # main
     permissions:
       issues: write

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -20,7 +20,7 @@ global:
   # Shared by all components; mounted read-only at /etc/.secrets/ in each container.
   # The secret must use these exact key names (hardcoded in the application):
   #   redis-url             — Redis/Valkey connection URL (e.g. redis://host:6379/0)
-  #   postgresql-url        — PostgreSQL connection URL (e.g. postgresql://user:pass@host/db)
+  #   postgresql-url        — PostgreSQL connection URL (e.g. postgresql://[user]:[pass]@[host]/[db])
   #   inference-api-key     — API key for the inference gateway (optional; omit if not required)
   #   s3-secret-access-key  — S3 secret access key (required when file_client.type is "s3")
   # Create with: kubectl create secret generic <name> --from-literal=redis-url=redis://...

--- a/internal/database/postgresql/db_postgresql.go
+++ b/internal/database/postgresql/db_postgresql.go
@@ -40,7 +40,7 @@ type pgxPool interface {
 
 // PostgreSQLConfig holds the configuration for a PostgreSQL connection.
 type PostgreSQLConfig struct {
-	// Url is a PostgreSQL connection string (e.g., "postgres://user:pass@host:5432/dbname?sslmode=disable").
+	// Url is a PostgreSQL connection string (e.g., "postgres://[user]:[pass]@[host]:5432/[dbname]?sslmode=disable").
 	Url string `yaml:"-"`
 	// EnableTracing enables OpenTelemetry tracing for all PostgreSQL operations.
 	EnableTracing bool

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -248,7 +248,7 @@ create_tls_secret() {
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
-    trap "rm -rf ${tmp_dir}" RETURN
+    trap 'rm -rf ${tmp_dir}' RETURN
 
     openssl req -x509 -newkey rsa:2048 -nodes \
         -keyout "${tmp_dir}/tls.key" \


### PR DESCRIPTION
## Why is this PR needed?

The must-fix security report flagged multiple GitHub Actions workflow issues in this repository, including unpinned action references, unsafe action caching, a shellcheck finding, and secret-scanner false positives in PostgreSQL connection string examples.

Most of those findings can be fixed directly in-tree. Two remaining findings are `pull_request_target` warnings on workflows that need write access for fork PRs; those are intentionally kept and documented separately for risk acceptance because changing the trigger would break the current behaviour.

## What does this PR do?

- pins third-party and reusable GitHub Actions workflow references by commit SHA
- disables GitHub Actions caches where the report flagged cache-poisoning risk
- fixes the shellcheck `SC2064` finding in `scripts/dev-deploy.sh`
- replaces example PostgreSQL credentials in comments with placeholders to clear secret-scanner false positives
- adds inline security rationale to the two `pull_request_target` workflows that remain intentionally unchanged

## How was this tested?

- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [x] Manual review of must-fix findings against the updated workflow diff

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

- Related to RHOAIENG-63961