### PR TITLE
docs: remove postgres secret-like example from values

### DIFF
--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -20,7 +20,7 @@ global:
   # Shared by all components; mounted read-only at /etc/.secrets/ in each container.
   # The secret must use these exact key names (hardcoded in the application):
   #   redis-url             — Redis/Valkey connection URL (e.g. redis://host:6379/0)
-  #   postgresql-url        — PostgreSQL connection URL (e.g. postgresql://user:pass@host/db)
+  #   postgresql-url        — PostgreSQL connection URL (e.g. postgresql://[user]:[pass]@[host]/[db])
   #   inference-api-key     — API key for the inference gateway (optional; omit if not required)
   #   s3-secret-access-key  — S3 secret access key (required when file_client.type is "s3")
   # Create with: kubectl create secret generic <name> --from-literal=redis-url=redis://...


### PR DESCRIPTION
## Why is this PR needed?

The security scan flagged the example PostgreSQL DSN in `values.yaml` comments as a secret-like string. This is a documentation-only false positive.

## What does this PR do?

- replaces the example PostgreSQL credentials in `values.yaml` comments with placeholders
- keeps the documentation intent while avoiding secret-scanner false positives

## How was this tested?

- [x] Manual review of the comment-only diff
- [x] Pre-commit checks pass (`make pre-commit`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)

## Related Issues

- Related to RHOAIENG-63961