### PR TITLE
docs: remove postgres secret-like example from godoc

### DIFF
--- a/internal/database/postgresql/db_postgresql.go
+++ b/internal/database/postgresql/db_postgresql.go
@@ -40,7 +40,7 @@ type pgxPool interface {
 
 // PostgreSQLConfig holds the configuration for a PostgreSQL connection.
 type PostgreSQLConfig struct {
-	// Url is a PostgreSQL connection string (e.g., "postgres://user:pass@host:5432/dbname?sslmode=disable").
+	// Url is a PostgreSQL connection string (e.g., "postgres://[user]:[pass]@[host]:5432/[dbname]?sslmode=disable").
 	Url string `yaml:"-"`
 	// EnableTracing enables OpenTelemetry tracing for all PostgreSQL operations.
 	EnableTracing bool


### PR DESCRIPTION
## Why is this PR needed?

The security scan flagged the example PostgreSQL DSN in the `PostgreSQLConfig` godoc comment as a secret-like string. This is a documentation-only false positive.

## What does this PR do?

- replaces the example PostgreSQL credentials in the `PostgreSQLConfig` godoc comment with placeholders
- keeps the documentation intent while avoiding secret-scanner false positives

## How was this tested?

- [x] Manual review of the comment-only diff
- [x] Pre-commit checks pass (`make pre-commit`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [X] Pre-commit checks pass (`make pre-commit`)

## Related Issues

- Related to RHOAIENG-63961