### PR TITLE
fix: quote trap cleanup in dev-deploy

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -248,7 +248,7 @@ create_tls_secret() {
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
-    trap "rm -rf ${tmp_dir}" RETURN
+    trap 'rm -rf ${tmp_dir}' RETURN
 
     openssl req -x509 -newkey rsa:2048 -nodes \
         -keyout "${tmp_dir}/tls.key" \


### PR DESCRIPTION
## Why is this PR needed?

Shellcheck flagged the `trap` cleanup in `scripts/dev-deploy.sh` with `SC2064` because the command was double-quoted and expanded when the trap was registered instead of when it ran.

## What does this PR do?

- single-quotes the `trap` cleanup command in `create_tls_secret()`
- ensures `${tmp_dir}` is expanded when the trap executes

## How was this tested?

- [x] Manual review of the shell diff
- [x] Pre-commit checks pass (`make pre-commit`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)

## Related Issues

- Related to RHOAIENG-63961