### PR TITLE
revert: restore double-quoted trap in dev-deploy.sh

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -248,7 +248,8 @@ create_tls_secret() {
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
-    trap 'rm -rf ${tmp_dir}' RETURN
+    # shellcheck disable=SC2064  # Intentional: expand tmp_dir at definition time; it is local and out of scope when RETURN trap fires from caller
+    trap "rm -rf '${tmp_dir}'" RETURN
 
     openssl req -x509 -newkey rsa:2048 -nodes \
         -keyout "${tmp_dir}/tls.key" \


### PR DESCRIPTION
## Why is this PR needed?

PR #475 changed the `trap` quoting in `create_tls_secret()` from double quotes to single quotes to satisfy ShellCheck SC2064. This broke deployment script. every run fails at the "Deploy dev environment" step with `tmp_dir: unbound variable`.

https://github.com/llm-d-incubation/batch-gateway/actions/runs/27155061072

## What does this PR do?

Reverts the quoting change and adds a `shellcheck disable=SC2064` directive.

**Why SC2064 is a false positive here:** `tmp_dir` is a `local` variable inside `create_tls_secret()`. Bash's `RETURN` trap can leak to the calling function (`main()`). When `main()` returns, the trap fires again — but `tmp_dir` is out of scope, so `set -u` crashes. Double quotes are correct because we need the path expanded at definition time, not at execution time.

## How was this tested?

- [x] `make dev-deploy` succeeds (verified locally)
- [x] `make dev-deploy` with GIE enabled succeeds (verified locally)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] E2E tests pass

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)

## Related Issues

- Reverts #475

## Follow-up: This false positive finding will be included in the security check feedback.