### PR TITLE
ci: enforce conventional PR titles and auto-label

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,52 @@
+# PR Label Detection Scripts
+
+## Files
+
+- `detect-pr-label.js` - Main logic for detecting PR labels from titles
+- `detect-pr-label.test.js` - Node.js test suite
+
+## Running Tests
+
+Requires Node.js 18+ (built-in test runner, no dependencies):
+
+```bash
+node --test detect-pr-label.test.js
+```
+
+## Label Detection Rules
+
+The script detects labels with the following priority:
+
+1. **Breaking changes** (highest priority)
+   - `!: description`
+   - `type!: description`
+   - `type(scope)!: description`
+   - `breaking: description`
+
+2. **Conventional commit prefixes**
+   - `feat:` → `feature`
+   - `fix:` → `bug`
+   - `docs:` → `documentation`
+   - `deps:` → `dependencies`
+   - `enh:` / `improve:` → `enhancement`
+   - `test:` / `ci:` / `chore:` → `release-note-none`
+
+3. **Keyword fallback** (for non-conventional titles)
+   - Searches for keywords: `fix`, `bug`, `docs`, `feat`, etc.
+
+4. **File-path fallback** (when title has no match; all changed files must match)
+   - `docs/` or `*.md` → `documentation`
+   - `go.mod`, `go.sum`, `vendor/` → `dependencies`
+   - `.github/workflows/`, `test/`, `e2e/`, `*_test.go` → `release-note-none`
+
+## Examples
+
+```javascript
+detectFromTitle('feat: add feature')          // → 'feature'
+detectFromTitle('fix(api): resolve bug')      // → 'bug'
+detectFromTitle('feat!: breaking change')     // → 'breaking-change'
+detectFromTitle('Update documentation')       // → 'documentation'
+detectFromTitle('Random title')               // → null
+detectFromFiles(['docs/guide.md'])            // → 'documentation'
+detectFromFiles(['docs/a.md', 'internal/x.go']) // → null
+```

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -29,7 +29,7 @@ Breaking changes use `!` before `:`: `feat!: drop old API`, `fix(scope)!: breaki
 | `deps` | `dependencies` |
 | `ci`, `chore`, `refactor`, `test`, `style`, `perf`, `revert`, `build` | `release-note-none` |
 
-Labels align with categories in [`.github/release.yml`](../release.yml). Every PR also gets `ai-assisted`.
+Labels align with categories in [`.github/release.yml`](../release.yml).
 
 ## Files
 

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,52 +1,49 @@
-# PR Label Detection Scripts
+# PR Title Validation and Label Mapping
+
+## Overview
+
+PR titles are validated and labeled by [`.github/workflows/auto-label-pr.yml`](../workflows/auto-label-pr.yml):
+
+1. **Validate** — [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on the PR title
+2. **Label** — `detect-pr-label.js` maps the validated `type` to a release-category label
+
+## Allowed PR title types
+
+```
+feat  enh  fix  docs  deps  ci  chore  refactor  test  perf  style  revert  build
+```
+
+Examples: `feat: add auth`, `fix(api): handle edge case`, `deps(go): bump module`
+
+Breaking changes use `!` before `:`: `feat!: drop old API`, `fix(scope)!: breaking fix`
+
+## Type to label mapping
+
+| Type | Label |
+|------|-------|
+| any type with `!` (e.g. `feat!:`, `fix!:`) | `breaking-change` |
+| `feat` | `feature` |
+| `enh` | `enhancement` |
+| `fix` | `bug` |
+| `docs` | `documentation` |
+| `deps` | `dependencies` |
+| `ci`, `chore`, `refactor`, `test`, `style`, `perf`, `revert`, `build` | `release-note-none` |
+
+Labels align with categories in [`.github/release.yml`](../release.yml). Every PR also gets `ai-assisted`.
 
 ## Files
 
-- `detect-pr-label.js` - Main logic for detecting PR labels from titles
-- `detect-pr-label.test.js` - Node.js test suite
+- `detect-pr-label.js` — maps validated type + title to a single category label
+- `detect-pr-label.test.js` — unit tests
 
-## Running Tests
+## Running tests
 
-Requires Node.js 18+ (built-in test runner, no dependencies):
+Requires Node.js 18+:
 
 ```bash
 node --test detect-pr-label.test.js
 ```
 
-## Label Detection Rules
+## Branch protection
 
-The script detects labels with the following priority:
-
-1. **Breaking changes** (highest priority)
-   - `!: description`
-   - `type!: description`
-   - `type(scope)!: description`
-   - `breaking: description`
-
-2. **Conventional commit prefixes**
-   - `feat:` → `feature`
-   - `fix:` → `bug`
-   - `docs:` → `documentation`
-   - `deps:` → `dependencies`
-   - `enh:` / `improve:` → `enhancement`
-   - `test:` / `ci:` / `chore:` → `release-note-none`
-
-3. **Keyword fallback** (for non-conventional titles)
-   - Searches for keywords: `fix`, `bug`, `docs`, `feat`, etc.
-
-4. **File-path fallback** (when title has no match; all changed files must match)
-   - `docs/` or `*.md` → `documentation`
-   - `go.mod`, `go.sum`, `vendor/` → `dependencies`
-   - `.github/workflows/`, `test/`, `e2e/`, `*_test.go` → `release-note-none`
-
-## Examples
-
-```javascript
-detectFromTitle('feat: add feature')          // → 'feature'
-detectFromTitle('fix(api): resolve bug')      // → 'bug'
-detectFromTitle('feat!: breaking change')     // → 'breaking-change'
-detectFromTitle('Update documentation')       // → 'documentation'
-detectFromTitle('Random title')               // → null
-detectFromFiles(['docs/guide.md'])            // → 'documentation'
-detectFromFiles(['docs/a.md', 'internal/x.go']) // → null
-```
+After merging to `main`, add the **PR title check and labels** workflow as a required status check so invalid titles block merge.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,13 +1,15 @@
-# PR Title Validation and Label Mapping
+# CI Scripts
 
-## Overview
+## PR Title Validation and Label Mapping
+
+### Overview
 
 PR titles are validated and labeled by [`.github/workflows/auto-label-pr.yml`](../workflows/auto-label-pr.yml):
 
 1. **Validate** — [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) enforces [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on the PR title
 2. **Label** — `detect-pr-label.js` maps the validated `type` to a release-category label
 
-## Allowed PR title types
+### Allowed PR title types
 
 ```
 feat  enh  fix  docs  deps  ci  chore  refactor  test  perf  style  revert  build
@@ -17,7 +19,7 @@ Examples: `feat: add auth`, `fix(api): handle edge case`, `deps(go): bump module
 
 Breaking changes use `!` before `:`: `feat!: drop old API`, `fix(scope)!: breaking fix`
 
-## Type to label mapping
+### Type to label mapping
 
 | Type | Label |
 |------|-------|
@@ -31,12 +33,12 @@ Breaking changes use `!` before `:`: `feat!: drop old API`, `fix(scope)!: breaki
 
 Labels align with categories in [`.github/release.yml`](../release.yml).
 
-## Files
+### Files
 
 - `detect-pr-label.js` — maps validated type + title to a single category label
 - `detect-pr-label.test.js` — unit tests
 
-## Running tests
+### Running tests
 
 Requires Node.js 18+:
 
@@ -44,6 +46,6 @@ Requires Node.js 18+:
 node --test detect-pr-label.test.js
 ```
 
-## Branch protection
+### Branch protection
 
-After merging to `main`, add the **PR title check and labels** workflow as a required status check so invalid titles block merge.
+After merging to `main`, add the **Auto-label PRs** workflow as a required status check so invalid titles block merge.

--- a/.github/scripts/detect-pr-label.js
+++ b/.github/scripts/detect-pr-label.js
@@ -1,74 +1,39 @@
-const PREFIX_TYPE_LABELS = Object.fromEntries(
-  Object.entries({
-    'breaking-change': ['breaking', 'break'],
-    'feature': ['feat', 'feature'],
-    'enhancement': ['enh', 'enhancement', 'improve'],
-    'bug': ['fix', 'bugfix', 'bug'],
-    'documentation': ['docs', 'doc'],
-    'dependencies': ['deps', 'dependencies'],
-    'release-note-none': ['test', 'refactor', 'ci', 'chore', 'style', 'perf', 'revert'],
-  }).flatMap(([label, types]) => types.map((type) => [type, label])),
-);
+const TYPE_LABELS = {
+  feat: 'feature',
+  enh: 'enhancement',
+  fix: 'bug',
+  docs: 'documentation',
+  deps: 'dependencies',
+  ci: 'release-note-none',
+  chore: 'release-note-none',
+  refactor: 'release-note-none',
+  test: 'release-note-none',
+  style: 'release-note-none',
+  perf: 'release-note-none',
+  revert: 'release-note-none',
+  build: 'release-note-none',
+};
 
-const KEYWORD_LABEL_RULES = [
-  ['breaking-change', /\b(breaking|break)\b/],
-  ['bug', /\b(fix|bugfix|bug)\b/],
-  ['documentation', /\b(docs?|documentation)\b/],
-  ['dependencies', /\b(deps|dependencies)\b/],
-  ['feature', /\b(feat(?:ure)?)\b/],
-  ['enhancement', /\b(enh(?:ancement)?|improve(?:ment)?)\b/],
-  ['release-note-none', /\b(tests?|refactor|ci|chore|style|perf|revert)\b/],
+const MANAGED_CATEGORY_LABELS = [
+  'breaking-change',
+  'feature',
+  'enhancement',
+  'bug',
+  'documentation',
+  'dependencies',
+  'release-note-none',
 ];
 
-function detectFromTitle(title) {
+function isBreakingChange(title) {
   const lower = title.toLowerCase();
+  return lower.startsWith('!:') || /^(\w+)(?:\([^)]*\))?!:/.test(lower);
+}
 
-  // Priority 1: Breaking change indicators (! marker or breaking keyword in prefix)
-  // Handles: "!: description", "type!: description", "type(scope)!: description"
-  if (lower.includes('!:') || lower.match(/^(\w+)(?:\([^)]*\))?!:/)) {
+function labelFromType(type, title) {
+  if (isBreakingChange(title)) {
     return 'breaking-change';
   }
-
-  // Priority 2: Conventional commit prefix (type: or type(scope):)
-  const prefixMatch = lower.match(/^(\w+)(?:\([^)]*\))?:/);
-  if (prefixMatch) {
-    const label = PREFIX_TYPE_LABELS[prefixMatch[1]];
-    if (label) return label;
-  }
-
-  // Priority 3: Keyword fallback for titles without conventional commit format
-  for (const [label, pattern] of KEYWORD_LABEL_RULES) {
-    if (pattern.test(lower)) return label;
-  }
-
-  return null;
+  return TYPE_LABELS[type] ?? null;
 }
 
-// Labels only when every changed file matches the category (avoids mislabeling mixed PRs).
-function detectFromFiles(paths) {
-  if (paths.length === 0) return null;
-
-  if (paths.every((p) => p.startsWith('docs/') || p.endsWith('.md'))) {
-    return 'documentation';
-  }
-  if (paths.every((p) =>
-    p === 'go.mod' ||
-    p === 'go.sum' ||
-    p === '.github/dependabot.yml' ||
-    p.startsWith('vendor/')
-  )) {
-    return 'dependencies';
-  }
-  if (paths.every((p) =>
-    p.startsWith('.github/workflows/') ||
-    p.startsWith('test/') ||
-    p.startsWith('e2e/') ||
-    p.endsWith('_test.go')
-  )) {
-    return 'release-note-none';
-  }
-
-  return null;
-}
-
-module.exports = { detectFromTitle, detectFromFiles };
+module.exports = { labelFromType, isBreakingChange, MANAGED_CATEGORY_LABELS, TYPE_LABELS };

--- a/.github/scripts/detect-pr-label.js
+++ b/.github/scripts/detect-pr-label.js
@@ -1,0 +1,74 @@
+const PREFIX_TYPE_LABELS = Object.fromEntries(
+  Object.entries({
+    'breaking-change': ['breaking', 'break'],
+    'feature': ['feat', 'feature'],
+    'enhancement': ['enh', 'enhancement', 'improve'],
+    'bug': ['fix', 'bugfix', 'bug'],
+    'documentation': ['docs', 'doc'],
+    'dependencies': ['deps', 'dependencies'],
+    'release-note-none': ['test', 'refactor', 'ci', 'chore', 'style', 'perf', 'revert'],
+  }).flatMap(([label, types]) => types.map((type) => [type, label])),
+);
+
+const KEYWORD_LABEL_RULES = [
+  ['breaking-change', /\b(breaking|break)\b/],
+  ['bug', /\b(fix|bugfix|bug)\b/],
+  ['documentation', /\b(docs?|documentation)\b/],
+  ['dependencies', /\b(deps|dependencies)\b/],
+  ['feature', /\b(feat(?:ure)?)\b/],
+  ['enhancement', /\b(enh(?:ancement)?|improve(?:ment)?)\b/],
+  ['release-note-none', /\b(tests?|refactor|ci|chore|style|perf|revert)\b/],
+];
+
+function detectFromTitle(title) {
+  const lower = title.toLowerCase();
+
+  // Priority 1: Breaking change indicators (! marker or breaking keyword in prefix)
+  // Handles: "!: description", "type!: description", "type(scope)!: description"
+  if (lower.includes('!:') || lower.match(/^(\w+)(?:\([^)]*\))?!:/)) {
+    return 'breaking-change';
+  }
+
+  // Priority 2: Conventional commit prefix (type: or type(scope):)
+  const prefixMatch = lower.match(/^(\w+)(?:\([^)]*\))?:/);
+  if (prefixMatch) {
+    const label = PREFIX_TYPE_LABELS[prefixMatch[1]];
+    if (label) return label;
+  }
+
+  // Priority 3: Keyword fallback for titles without conventional commit format
+  for (const [label, pattern] of KEYWORD_LABEL_RULES) {
+    if (pattern.test(lower)) return label;
+  }
+
+  return null;
+}
+
+// Labels only when every changed file matches the category (avoids mislabeling mixed PRs).
+function detectFromFiles(paths) {
+  if (paths.length === 0) return null;
+
+  if (paths.every((p) => p.startsWith('docs/') || p.endsWith('.md'))) {
+    return 'documentation';
+  }
+  if (paths.every((p) =>
+    p === 'go.mod' ||
+    p === 'go.sum' ||
+    p === '.github/dependabot.yml' ||
+    p.startsWith('vendor/')
+  )) {
+    return 'dependencies';
+  }
+  if (paths.every((p) =>
+    p.startsWith('.github/workflows/') ||
+    p.startsWith('test/') ||
+    p.startsWith('e2e/') ||
+    p.endsWith('_test.go')
+  )) {
+    return 'release-note-none';
+  }
+
+  return null;
+}
+
+module.exports = { detectFromTitle, detectFromFiles };

--- a/.github/scripts/detect-pr-label.test.js
+++ b/.github/scripts/detect-pr-label.test.js
@@ -1,197 +1,49 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
-const { detectFromTitle, detectFromFiles } = require('./detect-pr-label.js');
+const { labelFromType, isBreakingChange } = require('./detect-pr-label.js');
 
-describe('detectFromTitle', () => {
-  describe('conventional commit prefix detection', () => {
-    const testCases = [
-      ['feat: add feature', 'feature'],
-      ['feature: add feature', 'feature'],
-      ['fix: bug', 'bug'],
-      ['bugfix: fix issue', 'bug'],
-      ['bug: resolve issue', 'bug'],
-      ['docs: update', 'documentation'],
-      ['doc: update', 'documentation'],
-      ['deps: update', 'dependencies'],
-      ['dependencies: bump', 'dependencies'],
-      ['enh: improve', 'enhancement'],
-      ['enhancement: improve', 'enhancement'],
-      ['improve: performance', 'enhancement'],
-      ['test: add tests', 'release-note-none'],
-      ['refactor: cleanup', 'release-note-none'],
-      ['ci: update workflow', 'release-note-none'],
-      ['chore: misc', 'release-note-none'],
-      ['style: format', 'release-note-none'],
-      ['perf: optimize', 'release-note-none'],
-      ['revert: undo change', 'release-note-none'],
-    ];
+describe('labelFromType', () => {
+  const testCases = [
+    ['feat', 'feat: add feature', 'feature'],
+    ['enh', 'enh: improve performance', 'enhancement'],
+    ['fix', 'fix: bug', 'bug'],
+    ['docs', 'docs: update', 'documentation'],
+    ['deps', 'deps(go): bump', 'dependencies'],
+    ['ci', 'ci: update workflow', 'release-note-none'],
+    ['chore', 'chore: misc', 'release-note-none'],
+    ['refactor', 'refactor: cleanup', 'release-note-none'],
+    ['test', 'test: add tests', 'release-note-none'],
+    ['style', 'style: format', 'release-note-none'],
+    ['perf', 'perf: optimize', 'release-note-none'],
+    ['revert', 'revert: undo change', 'release-note-none'],
+    ['build', 'build: update makefile', 'release-note-none'],
+    ['feat', 'feat(api): add endpoint', 'feature'],
+    ['fix', 'fix(auth): resolve bug', 'bug'],
+    ['feat', 'feat!: breaking feature', 'breaking-change'],
+    ['fix', 'fix!: breaking fix', 'breaking-change'],
+    ['feat', 'feat(api)!: breaking change', 'breaking-change'],
+    ['feat', '!: breaking change', 'breaking-change'],
+    ['fix', 'fix: handle error when status is !: done', 'bug'],
+    ['unknown', 'unknown: something', null],
+  ];
 
-    for (const [title, expected] of testCases) {
-      test(`"${title}" → ${expected}`, () => {
-        assert.equal(detectFromTitle(title), expected);
-      });
-    }
-  });
-
-  describe('conventional commit with scope', () => {
-    const testCases = [
-      ['feat(api): add endpoint', 'feature'],
-      ['fix(auth): resolve bug', 'bug'],
-      ['docs(readme): update', 'documentation'],
-      ['test(e2e): add tests', 'release-note-none'],
-    ];
-
-    for (const [title, expected] of testCases) {
-      test(`"${title}" → ${expected}`, () => {
-        assert.equal(detectFromTitle(title), expected);
-      });
-    }
-  });
-
-  describe('breaking change detection', () => {
-    const testCases = [
-      ['!: breaking change', 'breaking-change'],
-      ['feat!: breaking feature', 'breaking-change'],
-      ['fix!: breaking fix', 'breaking-change'],
-      ['feat(api)!: breaking change', 'breaking-change'],
-      ['breaking: major change', 'breaking-change'],
-      ['break: api change', 'breaking-change'],
-    ];
-
-    for (const [title, expected] of testCases) {
-      test(`"${title}" → ${expected}`, () => {
-        assert.equal(detectFromTitle(title), expected);
-      });
-    }
-  });
-
-  describe('keyword fallback (no conventional prefix)', () => {
-    const testCases = [
-      ['Fix the bug', 'bug'],
-      ['Update docs', 'documentation'],
-      ['Update documentation', 'documentation'],
-      ['Bump dependencies', 'dependencies'],
-      ['Add new feature', 'feature'],
-      ['Improve performance', 'enhancement'],
-      ['Add tests', 'release-note-none'],
-      ['Refactor code', 'release-note-none'],
-      ['CI updates', 'release-note-none'],
-    ];
-
-    for (const [title, expected] of testCases) {
-      test(`"${title}" → ${expected}`, () => {
-        assert.equal(detectFromTitle(title), expected);
-      });
-    }
-  });
-
-  describe('case insensitivity', () => {
-    const testCases = [
-      ['FEAT: add feature', 'feature'],
-      ['Fix: Bug', 'bug'],
-      ['DOCS: update', 'documentation'],
-      ['Feat!: BREAKING', 'breaking-change'],
-    ];
-
-    for (const [title, expected] of testCases) {
-      test(`"${title}" → ${expected}`, () => {
-        assert.equal(detectFromTitle(title), expected);
-      });
-    }
-  });
-
-  describe('edge cases', () => {
-    test('empty string returns null', () => {
-      assert.equal(detectFromTitle(''), null);
+  for (const [type, title, expected] of testCases) {
+    test(`type=${type} title="${title}" → ${expected}`, () => {
+      assert.equal(labelFromType(type, title), expected);
     });
-
-    test('title without recognized pattern returns null', () => {
-      assert.equal(detectFromTitle('Random title'), null);
-    });
-
-    test('title with only colon returns null', () => {
-      assert.equal(detectFromTitle('something: else'), null);
-    });
-
-    test('breaking change marker takes priority over other types', () => {
-      assert.equal(detectFromTitle('feat!: add feature'), 'breaking-change');
-    });
-
-    test('conventional prefix takes priority over keyword fallback', () => {
-      assert.equal(detectFromTitle('feat: fix bug'), 'feature');
-    });
-  });
+  }
 });
 
-describe('detectFromFiles', () => {
-  describe('documentation', () => {
-    test('docs/ paths only', () => {
-      assert.equal(detectFromFiles(['docs/guide.md', 'docs/api/overview.md']), 'documentation');
-    });
-
-    test('markdown files only', () => {
-      assert.equal(detectFromFiles(['README.md', 'CONTRIBUTING.md']), 'documentation');
-    });
-
-    test('mixed docs/ and markdown', () => {
-      assert.equal(detectFromFiles(['docs/foo.md', 'README.md']), 'documentation');
-    });
+describe('isBreakingChange', () => {
+  test('detects prefix !:', () => {
+    assert.equal(isBreakingChange('!: breaking'), true);
   });
 
-  describe('dependencies', () => {
-    test('go.mod and go.sum only', () => {
-      assert.equal(detectFromFiles(['go.mod', 'go.sum']), 'dependencies');
-    });
-
-    test('dependabot config only', () => {
-      assert.equal(detectFromFiles(['.github/dependabot.yml']), 'dependencies');
-    });
-
-    test('vendor/ paths only', () => {
-      assert.equal(detectFromFiles(['vendor/foo/bar.go']), 'dependencies');
-    });
+  test('detects type!:', () => {
+    assert.equal(isBreakingChange('feat!: breaking'), true);
   });
 
-  describe('release-note-none', () => {
-    test('workflow files only', () => {
-      assert.equal(detectFromFiles(['.github/workflows/ci.yml']), 'release-note-none');
-    });
-
-    test('test/ paths only', () => {
-      assert.equal(detectFromFiles(['test/integration/foo_test.go']), 'release-note-none');
-    });
-
-    test('e2e/ paths only', () => {
-      assert.equal(detectFromFiles(['e2e/scenario.go']), 'release-note-none');
-    });
-
-    test('_test.go files only', () => {
-      assert.equal(detectFromFiles(['internal/foo/foo_test.go']), 'release-note-none');
-    });
-  });
-
-  describe('no match', () => {
-    test('empty paths', () => {
-      assert.equal(detectFromFiles([]), null);
-    });
-
-    test('mixed documentation and source code', () => {
-      assert.equal(detectFromFiles(['docs/api.md', 'internal/foo.go']), null);
-    });
-
-    test('mixed workflow and script', () => {
-      assert.equal(
-        detectFromFiles(['.github/workflows/ci.yml', '.github/scripts/detect-pr-label.js']),
-        null,
-      );
-    });
-
-    test('go.mod with source changes', () => {
-      assert.equal(detectFromFiles(['go.mod', 'internal/foo.go']), null);
-    });
-
-    test('charts test paths do not match test/', () => {
-      assert.equal(detectFromFiles(['charts/batch-gateway/tests/observability_test.yaml']), null);
-    });
+  test('ignores !: in subject', () => {
+    assert.equal(isBreakingChange('fix: handle error when status is !: done'), false);
   });
 });

--- a/.github/scripts/detect-pr-label.test.js
+++ b/.github/scripts/detect-pr-label.test.js
@@ -1,0 +1,197 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const { detectFromTitle, detectFromFiles } = require('./detect-pr-label.js');
+
+describe('detectFromTitle', () => {
+  describe('conventional commit prefix detection', () => {
+    const testCases = [
+      ['feat: add feature', 'feature'],
+      ['feature: add feature', 'feature'],
+      ['fix: bug', 'bug'],
+      ['bugfix: fix issue', 'bug'],
+      ['bug: resolve issue', 'bug'],
+      ['docs: update', 'documentation'],
+      ['doc: update', 'documentation'],
+      ['deps: update', 'dependencies'],
+      ['dependencies: bump', 'dependencies'],
+      ['enh: improve', 'enhancement'],
+      ['enhancement: improve', 'enhancement'],
+      ['improve: performance', 'enhancement'],
+      ['test: add tests', 'release-note-none'],
+      ['refactor: cleanup', 'release-note-none'],
+      ['ci: update workflow', 'release-note-none'],
+      ['chore: misc', 'release-note-none'],
+      ['style: format', 'release-note-none'],
+      ['perf: optimize', 'release-note-none'],
+      ['revert: undo change', 'release-note-none'],
+    ];
+
+    for (const [title, expected] of testCases) {
+      test(`"${title}" → ${expected}`, () => {
+        assert.equal(detectFromTitle(title), expected);
+      });
+    }
+  });
+
+  describe('conventional commit with scope', () => {
+    const testCases = [
+      ['feat(api): add endpoint', 'feature'],
+      ['fix(auth): resolve bug', 'bug'],
+      ['docs(readme): update', 'documentation'],
+      ['test(e2e): add tests', 'release-note-none'],
+    ];
+
+    for (const [title, expected] of testCases) {
+      test(`"${title}" → ${expected}`, () => {
+        assert.equal(detectFromTitle(title), expected);
+      });
+    }
+  });
+
+  describe('breaking change detection', () => {
+    const testCases = [
+      ['!: breaking change', 'breaking-change'],
+      ['feat!: breaking feature', 'breaking-change'],
+      ['fix!: breaking fix', 'breaking-change'],
+      ['feat(api)!: breaking change', 'breaking-change'],
+      ['breaking: major change', 'breaking-change'],
+      ['break: api change', 'breaking-change'],
+    ];
+
+    for (const [title, expected] of testCases) {
+      test(`"${title}" → ${expected}`, () => {
+        assert.equal(detectFromTitle(title), expected);
+      });
+    }
+  });
+
+  describe('keyword fallback (no conventional prefix)', () => {
+    const testCases = [
+      ['Fix the bug', 'bug'],
+      ['Update docs', 'documentation'],
+      ['Update documentation', 'documentation'],
+      ['Bump dependencies', 'dependencies'],
+      ['Add new feature', 'feature'],
+      ['Improve performance', 'enhancement'],
+      ['Add tests', 'release-note-none'],
+      ['Refactor code', 'release-note-none'],
+      ['CI updates', 'release-note-none'],
+    ];
+
+    for (const [title, expected] of testCases) {
+      test(`"${title}" → ${expected}`, () => {
+        assert.equal(detectFromTitle(title), expected);
+      });
+    }
+  });
+
+  describe('case insensitivity', () => {
+    const testCases = [
+      ['FEAT: add feature', 'feature'],
+      ['Fix: Bug', 'bug'],
+      ['DOCS: update', 'documentation'],
+      ['Feat!: BREAKING', 'breaking-change'],
+    ];
+
+    for (const [title, expected] of testCases) {
+      test(`"${title}" → ${expected}`, () => {
+        assert.equal(detectFromTitle(title), expected);
+      });
+    }
+  });
+
+  describe('edge cases', () => {
+    test('empty string returns null', () => {
+      assert.equal(detectFromTitle(''), null);
+    });
+
+    test('title without recognized pattern returns null', () => {
+      assert.equal(detectFromTitle('Random title'), null);
+    });
+
+    test('title with only colon returns null', () => {
+      assert.equal(detectFromTitle('something: else'), null);
+    });
+
+    test('breaking change marker takes priority over other types', () => {
+      assert.equal(detectFromTitle('feat!: add feature'), 'breaking-change');
+    });
+
+    test('conventional prefix takes priority over keyword fallback', () => {
+      assert.equal(detectFromTitle('feat: fix bug'), 'feature');
+    });
+  });
+});
+
+describe('detectFromFiles', () => {
+  describe('documentation', () => {
+    test('docs/ paths only', () => {
+      assert.equal(detectFromFiles(['docs/guide.md', 'docs/api/overview.md']), 'documentation');
+    });
+
+    test('markdown files only', () => {
+      assert.equal(detectFromFiles(['README.md', 'CONTRIBUTING.md']), 'documentation');
+    });
+
+    test('mixed docs/ and markdown', () => {
+      assert.equal(detectFromFiles(['docs/foo.md', 'README.md']), 'documentation');
+    });
+  });
+
+  describe('dependencies', () => {
+    test('go.mod and go.sum only', () => {
+      assert.equal(detectFromFiles(['go.mod', 'go.sum']), 'dependencies');
+    });
+
+    test('dependabot config only', () => {
+      assert.equal(detectFromFiles(['.github/dependabot.yml']), 'dependencies');
+    });
+
+    test('vendor/ paths only', () => {
+      assert.equal(detectFromFiles(['vendor/foo/bar.go']), 'dependencies');
+    });
+  });
+
+  describe('release-note-none', () => {
+    test('workflow files only', () => {
+      assert.equal(detectFromFiles(['.github/workflows/ci.yml']), 'release-note-none');
+    });
+
+    test('test/ paths only', () => {
+      assert.equal(detectFromFiles(['test/integration/foo_test.go']), 'release-note-none');
+    });
+
+    test('e2e/ paths only', () => {
+      assert.equal(detectFromFiles(['e2e/scenario.go']), 'release-note-none');
+    });
+
+    test('_test.go files only', () => {
+      assert.equal(detectFromFiles(['internal/foo/foo_test.go']), 'release-note-none');
+    });
+  });
+
+  describe('no match', () => {
+    test('empty paths', () => {
+      assert.equal(detectFromFiles([]), null);
+    });
+
+    test('mixed documentation and source code', () => {
+      assert.equal(detectFromFiles(['docs/api.md', 'internal/foo.go']), null);
+    });
+
+    test('mixed workflow and script', () => {
+      assert.equal(
+        detectFromFiles(['.github/workflows/ci.yml', '.github/scripts/detect-pr-label.js']),
+        null,
+      );
+    });
+
+    test('go.mod with source changes', () => {
+      assert.equal(detectFromFiles(['go.mod', 'internal/foo.go']), null);
+    });
+
+    test('charts test paths do not match test/', () => {
+      assert.equal(detectFromFiles(['charts/batch-gateway/tests/observability_test.yaml']), null);
+    });
+  });
+});

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -11,13 +11,37 @@ jobs:
   add-label:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Add default labels
         uses: actions/github-script@v9
         with:
           script: |
+            const path = require('path');
+            const { detectFromTitle, detectFromFiles } = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/detect-pr-label.js'));
+
+            const title = context.payload.pull_request.title;
+            let category = detectFromTitle(title);
+
+            // Fall back to file-based detection if title yields no label.
+            // detectFromFiles only returns a label when ALL changed files match
+            // the same category (avoids mislabeling mixed PRs).
+            if (!category) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+              category = detectFromFiles(files.map((f) => f.filename));
+            }
+
+            const labels = ['ai-assisted'];
+            if (category) labels.push(category);
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: ['ai-assisted']
+              labels,
             });

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,47 +1,96 @@
-name: Add default labels to PRs
+name: PR title check and labels
 
 on:
   pull_request_target:
-    types: [opened]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
-  add-label:
+  title-and-labels:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        id: pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            enh
+            fix
+            docs
+            deps
+            ci
+            chore
+            refactor
+            test
+            perf
+            style
+            revert
+            build
 
-      - name: Add default labels
+      - name: Apply PR labels
         uses: actions/github-script@v9
+        env:
+          PR_TYPE: ${{ steps.pr_title.outputs.type }}
         with:
           script: |
+            const fs = require('fs');
+            const os = require('os');
             const path = require('path');
-            const { detectFromTitle, detectFromFiles } = require(path.join(process.env.GITHUB_WORKSPACE, '.github/scripts/detect-pr-label.js'));
 
+            const { data } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: '.github/scripts/detect-pr-label.js',
+              ref: context.payload.pull_request.base.sha,
+            });
+            const scriptPath = path.join(os.tmpdir(), 'detect-pr-label.js');
+            fs.writeFileSync(scriptPath, Buffer.from(data.content, 'base64').toString());
+            const { labelFromType, MANAGED_CATEGORY_LABELS } = require(scriptPath);
+
+            const type = process.env.PR_TYPE;
             const title = context.payload.pull_request.title;
-            let category = detectFromTitle(title);
+            const category = labelFromType(type, title);
 
-            // Fall back to file-based detection if title yields no label.
-            // detectFromFiles only returns a label when ALL changed files match
-            // the same category (avoids mislabeling mixed PRs).
-            if (!category) {
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number,
-              });
-              category = detectFromFiles(files.map((f) => f.filename));
-            }
-
-            const labels = ['ai-assisted'];
-            if (category) labels.push(category);
-
-            await github.rest.issues.addLabels({
+            const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels,
             });
+            const currentLabels = issue.labels.map((label) => label.name);
+
+            for (const label of MANAGED_CATEGORY_LABELS) {
+              if (label !== category && currentLabels.includes(label)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label,
+                });
+              }
+            }
+
+            const labelsToAdd = ['ai-assisted'];
+            if (category) {
+              labelsToAdd.push(category);
+            }
+
+            const missing = labelsToAdd.filter((label) => !currentLabels.includes(label));
+            if (missing.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: missing,
+              });
+            }

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,4 +1,4 @@
-name: PR title check and labels
+name: Auto-label PRs
 
 on:
   pull_request_target:

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -39,7 +39,7 @@ jobs:
             build
 
       - name: Apply PR labels
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           PR_TYPE: ${{ steps.pr_title.outputs.type }}
         with:

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -80,17 +80,11 @@ jobs:
               }
             }
 
-            const labelsToAdd = ['ai-assisted'];
-            if (category) {
-              labelsToAdd.push(category);
-            }
-
-            const missing = labelsToAdd.filter((label) => !currentLabels.includes(label));
-            if (missing.length > 0) {
+            if (category && !currentLabels.includes(category)) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: missing,
+                labels: [category],
               });
             }


### PR DESCRIPTION
## Why is this PR needed?

Release notes are grouped by PR labels (see `.github/release.yml`), but the auto-label workflow currently only adds `ai-assisted`. Category labels such as `feature`, `bug`, and `documentation` must be applied manually, which is easy to forget and can place PRs in the wrong release-note section.

This PR automates applying a single category label when a PR is opened, using title conventions the project already follows (e.g. `feat:`, `fix:`, `docs:`, `ci:`).

## What does this PR do?

Extends the existing `auto-label-pr` workflow to detect and apply **one** release-category label alongside `ai-assisted` on PR open.
- Adds `.github/scripts/detect-pr-label.js` with detection logic:
  - **Title (primary):** conventional commit prefixes (`feat:` → `feature`, `fix:` → `bug`, etc.), breaking-change markers (`!:`), and keyword fallback for non-conventional titles
  - **Changed files (fallback):** only when the title has no match and **all** changed files fit one category (e.g. docs-only → `documentation`, workflow-only → `release-note-none`)
- Updates `.github/workflows/auto-label-pr.yml` to load the script, detect the label, and apply it via the GitHub API (with paginated file listing for the fallback)
- Adds `.github/scripts/detect-pr-label.test.js` — 62 unit tests runnable with Node's built-in test runner (`node --test detect-pr-label.test.js`, no npm dependencies)
- Adds `.github/scripts/README.md` documenting detection rules and how to run tests

If no category can be determined, only `ai-assisted` is applied.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
