### PR TITLE
Fix PQDelete removing all members with the same SLO score

### DIFF
--- a/internal/database/redis/redis_ds_client.go
+++ b/internal/database/redis/redis_ds_client.go
@@ -96,6 +96,10 @@ var (
 	updateCASLua         string
 	redisScriptUpdateCAS = goredis.NewScript(updateCASLua)
 
+	//go:embed redis_pq_delete.lua
+	pqDeleteLua         string
+	redisScriptPQDelete = goredis.NewScript(pqDeleteLua)
+
 	//go:embed redis_pq_get_ids.lua
 	pqGetIDsLua         string
 	redisScriptPQGetIDs = goredis.NewScript(pqGetIDsLua)

--- a/internal/database/redis/redis_ds_client_test.go
+++ b/internal/database/redis/redis_ds_client_test.go
@@ -1451,6 +1451,57 @@ func TestRedisDSClient(t *testing.T) {
 		}
 	})
 
+	t.Run("Queue PQDelete removes only target item with same SLO", func(t *testing.T) {
+		if minirds != nil {
+			t.Skip("Miniredis model")
+		}
+		baseClient, _, _, exchClient := setupRedisDSClients(t, redisUrl, redisCaCert)
+		t.Cleanup(func() {
+			_ = baseClient.Close()
+		})
+
+		slo := time.Now().Add(time.Hour)
+		items := make([]*db_api.BatchJobPriority, 3)
+		for i := 0; i < 3; i++ {
+			items[i] = &db_api.BatchJobPriority{
+				ID:   uuid.New().String(),
+				SLO:  slo,
+				TTL:  1000,
+				Data: []byte(fmt.Sprintf("same-slo-%d", i)),
+			}
+			if err := exchClient.PQEnqueue(context.Background(), items[i]); err != nil {
+				t.Fatalf("Failed to enqueue item %d: %v", i, err)
+			}
+		}
+
+		// Delete only the middle item.
+		nDel, err := exchClient.PQDelete(context.Background(), items[1])
+		if err != nil {
+			t.Fatalf("PQDelete failed: %v", err)
+		}
+		if nDel != 1 {
+			t.Fatalf("Expected 1 deleted, got %d", nDel)
+		}
+
+		// Verify the other two items are still in the queue.
+		ids, err := exchClient.PQGetIDs(context.Background())
+		if err != nil {
+			t.Fatalf("PQGetIDs failed: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("Expected 2 items remaining, got %d", len(ids))
+		}
+		if ids[items[1].ID] {
+			t.Fatalf("Deleted item %s should not be in queue", items[1].ID)
+		}
+		if !ids[items[0].ID] || !ids[items[2].ID] {
+			t.Fatalf("Surviving items missing from queue")
+		}
+
+		// Cleanup.
+		_, _ = exchClient.PQDequeue(context.Background(), 1*time.Second, 100)
+	})
+
 	t.Run("includeStatic parameter - Batch", func(t *testing.T) {
 		t.Parallel()
 		baseClient, batchClient, _, _ := setupRedisDSClients(t, redisUrl, redisCaCert)

--- a/internal/database/redis/redis_pq_delete.lua
+++ b/internal/database/redis/redis_pq_delete.lua
@@ -1,0 +1,29 @@
+-- Copyright 2026 The llm-d Authors
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+--     http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- PQDelete: removes exactly one member from the priority queue sorted set
+-- matching both the given score and job ID.
+-- KEYS[1] = sorted set key (priority queue)
+-- ARGV[1] = score (SLO as UnixMicro string)
+-- ARGV[2] = target job ID
+-- Returns: number of members removed (0 or 1)
+
+local members = redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[1])
+for i = 1, #members do
+    local decoded = cjson.decode(members[i])
+    if decoded and decoded.id == ARGV[2] then
+        return redis.call("ZREM", KEYS[1], members[i])
+    end
+end
+return 0

--- a/internal/database/redis/redis_queue.go
+++ b/internal/database/redis/redis_queue.go
@@ -101,19 +101,13 @@ func (c *ExchangeDBClientRedis) PQDelete(ctx context.Context, item *db_api.Batch
 	score := strconv.FormatInt(item.SLO.UnixMicro(), 10)
 	cctx, ccancel := context.WithTimeout(ctx, c.timeout)
 	defer ccancel()
-	res := c.redisClient.ZRemRangeByScore(cctx, priorityQueueKeyName, score, score)
-	if res == nil {
-		err = fmt.Errorf("redis command result is nil")
+	res, lerr := redisScriptPQDelete.Run(cctx, c.redisClient,
+		[]string{priorityQueueKeyName}, score, item.ID).Int()
+	if lerr != nil {
+		err = lerr
 		return
 	}
-	if res.Err() == goredis.Nil {
-		logger.Info("PQDelete: key not found")
-		return
-	}
-	if err = res.Err(); err != nil {
-		return
-	}
-	nDeleted = int(res.Val())
+	nDeleted = res
 
 	logger.Info("PQDelete: succeeded")
 	return


### PR DESCRIPTION
## Why is this PR needed?

`PQDelete` uses `ZRemRangeByScore(score, score)` to remove a batch from the Redis priority queue. This deletes **all** members sharing that score, not just the target batch. When two batches have the same SLO microsecond value (same `completion_window` created close together), cancelling one silently removes the other — leaving it stuck in `validating` status with no queue entry and no recovery path.

### Note on #293 dependency

Issue #294 mentions being blocked on #293 (member normalization) because the caller can't reconstruct the exact member bytes for `ZRem`. This PR sidesteps that entirely by using an atomic Lua script that fetches members by score, decodes each to check the ID, and `ZREM`s only the match. No member reconstruction needed — the script works with the existing `BatchJobPriority` JSON format unchanged.

## What does this PR do?

- Adds `redis_pq_delete.lua`: an atomic Lua script that narrows by score via `ZRANGEBYSCORE`, then matches by job ID via `cjson.decode`, and removes exactly one member with `ZREM`. Same pattern as the existing `redis_pq_get_ids.lua`.
- Updates `PQDelete` in `redis_queue.go` to use the Lua script instead of `ZRemRangeByScore`.
- Adds a regression test: enqueue 3 items with identical SLO, delete the middle one, verify the other 2 survive via `PQGetIDs`.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

All queue tests pass against real Redis (not just miniredis). Full project test suite passes with zero failures.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #294