### PR TITLE
fix: add tls MinVersion for security findings address

### DIFF
--- a/internal/util/tls/tls.go
+++ b/internal/util/tls/tls.go
@@ -47,6 +47,7 @@ const (
 
 func GetTlsConfig(loadType LoadType, insecure bool, certFile string, keyFile string, caCertFile string) (*tls.Config, error) {
 	var tlsConf tls.Config
+	tlsConf.MinVersion = tls.VersionTLS12
 	if certFile != "" {
 		certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {

--- a/internal/util/tls/tls_test.go
+++ b/internal/util/tls/tls_test.go
@@ -1,0 +1,43 @@
+package tls
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestGetTlsConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		loadType LoadType
+		insecure bool
+	}{
+		{
+			name:     "client defaults to TLS 1.2 minimum",
+			loadType: LOAD_TYPE_CLIENT,
+		},
+		{
+			name:     "server defaults to TLS 1.2 minimum",
+			loadType: LOAD_TYPE_SERVER,
+		},
+		{
+			name:     "insecure client still enforces TLS 1.2 minimum",
+			loadType: LOAD_TYPE_CLIENT,
+			insecure: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := GetTlsConfig(tt.loadType, tt.insecure, "", "", "")
+			if err != nil {
+				t.Fatalf("GetTlsConfig() error = %v", err)
+			}
+			if cfg == nil {
+				t.Fatal("GetTlsConfig() returned nil config")
+			}
+			if cfg.MinVersion != tls.VersionTLS12 {
+				t.Fatalf("GetTlsConfig() MinVersion = %v, want %v", cfg.MinVersion, tls.VersionTLS12)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

The security review flagged `internal/util/tls.GetTlsConfig()` for relying on the Go runtime default TLS minimum version. While current Go defaults already enforce TLS 1.2+, this PR makes that policy explicit in shared TLS config.

## What does this PR do?

- sets `MinVersion: tls.VersionTLS12` in `GetTlsConfig()`
- adds unit coverage to verify the TLS minimum version across client, server, and insecure paths

## How was this tested?

- [x] `go test ./internal/util/tls`
- [x] `make pre-commit` 
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [X] CI checks pass (`make ci`)
- [X] E2E tests pass (`make test-e2e`)

## Related Issues

Related to RHOAIENG-63961