### PR TITLE
fix: add return after t.Fatal to satisfy staticcheck SA5011

### DIFF
--- a/internal/util/tls/tls_test.go
+++ b/internal/util/tls/tls_test.go
@@ -34,6 +34,7 @@ func TestGetTlsConfig(t *testing.T) {
 			}
 			if cfg == nil {
 				t.Fatal("GetTlsConfig() returned nil config")
+				return
 			}
 			if cfg.MinVersion != tls.VersionTLS12 {
 				t.Fatalf("GetTlsConfig() MinVersion = %v, want %v", cfg.MinVersion, tls.VersionTLS12)

--- a/pkg/clients/inference/inference_client_test.go
+++ b/pkg/clients/inference/inference_client_test.go
@@ -878,6 +878,7 @@ func testDroppedReason(t *testing.T) {
 			_, genErr := client.Generate(context.Background(), req)
 			if genErr == nil {
 				t.Fatal("expected non-nil error for 429 response")
+				return
 			}
 			if genErr.DroppedReason != tt.wantDroppedReason {
 				t.Errorf("DroppedReason = %q, want %q", genErr.DroppedReason, tt.wantDroppedReason)


### PR DESCRIPTION
## Summary

- Adds explicit `return` after `t.Fatal` nil-guard checks in `tls_test.go` and `inference_client_test.go` so staticcheck SA5011 can see the nil path terminates
- Fixes the CI failure on main: https://github.com/llm-d/llm-d-batch-gateway/actions/runs/27696042141

## Test plan

- [x] `golangci-lint run ./internal/util/tls/... ./pkg/clients/inference/...` — 0 issues
- [x] `go test ./internal/util/tls/...` — PASS
- [x] `go test ./pkg/clients/inference/... -run TestInferenceClient/DroppedReason` — PASS
- [x] `make pre-commit` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)