### PR TITLE
test: re-resolve processor observability for e2e runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,7 @@ benchmark-local-teardown:
 test-e2e:
 	@echo "Running E2E tests..."
 	@OUT=$$(mktemp); \
+	echo "Processor observability endpoint: auto-resolved by the e2e test helpers"; \
 	cd test/e2e && $(GO) test -v -count=1 $(if $(TEST_RUN),-run $(TEST_RUN)) ./... 2>&1 | tee $$OUT; \
 	TEST_EXIT=$${PIPESTATUS[0]}; \
 	PASS_COUNT=$$(grep -- '--- PASS:' $$OUT 2>/dev/null | wc -l | tr -d ' '); \

--- a/scripts/dev-clean.sh
+++ b/scripts/dev-clean.sh
@@ -25,8 +25,8 @@ cleanup_kubernetes_resources() {
     helm uninstall "${REDIS_RELEASE}" -n "${NAMESPACE}" 2>/dev/null || warn "Failed to uninstall ${REDIS_RELEASE} (may not exist)"
     helm uninstall "${POSTGRESQL_RELEASE}" -n "${NAMESPACE}" 2>/dev/null || warn "Failed to uninstall ${POSTGRESQL_RELEASE} (may not exist)"
 
-    # Delete NodePort services (created outside of Helm)
-    log "Deleting NodePort services..."
+    # Delete developer-created access services (created outside of Helm)
+    log "Deleting developer-created services..."
     kubectl delete svc "${HELM_RELEASE}-apiserver-nodeport" -n "${NAMESPACE}" --ignore-not-found=true
     kubectl delete svc "${HELM_RELEASE}-processor-nodeport" -n "${NAMESPACE}" --ignore-not-found=true
     kubectl delete svc "${PROMETHEUS_NAME}-nodeport" -n "${NAMESPACE}" --ignore-not-found=true

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -33,7 +33,6 @@ GRAFANA_IMAGE="${GRAFANA_IMAGE:-${IMAGE_REGISTRY}/grafana/grafana:latest}"
 LOG_VERBOSITY="${LOG_VERBOSITY:-5}"
 APISERVER_NODE_PORT="${APISERVER_NODE_PORT:-30080}"
 APISERVER_OBS_NODE_PORT="${APISERVER_OBS_NODE_PORT:-30081}"
-PROCESSOR_NODE_PORT="${PROCESSOR_NODE_PORT:-30090}"
 # Metrics ports must match values.yaml defaults (processor.addr / gc.config.metricsAddr)
 PROCESSOR_METRICS_PORT="${PROCESSOR_METRICS_PORT:-9090}"
 GC_METRICS_PORT="${GC_METRICS_PORT:-9091}"
@@ -124,9 +123,6 @@ nodes:
     protocol: TCP
   - containerPort: ${APISERVER_OBS_NODE_PORT}
     hostPort: ${LOCAL_OBS_PORT}
-    protocol: TCP
-  - containerPort: ${PROCESSOR_NODE_PORT}
-    hostPort: ${LOCAL_PROCESSOR_PORT}
     protocol: TCP
   - containerPort: ${JAEGER_NODE_PORT}
     hostPort: ${JAEGER_PORT}
@@ -1244,7 +1240,6 @@ kind: Service
 metadata:
   name: ${HELM_RELEASE}-processor-nodeport
 spec:
-  type: NodePort
   selector:
     app.kubernetes.io/name: batch-gateway-processor
     app.kubernetes.io/instance: ${HELM_RELEASE}
@@ -1254,7 +1249,6 @@ spec:
     protocol: TCP
     port: 9090
     targetPort: metrics
-    nodePort: ${PROCESSOR_NODE_PORT}
 ---
 apiVersion: v1
 kind: Service
@@ -1304,6 +1298,7 @@ EOF
 
     log "NodePort services created."
     wait_for_http_ready
+    log "Processor observability service created for local port-forwarding."
 }
 
 print_usage() {
@@ -1318,6 +1313,7 @@ print_usage() {
     echo "  1. Run E2E tests:"
     echo ""
     echo "       make test-e2e"
+    echo "       # make test-e2e will port-forward processor observability automatically"
     echo ""
     echo "  2. Upload a batch input file (JSONL):"
     echo ""
@@ -1356,11 +1352,12 @@ print_usage() {
     echo "       go tool pprof http://localhost:${LOCAL_OBS_PORT}/debug/pprof/allocs             # Allocs"
     echo "       go tool pprof http://localhost:${LOCAL_OBS_PORT}/debug/pprof/goroutine          # Goroutine"
     echo ""
-    echo "     Processor (port ${LOCAL_PROCESSOR_PORT}):"
-    echo "       go tool pprof http://localhost:${LOCAL_PROCESSOR_PORT}/debug/pprof/profile?seconds=30  # CPU"
-    echo "       go tool pprof http://localhost:${LOCAL_PROCESSOR_PORT}/debug/pprof/heap               # Heap"
-    echo "       go tool pprof http://localhost:${LOCAL_PROCESSOR_PORT}/debug/pprof/allocs             # Allocs"
-    echo "       go tool pprof http://localhost:${LOCAL_PROCESSOR_PORT}/debug/pprof/goroutine          # Goroutine"
+    echo "     Processor (via local port-forward):"
+    echo "       kubectl port-forward -n ${NAMESPACE} svc/${HELM_RELEASE}-processor-nodeport 19090:9090"
+    echo "       go tool pprof http://127.0.0.1:19090/debug/pprof/profile?seconds=30  # CPU"
+    echo "       go tool pprof http://127.0.0.1:19090/debug/pprof/heap               # Heap"
+    echo "       go tool pprof http://127.0.0.1:19090/debug/pprof/allocs             # Allocs"
+    echo "       go tool pprof http://127.0.0.1:19090/debug/pprof/goroutine          # Goroutine"
     echo ""
     echo "  5. Prometheus (metrics):"
     echo ""

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,8 @@ This script:
 4. Installs PostgreSQL via Helm
 5. Deploys a vLLM simulator as the inference backend
 6. Deploys batch-gateway via Helm
-7. Creates NodePort services mapping to `https://localhost:8000` (apiserver), `http://localhost:8081` (apiserver observability), and `http://localhost:9090` (processor observability)
+7. Creates NodePort services mapping to `https://localhost:8000` (apiserver) and `http://localhost:8081` (apiserver observability)
+8. Creates a processor observability service that `make test-e2e` reaches via a temporary local `kubectl port-forward`
 
 **Environment variables**
 
@@ -61,7 +62,7 @@ make test-e2e
 |---------------------------|----------------------------------|------------------------------------------------------------|
 | `TEST_APISERVER_URL`      | `https://localhost:8000`         | Base URL of the running API server (TLS)                   |
 | `TEST_APISERVER_OBS_URL`  | `http://localhost:8081`          | Apiserver observability endpoint (health, metrics)         |
-| `TEST_PROCESSOR_OBS_URL`  | `http://localhost:9090`          | Processor observability endpoint (health, metrics)         |
+| `TEST_PROCESSOR_OBS_URL`  | auto-resolved by the e2e test helpers | Processor observability endpoint (health, metrics)   |
 | `TEST_JAEGER_URL`         | `http://localhost:16686`         | Jaeger query endpoint for trace verification               |
 | `TEST_TENANT_HEADER`      | `X-MaaS-Username`               | HTTP header used to identify the tenant                    |
 | `TEST_TENANT_ID`          | `default`                        | Tenant ID sent in the tenant header                        |
@@ -78,6 +79,13 @@ Example with overrides:
 
 ```bash
 TEST_APISERVER_URL=https://localhost:9000 TEST_TENANT_ID=my-tenant make test-e2e
+```
+
+If you run `go test` directly instead of `make test-e2e`, the test helpers will auto-resolve the processor observability endpoint. You can still override it explicitly if needed:
+
+```bash
+TEST_PROCESSOR_OBS_URL=http://127.0.0.1:19090 \
+go test -v ./test/e2e/...
 ```
 
 ## 3. Cleanup

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,7 +29,7 @@ import (
 var (
 	testApiserverURL      = getEnvOrDefault("TEST_APISERVER_URL", "https://localhost:8000")
 	testApiserverObsURL   = getEnvOrDefault("TEST_APISERVER_OBS_URL", "http://localhost:8081")
-	testProcessorObsURL   = getEnvOrDefault("TEST_PROCESSOR_OBS_URL", "http://localhost:9090")
+	testProcessorObsURL   = getEnvOrDefault("TEST_PROCESSOR_OBS_URL", "")
 	testJaegerURL         = getEnvOrDefault("TEST_JAEGER_URL", "http://localhost:16686")
 	testTenantHeader      = getEnvOrDefault("TEST_TENANT_HEADER", "X-MaaS-Username")
 	testTenantID          = getEnvOrDefault("TEST_TENANT_ID", "default")

--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -30,7 +30,6 @@ package e2e_test
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"os/exec"
 	"regexp"
@@ -570,15 +569,9 @@ func resolveExpectedObjective(t *testing.T, model string) string {
 func scrapeProcessorMetrics(t *testing.T) string {
 	t.Helper()
 
-	resp, err := http.Get(testProcessorObsURL + "/metrics")
+	_, body, err := readProcessorObsEndpoint(t, "/metrics")
 	if err != nil {
 		t.Fatalf("failed to scrape processor metrics: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("failed to read processor metrics body: %v", err)
 	}
 	return string(body)
 }

--- a/test/e2e/helm_upgrade_test.go
+++ b/test/e2e/helm_upgrade_test.go
@@ -109,7 +109,7 @@ func testHelmUpgrade(t *testing.T) {
 		t.Logf("ConfigMap max_retries changed from %d to %d (model_gateways[%s])", originalMaxRetries, got, testModel)
 
 		waitForRollout(t, fmt.Sprintf("%s-processor", testHelmRelease))
-		waitForReady(t, testProcessorObsURL, 180*time.Second)
+		waitForProcessorReady(t, 180*time.Second)
 		t.Log("processor healthy after helm upgrade")
 	})
 
@@ -124,7 +124,7 @@ func testHelmUpgrade(t *testing.T) {
 		}
 
 		waitForRollout(t, fmt.Sprintf("%s-processor", testHelmRelease))
-		waitForReady(t, testProcessorObsURL, 180*time.Second)
+		waitForProcessorReady(t, 180*time.Second)
 		t.Log("original values restored successfully")
 	})
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -15,6 +15,7 @@
 package e2e_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -808,4 +809,140 @@ func fetchOutputFile(t *testing.T, batch *openai.Batch) string {
 		t.Fatalf("read output file body failed: %v", err)
 	}
 	return strings.TrimSpace(string(body))
+}
+
+func withProcessorObsURL(t *testing.T, fn func(string)) {
+	t.Helper()
+
+	if testProcessorObsURL != "" {
+		fn(testProcessorObsURL)
+		return
+	}
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe for processor port-forward: %v", err)
+	}
+	defer reader.Close()
+
+	cmd := exec.Command("kubectl", "port-forward",
+		"-n", testNamespace,
+		fmt.Sprintf("svc/%s-processor-nodeport", testHelmRelease),
+		":9090",
+		"--address", "127.0.0.1",
+	)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+
+	if err := cmd.Start(); err != nil {
+		writer.Close()
+		t.Fatalf("start processor port-forward: %v", err)
+	}
+	_ = writer.Close()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	waited := false
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		if !waited {
+			<-waitDone
+		}
+	}()
+
+	lineCh := make(chan string, 16)
+	scanDone := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(reader)
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		close(lineCh)
+		scanDone <- scanner.Err()
+	}()
+
+	var output []string
+	timeout := time.NewTimer(10 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case line, ok := <-lineCh:
+			if !ok {
+				if err := <-scanDone; err != nil {
+					t.Fatalf("read processor port-forward output: %v", err)
+				}
+				t.Fatalf("processor port-forward exited before reporting a local port:\n%s", strings.Join(output, "\n"))
+			}
+			output = append(output, line)
+			const prefix = "Forwarding from 127.0.0.1:"
+			if !strings.Contains(line, prefix) {
+				continue
+			}
+			parts := strings.Fields(strings.SplitN(line, prefix, 2)[1])
+			if len(parts) == 0 {
+				t.Fatalf("unexpected processor port-forward output: %q", line)
+			}
+			fn("http://127.0.0.1:" + parts[0])
+			return
+		case err := <-waitDone:
+			waited = true
+			t.Fatalf("processor port-forward exited early: %v\n%s", err, strings.Join(output, "\n"))
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for processor port-forward:\n%s", strings.Join(output, "\n"))
+		}
+	}
+}
+
+func readProcessorObsEndpoint(t *testing.T, path string) (int, []byte, error) {
+	t.Helper()
+
+	var (
+		status int
+		body   []byte
+		err    error
+	)
+
+	withProcessorObsURL(t, func(baseURL string) {
+		var resp *http.Response
+		resp, err = http.Get(baseURL + path)
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		status = resp.StatusCode
+		body, err = io.ReadAll(resp.Body)
+	})
+
+	return status, body, err
+}
+
+func waitForProcessorReady(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	var lastStatus int
+
+	for {
+		status, _, err := readProcessorObsEndpoint(t, "/ready")
+		if err == nil && status == http.StatusOK {
+			return
+		}
+		lastErr = err
+		lastStatus = status
+
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				t.Fatalf("processor not ready after %v: %v", timeout, lastErr)
+			}
+			t.Fatalf("processor not ready after %v (status %d)", timeout, lastStatus)
+		}
+		time.Sleep(time.Second)
+	}
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -816,6 +816,7 @@ type processorObsPortForward struct {
 	cmd      *exec.Cmd
 	reader   *os.File
 	waitDone chan error
+	scanDone chan error
 }
 
 func startProcessorObsPortForward(t *testing.T) (*processorObsPortForward, error) {
@@ -843,20 +844,26 @@ func startProcessorObsPortForward(t *testing.T) (*processorObsPortForward, error
 
 	var (
 		waitDone chan error
+		scanDone chan error
 		success  bool
 	)
+	startupDone := make(chan struct{})
 	defer func() {
 		if success {
 			return
 		}
+		close(startupDone)
 		_ = writer.Close()
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
+		_ = reader.Close()
 		if waitDone != nil {
 			<-waitDone
 		}
-		_ = reader.Close()
+		if scanDone != nil {
+			<-scanDone
+		}
 	}()
 
 	if err := cmd.Start(); err != nil {
@@ -869,12 +876,16 @@ func startProcessorObsPortForward(t *testing.T) (*processorObsPortForward, error
 		waitDone <- cmd.Wait()
 	}()
 
-	lineCh := make(chan string, 16)
-	scanDone := make(chan error, 1)
+	lineCh := make(chan string)
+	scanDone = make(chan error, 1)
 	go func() {
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
-			lineCh <- scanner.Text()
+			line := scanner.Text()
+			select {
+			case lineCh <- line:
+			case <-startupDone:
+			}
 		}
 		close(lineCh)
 		scanDone <- scanner.Err()
@@ -902,12 +913,14 @@ func startProcessorObsPortForward(t *testing.T) (*processorObsPortForward, error
 			if len(parts) == 0 {
 				return nil, fmt.Errorf("unexpected processor port-forward output: %q", line)
 			}
+			close(startupDone)
 			success = true
 			return &processorObsPortForward{
 				baseURL:  "http://127.0.0.1:" + parts[0],
 				cmd:      cmd,
 				reader:   reader,
 				waitDone: waitDone,
+				scanDone: scanDone,
 			}, nil
 		case err := <-waitDone:
 			return nil, fmt.Errorf("processor port-forward exited early: %v\n%s", err, strings.Join(output, "\n"))
@@ -924,11 +937,14 @@ func (pf *processorObsPortForward) Close() {
 	if pf.cmd != nil && pf.cmd.Process != nil {
 		_ = pf.cmd.Process.Kill()
 	}
+	if pf.reader != nil {
+		_ = pf.reader.Close()
+	}
 	if pf.waitDone != nil {
 		<-pf.waitDone
 	}
-	if pf.reader != nil {
-		_ = pf.reader.Close()
+	if pf.scanDone != nil {
+		<-pf.scanDone
 	}
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -811,19 +811,26 @@ func fetchOutputFile(t *testing.T, batch *openai.Batch) string {
 	return strings.TrimSpace(string(body))
 }
 
-func withProcessorObsURL(t *testing.T, fn func(string)) {
+type processorObsPortForward struct {
+	baseURL  string
+	cmd      *exec.Cmd
+	reader   *os.File
+	waitDone chan error
+}
+
+func startProcessorObsPortForward(t *testing.T) (*processorObsPortForward, error) {
 	t.Helper()
 
 	if testProcessorObsURL != "" {
-		fn(testProcessorObsURL)
-		return
+		return &processorObsPortForward{
+			baseURL: testProcessorObsURL,
+		}, nil
 	}
 
 	reader, writer, err := os.Pipe()
 	if err != nil {
-		t.Fatalf("create pipe for processor port-forward: %v", err)
+		return nil, fmt.Errorf("create pipe for processor port-forward: %w", err)
 	}
-	defer reader.Close()
 
 	cmd := exec.Command("kubectl", "port-forward",
 		"-n", testNamespace,
@@ -834,25 +841,32 @@ func withProcessorObsURL(t *testing.T, fn func(string)) {
 	cmd.Stdout = writer
 	cmd.Stderr = writer
 
-	if err := cmd.Start(); err != nil {
-		writer.Close()
-		t.Fatalf("start processor port-forward: %v", err)
-	}
-	_ = writer.Close()
-
-	waitDone := make(chan error, 1)
-	go func() {
-		waitDone <- cmd.Wait()
-	}()
-
-	waited := false
+	var (
+		waitDone chan error
+		success  bool
+	)
 	defer func() {
+		if success {
+			return
+		}
+		_ = writer.Close()
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		if !waited {
+		if waitDone != nil {
 			<-waitDone
 		}
+		_ = reader.Close()
+	}()
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start processor port-forward: %w", err)
+	}
+	_ = writer.Close()
+
+	waitDone = make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
 	}()
 
 	lineCh := make(chan string, 16)
@@ -875,9 +889,9 @@ func withProcessorObsURL(t *testing.T, fn func(string)) {
 		case line, ok := <-lineCh:
 			if !ok {
 				if err := <-scanDone; err != nil {
-					t.Fatalf("read processor port-forward output: %v", err)
+					return nil, fmt.Errorf("read processor port-forward output: %w", err)
 				}
-				t.Fatalf("processor port-forward exited before reporting a local port:\n%s", strings.Join(output, "\n"))
+				return nil, fmt.Errorf("processor port-forward exited before reporting a local port:\n%s", strings.Join(output, "\n"))
 			}
 			output = append(output, line)
 			const prefix = "Forwarding from 127.0.0.1:"
@@ -886,40 +900,62 @@ func withProcessorObsURL(t *testing.T, fn func(string)) {
 			}
 			parts := strings.Fields(strings.SplitN(line, prefix, 2)[1])
 			if len(parts) == 0 {
-				t.Fatalf("unexpected processor port-forward output: %q", line)
+				return nil, fmt.Errorf("unexpected processor port-forward output: %q", line)
 			}
-			fn("http://127.0.0.1:" + parts[0])
-			return
+			success = true
+			return &processorObsPortForward{
+				baseURL:  "http://127.0.0.1:" + parts[0],
+				cmd:      cmd,
+				reader:   reader,
+				waitDone: waitDone,
+			}, nil
 		case err := <-waitDone:
-			waited = true
-			t.Fatalf("processor port-forward exited early: %v\n%s", err, strings.Join(output, "\n"))
+			return nil, fmt.Errorf("processor port-forward exited early: %v\n%s", err, strings.Join(output, "\n"))
 		case <-timeout.C:
-			t.Fatalf("timed out waiting for processor port-forward:\n%s", strings.Join(output, "\n"))
+			return nil, fmt.Errorf("timed out waiting for processor port-forward:\n%s", strings.Join(output, "\n"))
 		}
 	}
+}
+
+func (pf *processorObsPortForward) Close() {
+	if pf == nil {
+		return
+	}
+	if pf.cmd != nil && pf.cmd.Process != nil {
+		_ = pf.cmd.Process.Kill()
+	}
+	if pf.waitDone != nil {
+		<-pf.waitDone
+	}
+	if pf.reader != nil {
+		_ = pf.reader.Close()
+	}
+}
+
+func (pf *processorObsPortForward) Read(path string) (int, []byte, error) {
+	resp, err := http.Get(pf.baseURL + path)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, body, nil
 }
 
 func readProcessorObsEndpoint(t *testing.T, path string) (int, []byte, error) {
 	t.Helper()
 
-	var (
-		status int
-		body   []byte
-		err    error
-	)
+	pf, err := startProcessorObsPortForward(t)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer pf.Close()
 
-	withProcessorObsURL(t, func(baseURL string) {
-		var resp *http.Response
-		resp, err = http.Get(baseURL + path)
-		if err != nil {
-			return
-		}
-		defer resp.Body.Close()
-		status = resp.StatusCode
-		body, err = io.ReadAll(resp.Body)
-	})
-
-	return status, body, err
+	return pf.Read(path)
 }
 
 func waitForProcessorReady(t *testing.T, timeout time.Duration) {
@@ -928,14 +964,37 @@ func waitForProcessorReady(t *testing.T, timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	var lastStatus int
+	var pf *processorObsPortForward
+	defer func() {
+		if pf != nil {
+			pf.Close()
+		}
+	}()
 
 	for {
-		status, _, err := readProcessorObsEndpoint(t, "/ready")
+		if pf == nil {
+			var err error
+			pf, err = startProcessorObsPortForward(t)
+			if err != nil {
+				lastErr = err
+				if time.Now().After(deadline) {
+					t.Fatalf("processor not ready after %v: %v", timeout, lastErr)
+				}
+				time.Sleep(time.Second)
+				continue
+			}
+		}
+
+		status, _, err := pf.Read("/ready")
 		if err == nil && status == http.StatusOK {
 			return
 		}
 		lastErr = err
 		lastStatus = status
+		if err != nil {
+			pf.Close()
+			pf = nil
+		}
 
 		if time.Now().After(deadline) {
 			if lastErr != nil {

--- a/test/e2e/observability_test.go
+++ b/test/e2e/observability_test.go
@@ -123,13 +123,13 @@ func testPprof(t *testing.T) {
 	t.Run("Processor", func(t *testing.T) {
 		pf, err := startProcessorObsPortForward(t)
 		if err != nil {
-			t.Skipf("pprof not reachable on processor observability endpoint: %v", err)
+			t.Fatalf("processor port-forward failed: %v", err)
 		}
 		defer pf.Close()
 
 		status, _, err := pf.Read("/debug/pprof/")
 		if err != nil {
-			t.Skipf("pprof not reachable on processor observability endpoint: %v", err)
+			t.Fatalf("GET /debug/pprof/ failed: %v", err)
 		}
 		if status == http.StatusNotFound {
 			t.Skip("pprof not enabled on processor observability endpoint")

--- a/test/e2e/observability_test.go
+++ b/test/e2e/observability_test.go
@@ -29,7 +29,7 @@ import (
 
 func testObservability(t *testing.T) {
 	t.Run("APIServer", func(t *testing.T) { doTestObservabilityEndpoints(t, testApiserverObsURL) })
-	t.Run("Processor", func(t *testing.T) { doTestObservabilityEndpoints(t, testProcessorObsURL) })
+	t.Run("Processor", doTestProcessorObservabilityEndpoints)
 	t.Run("Pprof", testPprof)
 	t.Run("OtelTraces", doTestOtelTraces)
 	t.Run("RequestLogging", doTestRequestLogging)
@@ -94,7 +94,6 @@ func testPprof(t *testing.T) {
 		obsURL string
 	}{
 		{"APIServer", testApiserverObsURL},
-		{"Processor", testProcessorObsURL},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := http.Get(tc.obsURL + "/debug/pprof/")
@@ -120,6 +119,27 @@ func testPprof(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Processor", func(t *testing.T) {
+		status, _, err := readProcessorObsEndpoint(t, "/debug/pprof/")
+		if err != nil {
+			t.Skipf("pprof not reachable on processor observability endpoint: %v", err)
+		}
+		if status == http.StatusNotFound {
+			t.Skip("pprof not enabled on processor observability endpoint")
+		}
+		if status != http.StatusOK {
+			t.Errorf("expected 200 from /debug/pprof/, got %d", status)
+		}
+
+		heapStatus, _, err := readProcessorObsEndpoint(t, "/debug/pprof/heap")
+		if err != nil {
+			t.Fatalf("GET /debug/pprof/heap failed: %v", err)
+		}
+		if heapStatus != http.StatusOK {
+			t.Errorf("expected 200 from /debug/pprof/heap, got %d", heapStatus)
+		}
+	})
 }
 
 // doTestRequestLogging verifies that the apiserver emits request-level logs
@@ -183,6 +203,22 @@ func doTestObservabilityEndpoints(t *testing.T, obsURL string) {
 			resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("expected 200 from %s, got %d", endpoint, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func doTestProcessorObservabilityEndpoints(t *testing.T) {
+	t.Helper()
+
+	for _, endpoint := range []string{"/health", "/ready", "/metrics"} {
+		t.Run(strings.TrimPrefix(endpoint, "/"), func(t *testing.T) {
+			status, _, err := readProcessorObsEndpoint(t, endpoint)
+			if err != nil {
+				t.Fatalf("GET %s failed: %v", endpoint, err)
+			}
+			if status != http.StatusOK {
+				t.Errorf("expected 200 from %s, got %d", endpoint, status)
 			}
 		})
 	}

--- a/test/e2e/observability_test.go
+++ b/test/e2e/observability_test.go
@@ -121,7 +121,13 @@ func testPprof(t *testing.T) {
 	}
 
 	t.Run("Processor", func(t *testing.T) {
-		status, _, err := readProcessorObsEndpoint(t, "/debug/pprof/")
+		pf, err := startProcessorObsPortForward(t)
+		if err != nil {
+			t.Skipf("pprof not reachable on processor observability endpoint: %v", err)
+		}
+		defer pf.Close()
+
+		status, _, err := pf.Read("/debug/pprof/")
 		if err != nil {
 			t.Skipf("pprof not reachable on processor observability endpoint: %v", err)
 		}
@@ -132,7 +138,7 @@ func testPprof(t *testing.T) {
 			t.Errorf("expected 200 from /debug/pprof/, got %d", status)
 		}
 
-		heapStatus, _, err := readProcessorObsEndpoint(t, "/debug/pprof/heap")
+		heapStatus, _, err := pf.Read("/debug/pprof/heap")
 		if err != nil {
 			t.Fatalf("GET /debug/pprof/heap failed: %v", err)
 		}
@@ -211,9 +217,15 @@ func doTestObservabilityEndpoints(t *testing.T, obsURL string) {
 func doTestProcessorObservabilityEndpoints(t *testing.T) {
 	t.Helper()
 
+	pf, err := startProcessorObsPortForward(t)
+	if err != nil {
+		t.Fatalf("failed to start processor observability port-forward: %v", err)
+	}
+	defer pf.Close()
+
 	for _, endpoint := range []string{"/health", "/ready", "/metrics"} {
 		t.Run(strings.TrimPrefix(endpoint, "/"), func(t *testing.T) {
-			status, _, err := readProcessorObsEndpoint(t, endpoint)
+			status, _, err := pf.Read(endpoint)
 			if err != nil {
 				t.Fatalf("GET %s failed: %v", endpoint, err)
 			}

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -82,7 +82,7 @@ func doTestPodDeleteMidJob(t *testing.T) {
 	t.Logf("processor pod delete issued: %s", strings.TrimSpace(string(out)))
 
 	// Wait for the new pod to become ready.
-	waitForReady(t, testProcessorObsURL, 2*time.Minute)
+	waitForProcessorReady(t, 2*time.Minute)
 	t.Log("new processor pod is ready")
 
 	// The re-enqueue path should succeed reliably with the full grace period.
@@ -140,7 +140,7 @@ func doTestRollingRestartReEnqueue(t *testing.T) {
 
 	// Wait for rollout to complete.
 	waitForRollout(t, deployment)
-	waitForReady(t, testProcessorObsURL, 2*time.Minute)
+	waitForProcessorReady(t, 2*time.Minute)
 	t.Log("processor rollout complete and ready")
 
 	// Same re-enqueue path as PodDeleteMidJob. completed is expected; failed


### PR DESCRIPTION
## Why is this PR needed?

The previous attempt in #450 removed the fixed processor observability port, but the replacement still assumed that the processor endpoint would be directly reachable from the host. That does not hold reliably in local kind + Colima setups, where auto-detected NodePort addresses may not be reachable and long-lived port-forwards can break across processor restarts.

This PR supersedes #450 by moving processor observability resolution closer to the actual e2e checks instead of trying to maintain one stable host endpoint for the whole test run.

## What does this PR do?

- updates local dev deployment so processor observability is exposed through a service intended for local port-forward access rather than a fixed host-reachable port
- changes e2e processor observability checks to resolve access on demand in the Go test helpers, so metrics, readiness, and pprof checks still work after processor restarts and Helm upgrades
- aligns the local dev and e2e documentation with the new access model

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

- Supersedes #450