### PR TITLE
feat: Kind + inference-sim e2e path and workload shape alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,10 @@ BENCHMARK_RESULTS_DIR ?= benchmarks/results/local-run
 
 ## benchmark-local: Run benchmark e2e on local Kind cluster with inference-sim (no GPU required)
 benchmark-local:
+	@kind get clusters 2>/dev/null | grep -q $(KIND_CLUSTER_NAME) || \
+		{ echo "ERROR: Kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make dev-deploy' first."; exit 1; }
+	@docker exec $(KIND_CLUSTER_NAME)-control-plane crictl images 2>/dev/null | grep -q batch-gateway-apiserver || \
+		{ echo "ERROR: batch-gateway images not loaded in Kind. Run 'make dev-deploy' first."; exit 1; }
 	@echo "=== Benchmark local e2e (MODE=sim, scenario $(BENCHMARK_SCENARIO)) ==="
 	@echo "Step 1/4: Setting up infrastructure..."
 	@MODE=sim KUBE_CONTEXT=$(BENCHMARK_CONTEXT) SCENARIO=$(BENCHMARK_SCENARIO) BG_IMAGE_TAG=0.0.1 BG_PULL_POLICY=IfNotPresent bash benchmarks/setup.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm dev-deploy dev-clean dev-rm-cluster pre-commit
+.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm dev-deploy dev-clean dev-rm-cluster pre-commit benchmark-local benchmark-local-teardown
 
 SHELL := /usr/bin/env bash
 
@@ -346,6 +346,27 @@ dev-rm-cluster:
 	@echo "Deleting kind cluster 'batch-gateway-dev'..."
 	@kind delete cluster --name batch-gateway-dev || echo "Cluster not found or already deleted"
 	@echo "✅ Kind cluster deleted"
+
+BENCHMARK_CONTEXT ?= kind-$(KIND_CLUSTER_NAME)
+BENCHMARK_SCENARIO ?= 3
+BENCHMARK_RESULTS_DIR ?= benchmarks/results/local-run
+
+## benchmark-local: Run benchmark e2e on local Kind cluster with inference-sim (no GPU required)
+benchmark-local:
+	@echo "=== Benchmark local e2e (MODE=sim, scenario $(BENCHMARK_SCENARIO)) ==="
+	@echo "Step 1/4: Setting up infrastructure..."
+	@MODE=sim KUBE_CONTEXT=$(BENCHMARK_CONTEXT) SCENARIO=$(BENCHMARK_SCENARIO) BG_IMAGE_TAG=0.0.1 BG_PULL_POLICY=IfNotPresent bash benchmarks/setup.sh
+	@echo "Step 2/4: Generating prompts..."
+	@python3 benchmarks/generate_prompts.py --num-requests 50 --isl-distribution fixed --isl-mean 256 --model sim-model --multi-job --output-dir $(BENCHMARK_RESULTS_DIR)
+	@echo "Step 3/4: Running benchmark..."
+	@python3 benchmarks/benchmark.py --context $(BENCHMARK_CONTEXT) --scenarios $(BENCHMARK_SCENARIO) --model sim-model --batch-size 50 --num-jobs 1 --results-dir $(BENCHMARK_RESULTS_DIR)
+	@echo "Step 4/4: Done!"
+	@echo "Report: $(BENCHMARK_RESULTS_DIR)/report.html"
+	@echo "Metadata: $(BENCHMARK_RESULTS_DIR)/run-metadata.json"
+
+## benchmark-local-teardown: Teardown local benchmark environment
+benchmark-local-teardown:
+	@KUBE_CONTEXT=$(BENCHMARK_CONTEXT) SCENARIO=$(BENCHMARK_SCENARIO) bash benchmarks/teardown.sh
 
 ## test-e2e: Run E2E tests against a live API server (requires TEST_BASE_URL or dev-deploy NodePort services)
 ##           Use TEST_RUN to filter tests, e.g.: make test-e2e TEST_RUN=TestE2E/Batches/Cancel/InProgress

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -97,13 +97,64 @@ KUBE_CONTEXT=my-context SCENARIO=all ./benchmarks/teardown.sh
 
 ## Local Testing (Kind + inference-sim)
 
-The full pipeline can be validated locally without a GPU using [`llm-d-inference-sim`](https://github.com/llm-d/llm-d-inference-sim):
+The full pipeline can be validated locally without a GPU using [`llm-d-inference-sim`](https://github.com/llm-d/llm-d-inference-sim). This deploys inference-sim (a synthetic vLLM-compatible server), Redis, PostgreSQL, and batch-gateway into a local Kind cluster.
+
+### Prerequisites
+
+1. A Kind cluster with batch-gateway images pre-loaded:
 
 ```bash
-make dev-deploy  # Deploys Kind cluster with inference-sim
+make dev-deploy
 ```
 
-The simulator supports configurable TTFT, inter-token latency, and 429 rate-limiting injection. Metrics won't reflect real GPU performance, but orchestration, metric collection, and report generation can be validated end-to-end.
+This creates the Kind cluster, builds batch-gateway images, and loads them into the cluster. Alternatively, create a cluster manually (`kind create cluster`) and load images with `kind load docker-image`.
+
+### Running
+
+```bash
+make benchmark-local
+```
+
+This runs the full pipeline end-to-end:
+1. Deploys infrastructure (`setup.sh` with `MODE=sim`) — Redis, PostgreSQL, inference-sim, batch-gateway
+2. Generates prompts (`generate_prompts.py` with fixed ISL for fast local runs)
+3. Runs the benchmark (`benchmark.py`)
+4. Produces a report and metadata JSON in `benchmarks/results/latest/`
+
+Expected output:
+
+```
+=== Benchmark local e2e (MODE=sim, scenario 2) ===
+Step 1/4: Setting up infrastructure...
+Step 2/4: Generating prompts...
+Step 3/4: Running benchmark...
+Step 4/4: Done!
+Report: benchmarks/results/latest/report.html
+Metadata: benchmarks/results/latest/run-metadata.json
+```
+
+### Cleanup
+
+```bash
+make benchmark-local-teardown
+```
+
+This tears down the benchmark namespace while leaving the Kind cluster intact.
+
+### Configuration
+
+The simulator behaviour is controlled via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MODE` | `gpu` | Set to `sim` to use inference-sim (automatic in `make benchmark-local`) |
+| `SIM_IMAGE` | `ghcr.io/llm-d/llm-d-inference-sim:latest` | Inference-sim container image |
+| `SIM_TTFT` | `50ms` | Simulated time-to-first-token |
+| `SIM_ITL` | `20ms` | Simulated inter-token latency |
+
+Metrics from sim mode won't reflect real GPU performance, but orchestration, metric collection, and report generation can be validated end-to-end.
+
+> **Note:** Batch-gateway images must be built and loaded into Kind before running. If you see `ImagePullBackOff` errors, run `make dev-deploy` to rebuild and reload images.
 
 ## Traffic Pattern
 
@@ -188,6 +239,7 @@ Compare TTFT p99 during burst phases across scenarios:
 | `LLM_D_TAG` | No | `v0.7.0` | Git tag for llm-d guide values (used in OCI mode) |
 | `NAMESPACE` | No | `batch-bench-s${SCENARIO}` | Override namespace |
 | `MODEL` | No | `Qwen/Qwen3-8B` | Model to serve |
+| `MODEL_REVISION` | No | — | HuggingFace model revision/commit-sha to pin for reproducibility |
 | `GUIDE_NAME` | No | `optimized-baseline` | Inference pool name |
 | `BG_IMAGE_REPO` | No | — | Batch-gateway image repo override |
 | `BG_IMAGE_TAG` | No | — | Batch-gateway image tag override |

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -866,6 +866,7 @@ def main():
             "batch_gateway": "unknown",
             "router": "unknown",
             "vllm": "unknown",
+            "model_revision": os.environ.get("MODEL_REVISION", "latest"),
         },
         "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
     }

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -83,6 +83,9 @@ class PhaseMetrics:
     ttft_p50: float = 0.0
     ttft_p95: float = 0.0
     ttft_p99: float = 0.0
+    tpot_p50: float = 0.0
+    tpot_p95: float = 0.0
+    tpot_p99: float = 0.0
     itl_p50: float = 0.0
     itl_p95: float = 0.0
     itl_p99: float = 0.0
@@ -616,7 +619,9 @@ def generate_html_report(cfg, results):
                 <tr><td><strong>Batch</strong></td>
                     <td>{cfg.num_jobs} jobs x {cfg.batch_size} requests</td></tr>
                 <tr><td><strong>Prompts</strong></td>
-                    <td>{cfg.prompt_tokens} tokens, {cfg.num_system_prompts} system prompts</td></tr>
+                    <td>{cfg.prompt_tokens} tokens ISL, {cfg.num_system_prompts} system prompts</td></tr>
+                <tr><td><strong>Metrics</strong></td>
+                    <td>TTFT, TPOT, ITL, request latency (p50/p95/p99)</td></tr>
                 <tr><td><strong>Scenarios</strong></td>
                     <td>{', '.join(f's{r.scenario} ({r.name})' for r in results)}</td></tr>
             </table>
@@ -855,6 +860,8 @@ def main():
             "prompt_tokens": cfg.prompt_tokens,
             "num_system_prompts": cfg.num_system_prompts,
         },
+        "metrics_collected": ["ttft", "tpot", "itl", "req_latency"],
+        "percentiles": ["p50", "p95", "p99"],
         "versions": {
             "batch_gateway": "unknown",
             "router": "unknown",

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -1,33 +1,33 @@
 #!/usr/bin/env python3
 """
-Generate JSONL batch input files with Faker-based prompts and system-prompt diversity.
+Generate JSONL batch input files with configurable ISL/OSL distributions
+and system-prompt diversity.
 
 Produces OpenAI-compatible batch input files with configurable:
-- Number of requests
+- Input Sequence Length (ISL) distribution (lognormal, normal, uniform, fixed)
+- Output Sequence Length (OSL) distribution (lognormal, normal, uniform, fixed)
 - Number of distinct system prompts (for prefix-cache evaluation)
-- Prompt token length
+- System prompt length (tokens)
 - Model name
 
 Usage:
     python3 benchmarks/generate_prompts.py \
         --num-requests 1000 \
-        --num-system-prompts 5 \
-        --prompt-tokens 256 \
+        --num-system-prompts 32 \
         --model "Qwen/Qwen3-8B" \
         --output job-a.jsonl
 
     # Generate all 3 benchmark jobs at once:
     python3 benchmarks/generate_prompts.py \
         --num-requests 1000 \
-        --num-system-prompts 5 \
-        --prompt-tokens 256 \
-        --model "Qwen/Qwen3-8B" \
         --multi-job \
         --output-dir benchmarks/results/
 """
 
 import argparse
 import json
+import math
+import random
 import sys
 from pathlib import Path
 
@@ -41,7 +41,6 @@ except ImportError:
 
 
 # System prompt templates — meaningfully different personas to test prefix-cache grouping.
-# Each shares a common structure but different content, so FNV-32a hashes are distinct.
 SYSTEM_PROMPT_TEMPLATES = [
     (
         "You are a senior software engineer specializing in {lang}. "
@@ -76,7 +75,6 @@ SYSTEM_PROMPT_TEMPLATES = [
     ),
 ]
 
-# Fill-in values for templates
 TEMPLATE_FILLS = {
     "lang": ["Go", "Rust", "Python", "TypeScript", "Java"],
     "field": ["machine learning", "natural language processing", "time series analysis",
@@ -88,29 +86,56 @@ TEMPLATE_FILLS = {
 }
 
 
-def generate_system_prompts(num_prompts: int, seed: int) -> list[str]:
-    """Generate distinct system prompts by filling templates."""
+def sample_from_distribution(rng, distribution, mean, stdev, min_val=1):
+    """Sample a positive integer from the specified distribution."""
+    if distribution == "fixed":
+        return int(mean)
+    elif distribution == "lognormal":
+        # Convert desired mean/stdev to lognormal mu/sigma parameters
+        variance = stdev ** 2
+        mu = math.log(mean ** 2 / math.sqrt(variance + mean ** 2))
+        sigma = math.sqrt(math.log(1 + variance / mean ** 2))
+        val = rng.lognormvariate(mu, sigma)
+    elif distribution == "normal":
+        val = rng.gauss(mean, stdev)
+    elif distribution == "uniform":
+        low = max(min_val, mean - stdev)
+        high = mean + stdev
+        val = rng.uniform(low, high)
+    else:
+        val = mean
+
+    return max(min_val, int(round(val)))
+
+
+def generate_system_prompts(num_prompts: int, seed: int, target_tokens: int) -> list[str]:
+    """Generate distinct system prompts of approximately target_tokens length."""
     fake = Faker()
     fake.seed_instance(seed)
+
+    target_chars = target_tokens * 4
 
     prompts = []
     for i in range(num_prompts):
         template = SYSTEM_PROMPT_TEMPLATES[i % len(SYSTEM_PROMPT_TEMPLATES)]
-        # Find the placeholder key in this template
         for key, values in TEMPLATE_FILLS.items():
             if "{" + key + "}" in template:
                 fill_value = values[i % len(values)]
                 template = template.replace("{" + key + "}", fill_value)
                 break
-        prompts.append(template)
+
+        # Extend to target length if needed
+        if len(template) < target_chars:
+            padding = fake.text(max_nb_chars=max(target_chars - len(template), 100))
+            template = template + " " + padding
+
+        prompts.append(template[:target_chars].strip())
 
     return prompts
 
 
 def generate_user_prompt(fake: Faker, target_chars: int) -> str:
     """Generate a user prompt of approximately target_chars length."""
-    # faker.text() generates lorem-ipsum-like paragraphs
-    # We may need multiple calls to reach the target length
     text = ""
     while len(text) < target_chars:
         text += " " + fake.text(max_nb_chars=min(target_chars - len(text) + 50, 1000))
@@ -120,24 +145,36 @@ def generate_user_prompt(fake: Faker, target_chars: int) -> str:
 def generate_jsonl(
     num_requests: int,
     num_system_prompts: int,
-    prompt_tokens: int,
+    system_prompt_tokens: int,
     model: str,
     seed: int,
     output_path: Path,
+    isl_distribution: str,
+    isl_mean: float,
+    isl_stdev: float,
+    osl_distribution: str,
+    osl_mean: float,
+    osl_stdev: float,
     id_prefix: str = "req",
 ):
-    """Generate a JSONL batch input file."""
+    """Generate a JSONL batch input file with ISL/OSL distributions."""
     fake = Faker()
     fake.seed_instance(seed)
+    rng = random.Random(seed)
 
-    system_prompts = generate_system_prompts(num_system_prompts, seed)
-    # Approximate: 1 token ≈ 4 characters
-    target_chars = prompt_tokens * 4
+    system_prompts = generate_system_prompts(num_system_prompts, seed, system_prompt_tokens)
 
     with open(output_path, "w") as f:
         for i in range(num_requests):
             system_prompt = system_prompts[i % num_system_prompts]
+
+            # Sample ISL for this request (user prompt portion)
+            isl_tokens = sample_from_distribution(rng, isl_distribution, isl_mean, isl_stdev, min_val=16)
+            target_chars = isl_tokens * 4
             user_prompt = generate_user_prompt(fake, target_chars)
+
+            # Sample OSL (max_tokens) for this request
+            osl_tokens = sample_from_distribution(rng, osl_distribution, osl_mean, osl_stdev, min_val=1)
 
             line = {
                 "custom_id": f"{id_prefix}-{i:04d}",
@@ -145,6 +182,7 @@ def generate_jsonl(
                 "url": "/v1/chat/completions",
                 "body": {
                     "model": model,
+                    "max_tokens": osl_tokens,
                     "messages": [
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": user_prompt},
@@ -157,6 +195,8 @@ def generate_jsonl(
                 print(f"  Generated {i + 1}/{num_requests}", file=sys.stderr)
 
     print(f"Generated {num_requests} requests -> {output_path}", file=sys.stderr)
+    print(f"  ISL: {isl_distribution} (mean={isl_mean}, stdev={isl_stdev})", file=sys.stderr)
+    print(f"  OSL: {osl_distribution} (mean={osl_mean}, stdev={osl_stdev})", file=sys.stderr)
 
 
 def load_profile():
@@ -171,6 +211,8 @@ def load_profile():
 def main():
     profile = load_profile()
     prompt_cfg = profile.get("prompt", {})
+    isl_cfg = prompt_cfg.get("isl", {})
+    osl_cfg = prompt_cfg.get("osl", {})
 
     parser = argparse.ArgumentParser(
         description="Generate JSONL batch input files for benchmarking"
@@ -179,17 +221,46 @@ def main():
                         default=prompt_cfg.get("num_requests", 1000),
                         help="Number of requests per file (default: 1000)")
     parser.add_argument("--num-system-prompts", type=int,
-                        default=prompt_cfg.get("num_system_prompts", 5),
-                        help="Number of distinct system prompts (default: 5)")
-    parser.add_argument("--prompt-tokens", type=int,
-                        default=prompt_cfg.get("prompt_tokens", 256),
-                        help="Approximate input tokens per user prompt (default: 256)")
+                        default=prompt_cfg.get("num_system_prompts", 32),
+                        help="Number of distinct system prompts (default: 32)")
+    parser.add_argument("--system-prompt-tokens", type=int,
+                        default=prompt_cfg.get("system_prompt_tokens", 2048),
+                        help="Approximate tokens per system prompt (default: 2048)")
     parser.add_argument("--model",
                         default=prompt_cfg.get("model", "Qwen/Qwen3-8B"),
                         help="Model name for requests (default: Qwen/Qwen3-8B)")
     parser.add_argument("--seed", type=int,
                         default=prompt_cfg.get("seed", 42),
                         help="Random seed for reproducibility (default: 42)")
+
+    # ISL (Input Sequence Length) distribution
+    parser.add_argument("--isl-distribution",
+                        choices=["fixed", "lognormal", "normal", "uniform"],
+                        default=isl_cfg.get("distribution", "lognormal"),
+                        help="ISL distribution type (default: lognormal)")
+    parser.add_argument("--isl-mean", type=float,
+                        default=isl_cfg.get("mean", 1500),
+                        help="ISL distribution mean in tokens (default: 1500)")
+    parser.add_argument("--isl-stdev", type=float,
+                        default=isl_cfg.get("stdev", 1200),
+                        help="ISL distribution stdev in tokens (default: 1200)")
+
+    # OSL (Output Sequence Length) distribution
+    parser.add_argument("--osl-distribution",
+                        choices=["fixed", "lognormal", "normal", "uniform"],
+                        default=osl_cfg.get("distribution", "lognormal"),
+                        help="OSL distribution type (default: lognormal)")
+    parser.add_argument("--osl-mean", type=float,
+                        default=osl_cfg.get("mean", 500),
+                        help="OSL distribution mean in tokens (default: 500)")
+    parser.add_argument("--osl-stdev", type=float,
+                        default=osl_cfg.get("stdev", 400),
+                        help="OSL distribution stdev in tokens (default: 400)")
+
+    # Legacy compat
+    parser.add_argument("--prompt-tokens", type=int, default=None,
+                        help="(Legacy) Fixed ISL — equivalent to --isl-distribution=fixed --isl-mean=N")
+
     parser.add_argument("--output", type=Path, default=None,
                         help="Output JSONL file path (single-job mode)")
     parser.add_argument("--multi-job", action="store_true",
@@ -199,8 +270,13 @@ def main():
 
     args = parser.parse_args()
 
+    # Legacy --prompt-tokens overrides ISL to fixed mode
+    if args.prompt_tokens is not None:
+        args.isl_distribution = "fixed"
+        args.isl_mean = args.prompt_tokens
+        args.isl_stdev = 0
+
     if args.multi_job:
-        # Generate 3 jobs with different characteristics for SLO-deadline ordering demo
         args.output_dir.mkdir(parents=True, exist_ok=True)
         jobs = [
             ("job-a", "tight SLO (30m)"),
@@ -213,10 +289,16 @@ def main():
             generate_jsonl(
                 num_requests=args.num_requests,
                 num_system_prompts=args.num_system_prompts,
-                prompt_tokens=args.prompt_tokens,
+                system_prompt_tokens=args.system_prompt_tokens,
                 model=args.model,
-                seed=args.seed + i,  # Different seed per job for variety
+                seed=args.seed + i,
                 output_path=output_path,
+                isl_distribution=args.isl_distribution,
+                isl_mean=args.isl_mean,
+                isl_stdev=args.isl_stdev,
+                osl_distribution=args.osl_distribution,
+                osl_mean=args.osl_mean,
+                osl_stdev=args.osl_stdev,
                 id_prefix=name,
             )
         print(f"\nAll jobs generated in {args.output_dir}/", file=sys.stderr)
@@ -228,10 +310,16 @@ def main():
         generate_jsonl(
             num_requests=args.num_requests,
             num_system_prompts=args.num_system_prompts,
-            prompt_tokens=args.prompt_tokens,
+            system_prompt_tokens=args.system_prompt_tokens,
             model=args.model,
             seed=args.seed,
             output_path=args.output,
+            isl_distribution=args.isl_distribution,
+            isl_mean=args.isl_mean,
+            isl_stdev=args.isl_stdev,
+            osl_distribution=args.osl_distribution,
+            osl_mean=args.osl_mean,
+            osl_stdev=args.osl_stdev,
         )
 
 

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -86,7 +86,7 @@ TEMPLATE_FILLS = {
 }
 
 
-def sample_from_distribution(rng, distribution, mean, stdev, min_val=1):
+def sample_from_distribution(rng, distribution, mean, stdev, min_val=1, max_val=None):
     """Sample a positive integer from the specified distribution."""
     if distribution == "fixed":
         return int(mean)
@@ -105,7 +105,10 @@ def sample_from_distribution(rng, distribution, mean, stdev, min_val=1):
     else:
         val = mean
 
-    return max(min_val, int(round(val)))
+    val = max(min_val, int(round(val)))
+    if max_val is not None:
+        val = min(val, max_val)
+    return val
 
 
 def generate_system_prompts(num_prompts: int, seed: int, target_tokens: int) -> list[str]:
@@ -129,7 +132,9 @@ def generate_system_prompts(num_prompts: int, seed: int, target_tokens: int) -> 
             padding = fake.text(max_nb_chars=max(target_chars - len(template), 100))
             template = template + " " + padding
 
-        prompts.append(template[:target_chars].strip())
+        # Inject unique prefix to ensure distinct prefix-cache groups
+        prompt_text = f"[Persona {i:03d}] {template}"
+        prompts.append(prompt_text[:target_chars].strip())
 
     return prompts
 
@@ -152,9 +157,11 @@ def generate_jsonl(
     isl_distribution: str,
     isl_mean: float,
     isl_stdev: float,
+    isl_max: int,
     osl_distribution: str,
     osl_mean: float,
     osl_stdev: float,
+    osl_max: int,
     id_prefix: str = "req",
 ):
     """Generate a JSONL batch input file with ISL/OSL distributions."""
@@ -169,12 +176,12 @@ def generate_jsonl(
             system_prompt = system_prompts[i % num_system_prompts]
 
             # Sample ISL for this request (user prompt portion)
-            isl_tokens = sample_from_distribution(rng, isl_distribution, isl_mean, isl_stdev, min_val=16)
+            isl_tokens = sample_from_distribution(rng, isl_distribution, isl_mean, isl_stdev, min_val=16, max_val=isl_max)
             target_chars = isl_tokens * 4
             user_prompt = generate_user_prompt(fake, target_chars)
 
             # Sample OSL (max_tokens) for this request
-            osl_tokens = sample_from_distribution(rng, osl_distribution, osl_mean, osl_stdev, min_val=1)
+            osl_tokens = sample_from_distribution(rng, osl_distribution, osl_mean, osl_stdev, min_val=1, max_val=osl_max)
 
             line = {
                 "custom_id": f"{id_prefix}-{i:04d}",
@@ -244,6 +251,9 @@ def main():
     parser.add_argument("--isl-stdev", type=float,
                         default=isl_cfg.get("stdev", 1200),
                         help="ISL distribution stdev in tokens (default: 1200)")
+    parser.add_argument("--isl-max", type=int,
+                        default=isl_cfg.get("max", 4096),
+                        help="ISL maximum (clamp to model context length, default: 4096)")
 
     # OSL (Output Sequence Length) distribution
     parser.add_argument("--osl-distribution",
@@ -256,6 +266,9 @@ def main():
     parser.add_argument("--osl-stdev", type=float,
                         default=osl_cfg.get("stdev", 400),
                         help="OSL distribution stdev in tokens (default: 400)")
+    parser.add_argument("--osl-max", type=int,
+                        default=osl_cfg.get("max", 2048),
+                        help="OSL maximum (clamp output length, default: 2048)")
 
     # Legacy compat
     parser.add_argument("--prompt-tokens", type=int, default=None,
@@ -296,9 +309,11 @@ def main():
                 isl_distribution=args.isl_distribution,
                 isl_mean=args.isl_mean,
                 isl_stdev=args.isl_stdev,
+                isl_max=args.isl_max,
                 osl_distribution=args.osl_distribution,
                 osl_mean=args.osl_mean,
                 osl_stdev=args.osl_stdev,
+                osl_max=args.osl_max,
                 id_prefix=name,
             )
         print(f"\nAll jobs generated in {args.output_dir}/", file=sys.stderr)
@@ -317,9 +332,11 @@ def main():
             isl_distribution=args.isl_distribution,
             isl_mean=args.isl_mean,
             isl_stdev=args.isl_stdev,
+            isl_max=args.isl_max,
             osl_distribution=args.osl_distribution,
             osl_mean=args.osl_mean,
             osl_stdev=args.osl_stdev,
+            osl_max=args.osl_max,
         )
 
 

--- a/benchmarks/profiles/default.yaml
+++ b/benchmarks/profiles/default.yaml
@@ -1,8 +1,16 @@
 prompt:
   num_requests: 1000
-  num_system_prompts: 5
-  prompt_tokens: 256
+  num_system_prompts: 32
+  system_prompt_tokens: 2048
   seed: 42
+  isl:
+    distribution: lognormal
+    mean: 1500
+    stdev: 1200
+  osl:
+    distribution: lognormal
+    mean: 500
+    stdev: 400
 benchmark:
   burst_rate: 15
   idle_rate: 1

--- a/benchmarks/profiles/default.yaml
+++ b/benchmarks/profiles/default.yaml
@@ -7,10 +7,12 @@ prompt:
     distribution: lognormal
     mean: 1500
     stdev: 1200
+    max: 4096
   osl:
     distribution: lognormal
     mean: 500
     stdev: 400
+    max: 2048
 benchmark:
   burst_rate: 15
   idle_rate: 1

--- a/benchmarks/setup.sh
+++ b/benchmarks/setup.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 #   SCENARIO           — scenario number (0-5)
 #
 # Optional:
+#   MODE               — "sim" to use inference-sim instead of real vLLM (default: gpu)
 #   LLM_D_REPO         — path to llm-d checkout (overrides downloading from LLM_D_TAG)
 #   ROUTER_REPO        — path to llm-d-router checkout (overrides OCI chart)
 #   ROUTER_CHART_VERSION — OCI chart version for llm-d-router (default: 0.9.2)
@@ -19,6 +20,9 @@ set -euo pipefail
 #   NAMESPACE          — override auto-generated namespace (default: batch-bench-s${SCENARIO})
 #   MODEL              — model to serve (default: Qwen/Qwen3-8B)
 #   GUIDE_NAME         — inference pool name (default: optimized-baseline)
+#   SIM_IMAGE          — inference-sim container image (default: ghcr.io/llm-d/llm-d-inference-sim:latest)
+#   SIM_TTFT           — simulated time-to-first-token (default: 50ms)
+#   SIM_ITL            — simulated inter-token-latency (default: 20ms)
 #   BG_IMAGE_REPO      — batch-gateway image repo override
 #   BG_IMAGE_TAG       — batch-gateway image tag override
 
@@ -26,11 +30,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Defaults
-MODEL="${MODEL:-Qwen/Qwen3-8B}"
+MODE="${MODE:-gpu}"
+if [ "${MODE}" = "sim" ]; then
+    MODEL="${MODEL:-sim-model}"
+else
+    MODEL="${MODEL:-Qwen/Qwen3-8B}"
+fi
 GUIDE_NAME="${GUIDE_NAME:-optimized-baseline}"
 NAMESPACE="${NAMESPACE:-batch-bench-s${SCENARIO}}"
 ROUTER_CHART_VERSION="${ROUTER_CHART_VERSION:-0.9.2}"
 LLM_D_TAG="${LLM_D_TAG:-v0.7.0}"
+SIM_IMAGE="${SIM_IMAGE:-ghcr.io/llm-d/llm-d-inference-sim:latest}"
+SIM_TTFT="${SIM_TTFT:-50ms}"
+SIM_ITL="${SIM_ITL:-20ms}"
 
 # Validate required vars
 for var in KUBE_CONTEXT SCENARIO; do
@@ -108,51 +120,114 @@ spec:
 EOF
 ${K} -n "${NAMESPACE}" apply -f "${SCRIPT_DIR}/manifests/results-pvc.yaml"
 
-# --- llm-d Router (EPP) ---
-log "Installing llm-d Router (${GUIDE_NAME})"
-if [ -n "${ROUTER_REPO:-}" ] && [ -n "${LLM_D_REPO:-}" ]; then
-    # Local repo mode (development override)
-    log "  Using local repos: ROUTER_REPO=${ROUTER_REPO}, LLM_D_REPO=${LLM_D_REPO}"
-    if [ ! -f "${ROUTER_REPO}/config/charts/llm-d-router-gateway/charts/router-0.0.0.tgz" ]; then
-        (cd "${ROUTER_REPO}/config/charts/llm-d-router-gateway" && helm dependency build >/dev/null 2>&1)
-    fi
-    ${H} install "${GUIDE_NAME}" \
-        "${ROUTER_REPO}/config/charts/llm-d-router-gateway/" \
-        -n "${NAMESPACE}" \
-        -f "${LLM_D_REPO}/guides/recipes/router/base.values.yaml" \
-        -f "${LLM_D_REPO}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" \
-        -f "${LLM_D_REPO}/guides/recipes/router/features/monitoring.values.yaml" \
-        --set provider.name=istio \
-        --set httpRoute.create=true \
-        --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
+# --- Inference backend ---
+if [ "${MODE}" = "sim" ]; then
+    # Sim mode: deploy inference-sim (no GPU, no router, no Istio)
+    log "Deploying inference-sim (MODE=sim, model: ${MODEL})"
+    ${K} -n "${NAMESPACE}" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inference-sim
+  labels:
+    llm-d.ai/role: decode
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      llm-d.ai/role: decode
+  template:
+    metadata:
+      labels:
+        llm-d.ai/role: decode
+    spec:
+      containers:
+        - name: vllm-sim
+          image: ${SIM_IMAGE}
+          args:
+            - --model
+            - "${MODEL}"
+            - --port
+            - "8000"
+            - --time-to-first-token=${SIM_TTFT}
+            - --inter-token-latency=${SIM_ITL}
+          ports:
+            - containerPort: 8000
+              name: modelserver
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inference-sim
+spec:
+  selector:
+    llm-d.ai/role: decode
+  ports:
+    - port: 8000
+      targetPort: 8000
+      name: http
+EOF
 else
-    # OCI mode (default — reproducible, pinned versions)
-    log "  Using OCI chart: ghcr.io/llm-d/llm-d-router-gateway:${ROUTER_CHART_VERSION}"
-    log "  Using llm-d guide values from tag: ${LLM_D_TAG}"
+    # GPU mode: deploy real vLLM + llm-d Router + Istio Gateway
 
-    # Download guide values from pinned llm-d tag
-    LLM_D_VALUES_DIR=$(mktemp -d)
-    trap "rm -rf ${LLM_D_VALUES_DIR}" EXIT
-    local_base="https://raw.githubusercontent.com/llm-d/llm-d/${LLM_D_TAG}"
-    curl -sL "${local_base}/guides/recipes/router/base.values.yaml" -o "${LLM_D_VALUES_DIR}/base.values.yaml"
-    curl -sL "${local_base}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" -o "${LLM_D_VALUES_DIR}/guide.values.yaml"
-    curl -sL "${local_base}/guides/recipes/router/features/monitoring.values.yaml" -o "${LLM_D_VALUES_DIR}/monitoring.values.yaml"
+    # --- llm-d Router (EPP) ---
+    log "Installing llm-d Router (${GUIDE_NAME})"
+    if [ -n "${ROUTER_REPO:-}" ] && [ -n "${LLM_D_REPO:-}" ]; then
+        # Local repo mode (development override)
+        log "  Using local repos: ROUTER_REPO=${ROUTER_REPO}, LLM_D_REPO=${LLM_D_REPO}"
+        if [ ! -f "${ROUTER_REPO}/config/charts/llm-d-router-gateway/charts/router-0.0.0.tgz" ]; then
+            (cd "${ROUTER_REPO}/config/charts/llm-d-router-gateway" && helm dependency build >/dev/null 2>&1)
+        fi
+        ${H} install "${GUIDE_NAME}" \
+            "${ROUTER_REPO}/config/charts/llm-d-router-gateway/" \
+            -n "${NAMESPACE}" \
+            -f "${LLM_D_REPO}/guides/recipes/router/base.values.yaml" \
+            -f "${LLM_D_REPO}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" \
+            -f "${LLM_D_REPO}/guides/recipes/router/features/monitoring.values.yaml" \
+            --set provider.name=istio \
+            --set httpRoute.create=true \
+            --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
+    else
+        # OCI mode (default — reproducible, pinned versions)
+        log "  Using OCI chart: ghcr.io/llm-d/llm-d-router-gateway:${ROUTER_CHART_VERSION}"
+        log "  Using llm-d guide values from tag: ${LLM_D_TAG}"
 
-    ${H} install "${GUIDE_NAME}" \
-        oci://ghcr.io/llm-d/llm-d-router-gateway \
-        --version "${ROUTER_CHART_VERSION}" \
-        -n "${NAMESPACE}" \
-        -f "${LLM_D_VALUES_DIR}/base.values.yaml" \
-        -f "${LLM_D_VALUES_DIR}/guide.values.yaml" \
-        -f "${LLM_D_VALUES_DIR}/monitoring.values.yaml" \
-        --set provider.name=istio \
-        --set httpRoute.create=true \
-        --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
-fi
+        # Download guide values from pinned llm-d tag
+        LLM_D_VALUES_DIR=$(mktemp -d)
+        trap "rm -rf ${LLM_D_VALUES_DIR}" EXIT
+        local_base="https://raw.githubusercontent.com/llm-d/llm-d/${LLM_D_TAG}"
+        curl -sL "${local_base}/guides/recipes/router/base.values.yaml" -o "${LLM_D_VALUES_DIR}/base.values.yaml"
+        curl -sL "${local_base}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" -o "${LLM_D_VALUES_DIR}/guide.values.yaml"
+        curl -sL "${local_base}/guides/recipes/router/features/monitoring.values.yaml" -o "${LLM_D_VALUES_DIR}/monitoring.values.yaml"
 
-# --- Istio Gateway ---
-log "Creating Istio Gateway"
-${K} -n "${NAMESPACE}" apply -f - <<EOF
+        ${H} install "${GUIDE_NAME}" \
+            oci://ghcr.io/llm-d/llm-d-router-gateway \
+            --version "${ROUTER_CHART_VERSION}" \
+            -n "${NAMESPACE}" \
+            -f "${LLM_D_VALUES_DIR}/base.values.yaml" \
+            -f "${LLM_D_VALUES_DIR}/guide.values.yaml" \
+            -f "${LLM_D_VALUES_DIR}/monitoring.values.yaml" \
+            --set provider.name=istio \
+            --set httpRoute.create=true \
+            --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
+    fi
+
+    # --- Istio Gateway ---
+    log "Creating Istio Gateway"
+    ${K} -n "${NAMESPACE}" apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -170,9 +245,21 @@ spec:
         from: Same
 EOF
 
-# --- vLLM ---
-log "Deploying vLLM (${MODEL})"
-${K} -n "${NAMESPACE}" apply -k "${SCRIPT_DIR}/manifests/vllm/"
+    # --- vLLM ---
+    log "Deploying vLLM (${MODEL})"
+    ${K} -n "${NAMESPACE}" apply -k "${SCRIPT_DIR}/manifests/vllm/"
+fi
+
+# --- Wait for inference backend ---
+if [ "${MODE}" = "sim" ]; then
+    log "Waiting for inference-sim to be ready..."
+    ${K} -n "${NAMESPACE}" wait pod -l llm-d.ai/role=decode \
+        --for=condition=Ready --timeout=120s >/dev/null
+else
+    log "Waiting for vLLM to be ready..."
+    ${K} -n "${NAMESPACE}" wait pod -l llm-d.ai/role=decode \
+        --for=condition=Ready --timeout=300s >/dev/null
+fi
 
 # --- Batch Gateway (scenarios 2-5 only) ---
 VALUES_FILE=$(values_file_for_scenario)
@@ -189,6 +276,23 @@ if [ -n "${VALUES_FILE}" ]; then
         BG_EXTRA_ARGS+=(
             --set-string "apiserver.image.tag=${BG_IMAGE_TAG}"
             --set-string "processor.image.tag=${BG_IMAGE_TAG}"
+        )
+    fi
+    if [ -n "${BG_PULL_POLICY:-}" ]; then
+        BG_EXTRA_ARGS+=(
+            --set "apiserver.image.pullPolicy=${BG_PULL_POLICY}"
+            --set "processor.image.pullPolicy=${BG_PULL_POLICY}"
+        )
+    fi
+
+    # In sim mode, route processor directly to inference-sim service
+    if [ "${MODE}" = "sim" ]; then
+        BG_EXTRA_ARGS+=(
+            --set "processor.config.modelGateways.${MODEL}.url=http://inference-sim.${NAMESPACE}.svc.cluster.local:8000"
+            --set "processor.config.modelGateways.${MODEL}.requestTimeout=5m"
+            --set "processor.config.modelGateways.${MODEL}.maxRetries=3"
+            --set "processor.config.modelGateways.${MODEL}.initialBackoff=1s"
+            --set "processor.config.modelGateways.${MODEL}.maxBackoff=60s"
         )
     fi
 
@@ -220,11 +324,6 @@ if [ "${SCENARIO}" = "5" ]; then
     log "ERROR: Scenario 5 (async) is blocked on async-processor integration"
     log "  Skipping async-processor deployment"
 fi
-
-# --- Wait for readiness ---
-log "Waiting for vLLM to be ready..."
-${K} -n "${NAMESPACE}" wait pod -l llm-d.ai/role=decode \
-    --for=condition=Ready --timeout=300s >/dev/null
 
 if [ -n "${VALUES_FILE}" ]; then
     ${K} -n "${NAMESPACE}" rollout status deploy/batch-gateway-apiserver --timeout=60s >/dev/null

--- a/benchmarks/setup.sh
+++ b/benchmarks/setup.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 #   NAMESPACE          — override auto-generated namespace (default: batch-bench-s${SCENARIO})
 #   MODEL              — model to serve (default: Qwen/Qwen3-8B)
 #   GUIDE_NAME         — inference pool name (default: optimized-baseline)
+#   MODEL_REVISION     — HuggingFace model revision/commit-sha to pin (default: unset, uses latest)
 #   SIM_IMAGE          — inference-sim container image (default: ghcr.io/llm-d/llm-d-inference-sim:latest)
 #   SIM_TTFT           — simulated time-to-first-token (default: 50ms)
 #   SIM_ITL            — simulated inter-token-latency (default: 20ms)
@@ -248,6 +249,13 @@ EOF
     # --- vLLM ---
     log "Deploying vLLM (${MODEL})"
     ${K} -n "${NAMESPACE}" apply -k "${SCRIPT_DIR}/manifests/vllm/"
+
+    # Pin model revision if specified
+    if [ -n "${MODEL_REVISION:-}" ]; then
+        log "  Pinning model revision: ${MODEL_REVISION}"
+        ${K} -n "${NAMESPACE}" patch deploy/decode --type=json \
+            -p "[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/args/-\",\"value\":\"--revision=${MODEL_REVISION}\"}]" >/dev/null
+    fi
 fi
 
 # --- Wait for inference backend ---
@@ -285,14 +293,10 @@ if [ -n "${VALUES_FILE}" ]; then
         )
     fi
 
-    # In sim mode, route processor directly to inference-sim service
+    # In sim mode, replace all model gateways with a single entry pointing to inference-sim
     if [ "${MODE}" = "sim" ]; then
         BG_EXTRA_ARGS+=(
-            --set "processor.config.modelGateways.${MODEL}.url=http://inference-sim.${NAMESPACE}.svc.cluster.local:8000"
-            --set "processor.config.modelGateways.${MODEL}.requestTimeout=5m"
-            --set "processor.config.modelGateways.${MODEL}.maxRetries=3"
-            --set "processor.config.modelGateways.${MODEL}.initialBackoff=1s"
-            --set "processor.config.modelGateways.${MODEL}.maxBackoff=60s"
+            --set-json "processor.config.modelGateways={\"${MODEL}\":{\"url\":\"http://inference-sim.${NAMESPACE}.svc.cluster.local:8000\",\"requestTimeout\":\"5m\",\"maxRetries\":3,\"initialBackoff\":\"1s\",\"maxBackoff\":\"60s\"}}"
         )
     fi
 


### PR DESCRIPTION
## Summary

- Add `MODE=sim` to `setup.sh` — deploys inference-sim instead of real vLLM (no GPU needed, skips router/Istio)
- Replace fixed `--prompt-tokens` with configurable ISL/OSL distributions (lognormal, normal, uniform, fixed)
- Scale system prompt config to 32 prompts x 2048 tokens (matching llm-d ecosystem range)
- Add TPOT metric (p50/p95/p99) to PhaseMetrics and HTML report
- Add `make benchmark-local` / `make benchmark-local-teardown` Makefile targets

## Part of #491 (PR 1.5 of 4)

Enables full-pipeline validation on a local Kind cluster without CoreWeave access.

## Test plan

- [x] `bash -n setup.sh` — syntax valid
- [x] `python3 -m py_compile benchmark.py` — compiles
- [x] `python3 benchmarks/generate_prompts.py --help` — shows ISL/OSL flags
- [x] `make benchmark-local` — full e2e on Kind: setup, generate, benchmark, report
- [x] `run-metadata.json` written with correcrs and metrics list