### PR TITLE
fix: support Python 3.8 in generate_prompts.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ bin/
 .claude/
 .cursor/
 .codegraph/
+.venv/
+__pycache__/
+*.pyc
 benchmarks/results/*
 !benchmarks/results/.gitkeep

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """
 Generate JSONL batch input files with configurable ISL/OSL distributions
 and system-prompt diversity.


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to `generate_prompts.py` to fix `TypeError: 'type' object is not subscriptable` on Python 3.8 (caused by `list[str]` type hint)
- Add `.venv/`, `__pycache__/`, and `*.pyc` to `.gitignore`

## Test plan

- [x] `python3 benchmarks/generate_prompts.py --help` works on Python 3.8
- [x] `make benchmark-local` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)