### PR TITLE
fix: prevent temp file collision in concurrent fs storage uploads

### DIFF
--- a/internal/files_store/fs/client.go
+++ b/internal/files_store/fs/client.go
@@ -113,10 +113,20 @@ func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSiz
 	}
 
 	// Create temp file name within the target directory.
-	tmpName := filepath.Join(dir, fmt.Sprintf(".tmp-%d", time.Now().UnixNano()))
-	tmpFile, err := c.root.Create(tmpName)
-	if err != nil {
-		return nil, err
+	var tmpFile *os.File
+	var tmpName string
+	for range 3 {
+		tmpName = filepath.Join(dir, fmt.Sprintf(".tmp-%d", time.Now().UnixNano()))
+		tmpFile, err = c.root.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+	}
+	if tmpFile == nil {
+		return nil, fmt.Errorf("failed to create unique temp file in %s after retries", dir)
 	}
 	defer func() {
 		// Clean up on error.

--- a/internal/files_store/fs/client.go
+++ b/internal/files_store/fs/client.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -59,6 +60,8 @@ type Client struct {
 
 // Compile-time check that Client implements api.BatchFilesClient.
 var _ api.BatchFilesClient = (*Client)(nil)
+
+var tmpCounter atomic.Int64
 
 // New creates a new filesystem-based BatchFilesClient.
 func New(basePath string) (*Client, error) {
@@ -116,7 +119,7 @@ func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSiz
 	var tmpFile *os.File
 	var tmpName string
 	for range 3 {
-		tmpName = filepath.Join(dir, fmt.Sprintf(".tmp-%d", time.Now().UnixNano()))
+		tmpName = filepath.Join(dir, fmt.Sprintf(".tmp-%d-%d", time.Now().UnixNano(), tmpCounter.Add(1)))
 		tmpFile, err = c.root.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err == nil {
 			break

--- a/internal/files_store/fs/client_test.go
+++ b/internal/files_store/fs/client_test.go
@@ -20,10 +20,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -183,6 +185,50 @@ func TestStore(t *testing.T) {
 			t.Errorf("expected original content to be unchanged")
 		}
 	})
+}
+
+func TestStore_ConcurrentSameDir(t *testing.T) {
+	ctx := context.Background()
+	client := newTestClient(t)
+
+	const n = 10
+	errs := make([]error, n)
+	mds := make([]*api.BatchFileMetadata, n)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		go func() {
+			defer wg.Done()
+			content := []byte(fmt.Sprintf("content-%d", i))
+			mds[i], errs[i] = client.Store(ctx, fmt.Sprintf("file-%d.txt", i), testFolder, 1024, 0, bytes.NewReader(content))
+		}()
+	}
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("Store goroutine %d failed: %v", i, errs[i])
+		}
+	}
+
+	for i := range n {
+		reader, _, err := client.Retrieve(ctx, fmt.Sprintf("file-%d.txt", i), testFolder)
+		if err != nil {
+			t.Fatalf("failed to retrieve file-%d.txt: %v", i, err)
+		}
+		data, _ := io.ReadAll(reader)
+		if closer, ok := reader.(io.Closer); ok {
+			_ = closer.Close()
+		}
+		expected := fmt.Sprintf("content-%d", i)
+		if string(data) != expected {
+			t.Errorf("file-%d.txt: expected %q, got %q (data corruption from temp file collision)", i, expected, string(data))
+		}
+		if mds[i].Size != int64(len(expected)) {
+			t.Errorf("file-%d.txt: expected size %d, got %d", i, len(expected), mds[i].Size)
+		}
+	}
 }
 
 func TestRetrieve(t *testing.T) {


### PR DESCRIPTION
## Why is this PR needed?

`TestE2E/Batches/Cancel/InProgress` fails intermittently due to a data corruption bug in the filesystem storage client. When a batch is cancelled while in-progress, `uploadPartialResults` (and `finalizeJob`) upload the output and error files **concurrently** — two goroutines call `fs.Client.Store()` targeting the same tenant directory. `Store()` generates temp file names using `time.Now().UnixNano()`, and when both goroutines execute in the same nanosecond, they produce identical temp names. The second `Create` silently truncates the first goroutine's data, causing one file's content to overwrite the other.

This explains all symptoms from #504:
- Output file contains 20 cancelled entries instead of 5 completed ones
- Error file also has 20 entries — same data appears in both files (40 lines for 25 requests)
- `fast-1` through `fast-5` results are missing (destroyed by the truncation)

## What does this PR do?

Replaces the single `root.Create(tmpName)` call with `root.OpenFile()` using `O_CREATE|O_EXCL` flags inside a retry loop. `O_EXCL` is a kernel-level guarantee: if the temp file already exists, the call fails atomically with `os.ErrExist` instead of silently truncating. The retry generates a fresh nanosecond timestamp, which is guaranteed to differ after the failed syscall overhead.

Adds `TestStore_ConcurrentSameDir` — a regression test that launches 10 goroutines storing to the same directory concurrently and verifies each file has distinct, correct content.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #504
