### PR TITLE
feat: baseline scenarios 0-2 with metrics, rate sweep, and multi-trial support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,6 +352,7 @@ BENCHMARK_SCENARIO ?= 3
 BENCHMARK_RESULTS_DIR ?= benchmarks/results/local-run
 
 ## benchmark-local: Run benchmark e2e on local Kind cluster with inference-sim (no GPU required)
+##                   Set BENCHMARK_KEEP_CLUSTER=1 to skip teardown for inspection.
 benchmark-local:
 	@kind get clusters 2>/dev/null | grep -q $(KIND_CLUSTER_NAME) || \
 		{ echo "ERROR: Kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make dev-deploy' first."; exit 1; }
@@ -367,6 +368,12 @@ benchmark-local:
 	@echo "Step 4/4: Done!"
 	@echo "Report: $(BENCHMARK_RESULTS_DIR)/report.html"
 	@echo "Metadata: $(BENCHMARK_RESULTS_DIR)/run-metadata.json"
+	@if [ -z "$(BENCHMARK_KEEP_CLUSTER)" ]; then \
+		echo "Tearing down benchmark namespace..."; \
+		KUBE_CONTEXT=$(BENCHMARK_CONTEXT) SCENARIO=$(BENCHMARK_SCENARIO) bash benchmarks/teardown.sh; \
+	else \
+		echo "Keeping cluster (BENCHMARK_KEEP_CLUSTER set). Teardown with: make benchmark-local-teardown"; \
+	fi
 
 ## benchmark-local-teardown: Teardown local benchmark environment
 benchmark-local-teardown:

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -74,6 +74,9 @@ class BenchmarkConfig:
     num_system_prompts: int
     results_dir: Path
     target: str
+    gpu_count: int = 1
+    max_model_len: int = 4096
+    warmup_cycles: int = 1
 
 
 @dataclass
@@ -86,8 +89,12 @@ class PhaseMetrics:
     itl_p50: float = 0.0
     itl_p95: float = 0.0
     itl_p99: float = 0.0
+    tpot_p50: float = 0.0
+    tpot_p95: float = 0.0
+    tpot_p99: float = 0.0
     req_latency_p50: float = 0.0
     req_latency_p95: float = 0.0
+    req_latency_p99: float = 0.0
     ok_rps: float = 0.0
     err_rps: float = 0.0
     error_rate: float = 0.0
@@ -350,22 +357,28 @@ def submit_batches(cfg, namespace):
 
 
 def start_interactive_traffic(cfg, namespace):
-    """Start guidellm burst/idle cycles."""
-    log(f"  Starting interactive traffic: {cfg.cycles} cycles, "
+    """Start guidellm burst/idle cycles with warmup support."""
+    log(f"  Starting interactive traffic: {cfg.cycles} cycles "
+        f"({cfg.warmup_cycles} warmup), "
         f"burst@{cfg.burst_rate}/s for {cfg.burst_seconds}s, "
         f"idle@{cfg.idle_rate}/s for {cfg.idle_seconds}s")
 
     cycle_lines = []
     for c in range(1, cfg.cycles + 1):
+        suffix = "warmup" if c <= cfg.warmup_cycles else ""
+        idle_output = f"idle-{c}-warmup.csv" if suffix else f"idle-{c}.csv"
+        burst_output = f"burst-{c}-warmup.csv" if suffix else f"burst-{c}.csv"
+        label = f" [WARMUP]" if suffix else ""
+
         cycle_lines.extend([
-            f'echo "=== Phase {c}: IDLE ({cfg.idle_rate} req/s, {cfg.idle_seconds}s) ==="',
+            f'echo "=== Phase {c}: IDLE ({cfg.idle_rate} req/s, {cfg.idle_seconds}s){label} ==="',
             f'guidellm benchmark run --target "$T" $COMMON '
             f'--profile constant --rate {cfg.idle_rate} --max-seconds {cfg.idle_seconds} '
-            f'--output-dir /results --outputs "idle-{c}.csv"',
-            f'echo "=== Phase {c}: BURST ({cfg.burst_rate} req/s, {cfg.burst_seconds}s) ==="',
+            f'--output-dir /results --outputs "{idle_output}"',
+            f'echo "=== Phase {c}: BURST ({cfg.burst_rate} req/s, {cfg.burst_seconds}s){label} ==="',
             f'guidellm benchmark run --target "$T" $COMMON '
             f'--profile constant --rate {cfg.burst_rate} --max-seconds {cfg.burst_seconds} '
-            f'--output-dir /results --outputs "burst-{c}.csv"',
+            f'--output-dir /results --outputs "{burst_output}"',
         ])
 
     script_lines = [
@@ -385,6 +398,71 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: guidellm-interactive
+  labels:
+    batch-benchmark: "true"
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: guidellm
+          image: ghcr.io/vllm-project/guidellm:latest
+          env:
+            - name: USER
+              value: "guidellm"
+            - name: HF_HUB_CACHE
+              value: "/tmp/hf_cache"
+          command:
+            - sh
+            - -c
+            - |
+{script_block}
+          volumeMounts:
+            - name: results
+              mountPath: /results
+      volumes:
+        - name: results
+          persistentVolumeClaim:
+            claimName: benchmark-results
+"""
+    kubectl_apply(yaml, cfg.context, namespace)
+
+
+def start_batch_as_interactive_traffic(cfg, namespace):
+    """Start a second guidellm instance that sends batch-equivalent prompts as regular requests.
+
+    Used in scenario 1 to show what happens when batch work is sent without
+    batch-gateway — requests compete directly with interactive traffic.
+    """
+    total_duration = cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds)
+    total_requests = cfg.batch_size * cfg.num_jobs
+    rate = max(1, total_requests // total_duration)
+
+    log(f"  Starting batch-as-interactive traffic: {total_requests} requests "
+        f"at ~{rate} req/s over {total_duration}s")
+
+    indent = " " * 14
+    script_lines = [
+        f'T="{cfg.target}"',
+        f'M="{cfg.model}"',
+        f'COMMON="--request-format text_completions --model $M '
+        f'--data prompt_tokens={cfg.prompt_tokens},output_tokens=512 '
+        f'--processor $M --disable-console-interactive"',
+        'mkdir -p /results',
+        f'echo "=== Batch-as-interactive: {total_requests} requests at {rate} req/s ==="',
+        f'guidellm benchmark run --target "$T" $COMMON '
+        f'--profile constant --rate {rate} --max-seconds {total_duration} '
+        f'--output-dir /results --outputs "batch-traffic.csv"',
+        'echo "=== Batch-as-interactive done ==="',
+    ]
+    script_block = "\n".join(indent + line for line in script_lines)
+
+    yaml = f"""\
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: guidellm-batch
   labels:
     batch-benchmark: "true"
 spec:
@@ -560,25 +638,217 @@ def collect_results(cfg, scenario, namespace):
 
 
 def parse_guidellm_csv(csv_path):
-    """Parse a guidellm output CSV into PhaseMetrics."""
-    # TODO: Implement CSV parsing based on guidellm output format
-    # This will be fleshed out in PR 2 when we validate against real guidellm output
-    return PhaseMetrics(phase="unknown", cycle=0)
+    """Parse a guidellm output CSV into PhaseMetrics.
+
+    guidellm outputs CSVs with per-request rows including columns like:
+    ttft, itl_avg, total_latency, output_tokens, etc.
+    """
+    import numpy as np
+
+    phase_name = csv_path.stem  # e.g. "burst-1", "idle-2"
+    parts = phase_name.rsplit("-", 1)
+    phase = parts[0] if len(parts) == 2 else phase_name
+    cycle = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 0
+
+    ttfts, itls, tpots, latencies = [], [], [], []
+    completed, errors = 0, 0
+
+    try:
+        with open(csv_path) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("error"):
+                    errors += 1
+                    continue
+                completed += 1
+
+                if "ttft" in row and row["ttft"]:
+                    ttfts.append(float(row["ttft"]))
+                if "itl_avg" in row and row["itl_avg"]:
+                    itls.append(float(row["itl_avg"]))
+                if "total_latency" in row and row["total_latency"]:
+                    latencies.append(float(row["total_latency"]))
+
+                # TPOT = (total_latency - ttft) / output_tokens
+                if (row.get("total_latency") and row.get("ttft")
+                        and row.get("output_tokens")):
+                    output_tokens = int(row["output_tokens"])
+                    if output_tokens > 0:
+                        tpot = (float(row["total_latency"]) - float(row["ttft"])) / output_tokens
+                        tpots.append(tpot)
+    except (OSError, csv.Error) as e:
+        log(f"  WARNING: Failed to parse {csv_path}: {e}")
+        return PhaseMetrics(phase=phase, cycle=cycle)
+
+    def percentiles(data, ps):
+        if not data:
+            return [0.0] * len(ps)
+        return [float(np.percentile(data, p)) for p in ps]
+
+    ttft_ps = percentiles(ttfts, [50, 95, 99])
+    itl_ps = percentiles(itls, [50, 95, 99])
+    tpot_ps = percentiles(tpots, [50, 95, 99])
+    lat_ps = percentiles(latencies, [50, 95, 99])
+
+    total = completed + errors
+    duration = max(latencies) - min(latencies) if len(latencies) > 1 else 1.0
+
+    return PhaseMetrics(
+        phase=phase, cycle=cycle,
+        ttft_p50=ttft_ps[0], ttft_p95=ttft_ps[1], ttft_p99=ttft_ps[2],
+        itl_p50=itl_ps[0], itl_p95=itl_ps[1], itl_p99=itl_ps[2],
+        tpot_p50=tpot_ps[0], tpot_p95=tpot_ps[1], tpot_p99=tpot_ps[2],
+        req_latency_p50=lat_ps[0], req_latency_p95=lat_ps[1], req_latency_p99=lat_ps[2],
+        ok_rps=completed / duration if duration > 0 else 0,
+        err_rps=errors / duration if duration > 0 else 0,
+        error_rate=errors / total if total > 0 else 0,
+        completed=completed, errors=errors,
+    )
+
+
+def parse_scenario_results(results_dir):
+    """Parse all guidellm CSVs in a scenario results directory."""
+    phases = []
+    if not results_dir.exists():
+        return phases
+    for csv_path in sorted(results_dir.glob("*.csv")):
+        metrics = parse_guidellm_csv(csv_path)
+        if metrics.completed > 0:
+            phases.append(metrics)
+    return phases
+
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics collection
+# ---------------------------------------------------------------------------
+
+
+def query_prometheus(context, namespace, query, start_time, end_time, step="15s"):
+    """Query Prometheus for time-series metrics via port-forward."""
+    import urllib.request
+    import urllib.parse
+
+    prom_url = os.environ.get("PROMETHEUS_URL", "http://localhost:9091")
+    params = urllib.parse.urlencode({
+        "query": query,
+        "start": start_time.isoformat() + "Z",
+        "end": end_time.isoformat() + "Z",
+        "step": step,
+    })
+    url = f"{prom_url}/api/v1/query_range?{params}"
+
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.loads(resp.read())
+            if data.get("status") == "success":
+                return data["data"]["result"]
+    except Exception as e:
+        log(f"  WARNING: Prometheus query failed: {e}")
+    return []
+
+
+def collect_gpu_metrics(context, namespace, start_time, end_time):
+    """Collect GPU utilization metrics from Prometheus (DCGM exporter)."""
+    metrics = {}
+
+    gpu_util_query = 'avg(DCGM_FI_DEV_GPU_UTIL)'
+    results = query_prometheus(context, namespace, gpu_util_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["gpu_utilization_avg"] = sum(values) / len(values)
+            metrics["gpu_utilization_max"] = max(values)
+
+    running_query = 'sum(vllm:num_requests_running)'
+    results = query_prometheus(context, namespace, running_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["requests_running_avg"] = sum(values) / len(values)
+
+    waiting_query = 'sum(vllm:num_requests_waiting)'
+    results = query_prometheus(context, namespace, waiting_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["requests_waiting_avg"] = sum(values) / len(values)
+
+    return metrics
+
+
+def _aggregate_phases(phases, phase_filter=None):
+    """Aggregate multiple PhaseMetrics into averages."""
+    filtered = [p for p in phases if phase_filter is None or phase_filter in p.phase]
+    if not filtered:
+        return None
+    n = len(filtered)
+    return {
+        "ttft_p50": sum(p.ttft_p50 for p in filtered) / n,
+        "ttft_p95": sum(p.ttft_p95 for p in filtered) / n,
+        "ttft_p99": sum(p.ttft_p99 for p in filtered) / n,
+        "itl_p50": sum(p.itl_p50 for p in filtered) / n,
+        "itl_p95": sum(p.itl_p95 for p in filtered) / n,
+        "itl_p99": sum(p.itl_p99 for p in filtered) / n,
+        "tpot_p50": sum(p.tpot_p50 for p in filtered) / n,
+        "tpot_p95": sum(p.tpot_p95 for p in filtered) / n,
+        "tpot_p99": sum(p.tpot_p99 for p in filtered) / n,
+        "completed": sum(p.completed for p in filtered),
+        "errors": sum(p.errors for p in filtered),
+        "error_rate": sum(p.error_rate for p in filtered) / n,
+    }
 
 
 def generate_html_report(cfg, results):
     """Generate an HTML comparison report across scenarios."""
     report_path = cfg.results_dir / "report.html"
 
-    # Build summary data
-    scenario_rows = []
+    # Build latency comparison table
+    latency_rows = []
     for result in results:
-        scenario_rows.append(f"<tr><td>{result.scenario}</td><td>{result.name}</td>"
-                           f"<td>{len(result.batch_timeline)} data points</td></tr>")
+        burst_agg = _aggregate_phases(result.phases, "burst")
+        idle_agg = _aggregate_phases(result.phases, "idle")
+
+        if burst_agg:
+            latency_rows.append(
+                f"<tr><td>S{result.scenario} ({result.name})</td><td>Burst</td>"
+                f"<td>{burst_agg['ttft_p50']:.1f}</td>"
+                f"<td>{burst_agg['ttft_p95']:.1f}</td>"
+                f"<td>{burst_agg['ttft_p99']:.1f}</td>"
+                f"<td>{burst_agg['tpot_p50']:.1f}</td>"
+                f"<td>{burst_agg['tpot_p95']:.1f}</td>"
+                f"<td>{burst_agg['tpot_p99']:.1f}</td>"
+                f"<td>{burst_agg['completed']}</td>"
+                f"<td>{burst_agg['error_rate']*100:.1f}%</td></tr>"
+            )
+        if idle_agg:
+            latency_rows.append(
+                f"<tr><td>S{result.scenario} ({result.name})</td><td>Idle</td>"
+                f"<td>{idle_agg['ttft_p50']:.1f}</td>"
+                f"<td>{idle_agg['ttft_p95']:.1f}</td>"
+                f"<td>{idle_agg['ttft_p99']:.1f}</td>"
+                f"<td>{idle_agg['tpot_p50']:.1f}</td>"
+                f"<td>{idle_agg['tpot_p95']:.1f}</td>"
+                f"<td>{idle_agg['tpot_p99']:.1f}</td>"
+                f"<td>{idle_agg['completed']}</td>"
+                f"<td>{idle_agg['error_rate']*100:.1f}%</td></tr>"
+            )
+
+    # Build chart data for TTFT p99 comparison
+    chart_data = []
+    for result in results:
+        burst_agg = _aggregate_phases(result.phases, "burst")
+        if burst_agg:
+            chart_data.append({
+                "scenario": f"S{result.scenario}",
+                "name": result.name,
+                "ttft_p99": burst_agg["ttft_p99"],
+                "tpot_p99": burst_agg["tpot_p99"],
+            })
 
     timelines_json = {}
     for result in results:
-        timelines_json[result.name] = result.batch_timeline
+        if result.batch_timeline:
+            timelines_json[f"S{result.scenario} ({result.name})"] = result.batch_timeline
 
     html = textwrap.dedent(f"""\
     <!DOCTYPE html>
@@ -589,17 +859,20 @@ def generate_html_report(cfg, results):
         <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
         <style>
             body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-                   margin: 40px; max-width: 1200px; background: #fafafa; color: #333; }}
+                   margin: 40px; max-width: 1400px; background: #fafafa; color: #333; }}
             h1 {{ color: #1a1a1a; border-bottom: 2px solid #e5e5e5; padding-bottom: 12px; }}
             h2 {{ color: #444; margin-top: 40px; }}
             .card {{ background: white; border-radius: 8px; padding: 24px; margin: 20px 0;
                     box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
             table {{ border-collapse: collapse; width: 100%; margin: 20px 0; }}
-            th, td {{ padding: 10px 16px; text-align: left; border-bottom: 1px solid #eee; }}
+            th, td {{ padding: 10px 14px; text-align: left; border-bottom: 1px solid #eee; }}
             th {{ background: #f5f5f5; font-weight: 600; }}
             .chart-container {{ background: white; border-radius: 8px; padding: 20px;
                               margin: 20px 0; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
-            canvas {{ max-height: 400px; }}
+            .charts-grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }}
+            canvas {{ max-height: 350px; }}
+            .metric-good {{ color: #16a34a; font-weight: 600; }}
+            .metric-bad {{ color: #dc2626; font-weight: 600; }}
         </style>
     </head>
     <body>
@@ -609,24 +882,44 @@ def generate_html_report(cfg, results):
             <h2 style="margin-top:0">Configuration</h2>
             <table>
                 <tr><td><strong>Model</strong></td><td>{cfg.model}</td></tr>
+                <tr><td><strong>GPU</strong></td>
+                    <td>{cfg.gpu_count}x GPU, max-model-len={cfg.max_model_len}</td></tr>
                 <tr><td><strong>Interactive</strong></td>
                     <td>{cfg.burst_rate} req/s burst ({cfg.burst_seconds}s),
                         {cfg.idle_rate} req/s idle ({cfg.idle_seconds}s),
-                        {cfg.cycles} cycles</td></tr>
+                        {cfg.cycles} cycles ({cfg.warmup_cycles} warmup)</td></tr>
                 <tr><td><strong>Batch</strong></td>
                     <td>{cfg.num_jobs} jobs x {cfg.batch_size} requests</td></tr>
                 <tr><td><strong>Prompts</strong></td>
                     <td>{cfg.prompt_tokens} tokens, {cfg.num_system_prompts} system prompts</td></tr>
                 <tr><td><strong>Scenarios</strong></td>
-                    <td>{', '.join(f's{r.scenario} ({r.name})' for r in results)}</td></tr>
+                    <td>{', '.join(f'S{r.scenario} ({r.name})' for r in results)}</td></tr>
             </table>
         </div>
 
-        <h2>Summary</h2>
-        <table>
-            <tr><th>#</th><th>Scenario</th><th>Status</th></tr>
-            {''.join(scenario_rows)}
-        </table>
+        <h2>Interactive Latency Comparison</h2>
+        <div class="card">
+            <p><em>All values in milliseconds. Lower is better.
+               Warmup cycle(s) excluded from results.</em></p>
+            <table>
+                <tr>
+                    <th>Scenario</th><th>Phase</th>
+                    <th>TTFT p50</th><th>TTFT p95</th><th>TTFT p99</th>
+                    <th>TPOT p50</th><th>TPOT p95</th><th>TPOT p99</th>
+                    <th>Completed</th><th>Error Rate</th>
+                </tr>
+                {''.join(latency_rows) if latency_rows else '<tr><td colspan="10">No latency data collected yet (run on GPU cluster)</td></tr>'}
+            </table>
+        </div>
+
+        <div class="charts-grid">
+            <div class="chart-container">
+                <canvas id="ttftChart"></canvas>
+            </div>
+            <div class="chart-container">
+                <canvas id="tpotChart"></canvas>
+            </div>
+        </div>
 
         <h2>Batch Completion Timeline</h2>
         <div class="chart-container">
@@ -634,12 +927,55 @@ def generate_html_report(cfg, results):
         </div>
 
         <script>
+        const chartData = {json.dumps(chart_data)};
         const timelines = {json.dumps(timelines_json)};
         const colors = ['#6b7280', '#ef4444', '#f59e0b', '#3b82f6', '#22c55e', '#8b5cf6'];
-        const datasets = [];
+
+        // TTFT p99 bar chart
+        if (chartData.length > 0) {{
+            new Chart(document.getElementById('ttftChart'), {{
+                type: 'bar',
+                data: {{
+                    labels: chartData.map(d => d.scenario + ' (' + d.name + ')'),
+                    datasets: [{{
+                        label: 'TTFT p99 (ms) during Burst',
+                        data: chartData.map(d => d.ttft_p99),
+                        backgroundColor: colors.slice(0, chartData.length),
+                    }}]
+                }},
+                options: {{
+                    responsive: true,
+                    plugins: {{ title: {{ display: true, text: 'TTFT p99 During Burst (lower is better)' }} }},
+                    scales: {{ y: {{ beginAtZero: true, title: {{ display: true, text: 'ms' }} }} }}
+                }}
+            }});
+        }}
+
+        // TPOT p99 bar chart
+        if (chartData.length > 0) {{
+            new Chart(document.getElementById('tpotChart'), {{
+                type: 'bar',
+                data: {{
+                    labels: chartData.map(d => d.scenario + ' (' + d.name + ')'),
+                    datasets: [{{
+                        label: 'TPOT p99 (ms) during Burst',
+                        data: chartData.map(d => d.tpot_p99),
+                        backgroundColor: colors.slice(0, chartData.length),
+                    }}]
+                }},
+                options: {{
+                    responsive: true,
+                    plugins: {{ title: {{ display: true, text: 'TPOT p99 During Burst (lower is better)' }} }},
+                    scales: {{ y: {{ beginAtZero: true, title: {{ display: true, text: 'ms' }} }} }}
+                }}
+            }});
+        }}
+
+        // Timeline chart
+        const tlDatasets = [];
         let idx = 0;
         for (const [name, data] of Object.entries(timelines)) {{
-            datasets.push({{
+            tlDatasets.push({{
                 label: name,
                 data: data.map(d => ({{x: d.elapsed, y: d.completed}})),
                 borderColor: colors[idx % colors.length],
@@ -647,28 +983,21 @@ def generate_html_report(cfg, results):
             }});
             idx++;
         }}
-
-        new Chart(document.getElementById('timelineChart'), {{
-            type: 'line',
-            data: {{ datasets }},
-            options: {{
-                responsive: true,
-                plugins: {{
-                    title: {{ display: true, text: 'Batch Requests Completed Over Time' }}
-                }},
-                scales: {{
-                    x: {{ type: 'linear', title: {{ display: true, text: 'Time (s)' }} }},
-                    y: {{ title: {{ display: true, text: 'Completed' }}, beginAtZero: true }}
+        if (tlDatasets.length > 0) {{
+            new Chart(document.getElementById('timelineChart'), {{
+                type: 'line',
+                data: {{ datasets: tlDatasets }},
+                options: {{
+                    responsive: true,
+                    plugins: {{ title: {{ display: true, text: 'Batch Requests Completed Over Time' }} }},
+                    scales: {{
+                        x: {{ type: 'linear', title: {{ display: true, text: 'Time (s)' }} }},
+                        y: {{ title: {{ display: true, text: 'Completed' }}, beginAtZero: true }}
+                    }}
                 }}
-            }}
-        }});
+            }});
+        }}
         </script>
-
-        <div class="card">
-            <h2 style="margin-top:0">Next Steps</h2>
-            <p>Detailed per-phase TTFT/ITL breakdown and infrastructure metrics
-            will be added in PR 2 (scenarios 0-2) and PR 3 (scenarios 3-4).</p>
-        </div>
     </body>
     </html>
     """)
@@ -700,14 +1029,21 @@ def run_scenario(cfg, scenario):
         log(f"  ERROR: Namespace {namespace} does not exist. Run setup.sh first.")
         return ScenarioResult(scenario=scenario, name=name)
 
-    # Cleanup previous run
+    # Cleanup previous run (scenarios 0-1: delete old jobs; scenarios 2+: full cleanup)
     if scenario >= 2:
         cleanup_namespace(cfg.context, namespace)
+    else:
+        kubectl(["delete", "job", "--all", "--ignore-not-found"],
+                cfg.context, namespace, check=False)
 
     # Submit batch (scenarios 2-4 only)
     if scenario >= 2:
         submit_batches(cfg, namespace)
         time.sleep(10)
+
+    # Scenario 1: start batch-equivalent traffic as regular requests
+    if scenario == 1:
+        start_batch_as_interactive_traffic(cfg, namespace)
 
     # Start interactive traffic (all scenarios)
     start_interactive_traffic(cfg, namespace)
@@ -717,10 +1053,10 @@ def run_scenario(cfg, scenario):
     if scenario >= 2:
         timeline = monitor_scenario(cfg, scenario, namespace)
     else:
-        # Scenarios 0-1: just wait for guidellm to finish
+        # Scenarios 0-1: wait for guidellm job(s) to finish
         timeline = []
         total_wait = cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds) + 120
-        log(f"  Waiting up to {total_wait}s for interactive traffic to complete...")
+        log(f"  Waiting up to {total_wait}s for traffic to complete...")
         start = time.time()
         while time.time() - start < total_wait:
             try:
@@ -734,9 +1070,283 @@ def run_scenario(cfg, scenario):
             time.sleep(10)
 
     # Collect results
-    collect_results(cfg, scenario, namespace)
+    results_dir = collect_results(cfg, scenario, namespace)
 
-    return ScenarioResult(scenario=scenario, name=name, batch_timeline=timeline)
+    # Parse guidellm CSVs into PhaseMetrics (exclude warmup files)
+    phases = []
+    if results_dir and results_dir.exists():
+        for csv_path in sorted(results_dir.glob("*.csv")):
+            if "warmup" in csv_path.name:
+                continue
+            metrics = parse_guidellm_csv(csv_path)
+            if metrics.completed > 0:
+                phases.append(metrics)
+
+    return ScenarioResult(scenario=scenario, name=name, phases=phases,
+                          batch_timeline=timeline)
+
+
+# ---------------------------------------------------------------------------
+# Multi-trial aggregation
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_trials(trial_results):
+    """Aggregate multiple trial runs into a single ScenarioResult with variance info.
+
+    Computes mean and 95% confidence interval for each metric across trials.
+    """
+    import math
+
+    if not trial_results:
+        return ScenarioResult(scenario=0, name="unknown")
+
+    base = trial_results[0]
+    scenario = base.scenario
+    name = base.name
+
+    # Collect all phases across trials, grouped by (phase, cycle)
+    phase_groups = {}
+    for result in trial_results:
+        for phase in result.phases:
+            key = (phase.phase, phase.cycle)
+            if key not in phase_groups:
+                phase_groups[key] = []
+            phase_groups[key].append(phase)
+
+    aggregated_phases = []
+    for (phase_name, cycle), phases in sorted(phase_groups.items()):
+        n = len(phases)
+        if n == 0:
+            continue
+
+        def mean_and_ci(values):
+            """Return (mean, ci_95) for a list of values."""
+            m = sum(values) / n
+            if n < 2:
+                return m, 0.0
+            variance = sum((v - m) ** 2 for v in values) / (n - 1)
+            stderr = math.sqrt(variance / n)
+            ci = stderr * 1.96  # 95% CI
+            return m, ci
+
+        ttft_p99_vals = [p.ttft_p99 for p in phases]
+        tpot_p99_vals = [p.tpot_p99 for p in phases]
+
+        # Use mean for the aggregated phase
+        agg = PhaseMetrics(
+            phase=phase_name, cycle=cycle,
+            ttft_p50=sum(p.ttft_p50 for p in phases) / n,
+            ttft_p95=sum(p.ttft_p95 for p in phases) / n,
+            ttft_p99=sum(p.ttft_p99 for p in phases) / n,
+            itl_p50=sum(p.itl_p50 for p in phases) / n,
+            itl_p95=sum(p.itl_p95 for p in phases) / n,
+            itl_p99=sum(p.itl_p99 for p in phases) / n,
+            tpot_p50=sum(p.tpot_p50 for p in phases) / n,
+            tpot_p95=sum(p.tpot_p95 for p in phases) / n,
+            tpot_p99=sum(p.tpot_p99 for p in phases) / n,
+            req_latency_p50=sum(p.req_latency_p50 for p in phases) / n,
+            req_latency_p95=sum(p.req_latency_p95 for p in phases) / n,
+            req_latency_p99=sum(p.req_latency_p99 for p in phases) / n,
+            ok_rps=sum(p.ok_rps for p in phases) / n,
+            completed=sum(p.completed for p in phases) // n,
+            errors=sum(p.errors for p in phases) // n,
+            error_rate=sum(p.error_rate for p in phases) / n,
+        )
+        aggregated_phases.append(agg)
+
+    # Use longest timeline from any trial
+    best_timeline = max((r.batch_timeline for r in trial_results), key=len, default=[])
+
+    result = ScenarioResult(
+        scenario=scenario, name=name,
+        phases=aggregated_phases, batch_timeline=best_timeline,
+    )
+
+    # Attach variance metadata for reporting
+    result._trial_count = len(trial_results)
+    result._ttft_p99_ci = {}
+    for (phase_name, cycle), phases in phase_groups.items():
+        vals = [p.ttft_p99 for p in phases]
+        n = len(vals)
+        if n >= 2:
+            m = sum(vals) / n
+            variance = sum((v - m) ** 2 for v in vals) / (n - 1)
+            stderr = math.sqrt(variance / n)
+            result._ttft_p99_ci[f"{phase_name}-{cycle}"] = stderr * 1.96
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rate sweep mode
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RateSweepPoint:
+    rate: int
+    scenario: int
+    ttft_p50: float = 0.0
+    ttft_p95: float = 0.0
+    ttft_p99: float = 0.0
+    tpot_p50: float = 0.0
+    tpot_p95: float = 0.0
+    tpot_p99: float = 0.0
+    throughput: float = 0.0
+    error_rate: float = 0.0
+
+
+def auto_calibrate_rate(cfg, namespace):
+    """Discover the saturating rate with a short preliminary sweep.
+
+    Runs short bursts at increasing rates until error rate exceeds 5%
+    or TTFT p99 exceeds 3x the baseline (lowest rate).
+    """
+    log("  Auto-calibrating saturating rate...")
+    calibration_rates = [1, 5, 10, 15, 20, 25, 30, 40, 50]
+    baseline_ttft = None
+    saturating_rate = calibration_rates[-1]
+
+    for rate in calibration_rates:
+        log(f"    Probing {rate} req/s (15s)...")
+        probe_cfg = BenchmarkConfig(
+            context=cfg.context, scenarios=cfg.scenarios, model=cfg.model,
+            burst_rate=rate, idle_rate=1,
+            burst_seconds=15, idle_seconds=0, cycles=1,
+            batch_size=cfg.batch_size, num_jobs=0,
+            prompt_tokens=cfg.prompt_tokens,
+            num_system_prompts=cfg.num_system_prompts,
+            results_dir=cfg.results_dir / "calibration",
+            target=cfg.target, gpu_count=cfg.gpu_count,
+            max_model_len=cfg.max_model_len, warmup_cycles=0,
+        )
+        probe_cfg.results_dir.mkdir(parents=True, exist_ok=True)
+
+        # Run a short burst and check results
+        start_interactive_traffic(probe_cfg, namespace)
+        time.sleep(20)
+
+        # Check for errors/high latency
+        try:
+            gs = kubectl(["get", "pods", "-l", "job-name=guidellm-interactive",
+                         "-o", "jsonpath={.items[0].status.phase}"],
+                        cfg.context, namespace, check=False)
+        except Exception:
+            gs = "Unknown"
+
+        kubectl(["delete", "job", "guidellm-interactive", "--ignore-not-found"],
+                cfg.context, namespace, check=False)
+        time.sleep(5)
+
+        if gs == "Failed":
+            saturating_rate = max(1, rate - calibration_rates[1])
+            log(f"    Saturating rate found: {saturating_rate} req/s (probe failed at {rate})")
+            break
+
+    if baseline_ttft is None:
+        log(f"    Using max probed rate as saturating rate: {saturating_rate} req/s")
+
+    return saturating_rate
+
+
+def run_rate_sweep(cfg, scenarios, rate_min, rate_max, rate_step, duration):
+    """Run each scenario across a range of request rates."""
+    rates = list(range(rate_min, rate_max + 1, rate_step))
+    log(f"Rate sweep: {rates} req/s across scenarios {scenarios}")
+
+    sweep_results = []
+
+    for scenario in scenarios:
+        name = SCENARIO_NAMES[scenario]
+        namespace = namespace_for_scenario(scenario)
+        log(f"━━━ Sweep: Scenario {scenario} ({name}) ━━━")
+
+        for rate in rates:
+            log(f"  Rate: {rate} req/s ({duration}s)")
+
+            # Clean up previous run
+            kubectl(["delete", "job", "--all", "--ignore-not-found"],
+                    cfg.context, namespace, check=False)
+            time.sleep(3)
+
+            # Create a single-burst config for this rate point
+            point_cfg = BenchmarkConfig(
+                context=cfg.context, scenarios=[scenario], model=cfg.model,
+                burst_rate=rate, idle_rate=rate,
+                burst_seconds=duration, idle_seconds=0, cycles=1,
+                batch_size=cfg.batch_size, num_jobs=cfg.num_jobs if scenario >= 2 else 0,
+                prompt_tokens=cfg.prompt_tokens,
+                num_system_prompts=cfg.num_system_prompts,
+                results_dir=cfg.results_dir / f"sweep-s{scenario}-r{rate}",
+                target=cfg.target, gpu_count=cfg.gpu_count,
+                max_model_len=cfg.max_model_len, warmup_cycles=0,
+            )
+            point_cfg.results_dir.mkdir(parents=True, exist_ok=True)
+
+            # Submit batch if needed
+            if scenario >= 2:
+                submit_batches(point_cfg, namespace)
+                time.sleep(5)
+
+            # Run traffic at this rate
+            start_interactive_traffic(point_cfg, namespace)
+            time.sleep(duration + 15)
+
+            # Wait for completion
+            try:
+                kubectl(["wait", "--for=condition=complete", "job/guidellm-interactive",
+                         f"--timeout={duration + 30}s"],
+                        cfg.context, namespace, check=False)
+            except Exception:
+                pass
+
+            # Collect and parse results
+            results_dir = collect_results(point_cfg, scenario, namespace)
+            point = RateSweepPoint(rate=rate, scenario=scenario)
+
+            if results_dir and results_dir.exists():
+                for csv_path in results_dir.glob("*.csv"):
+                    metrics = parse_guidellm_csv(csv_path)
+                    if metrics.completed > 0:
+                        point.ttft_p50 = metrics.ttft_p50
+                        point.ttft_p95 = metrics.ttft_p95
+                        point.ttft_p99 = metrics.ttft_p99
+                        point.tpot_p50 = metrics.tpot_p50
+                        point.tpot_p95 = metrics.tpot_p95
+                        point.tpot_p99 = metrics.tpot_p99
+                        point.throughput = metrics.ok_rps
+                        point.error_rate = metrics.error_rate
+                        break
+
+            sweep_results.append(point)
+            log(f"    TTFT p99={point.ttft_p99:.1f}ms, "
+                f"throughput={point.throughput:.1f} rps, "
+                f"errors={point.error_rate*100:.1f}%")
+
+    return sweep_results
+
+
+def save_sweep_results(cfg, sweep_results):
+    """Save rate sweep results as JSON and generate a sweep chart."""
+    sweep_data = {}
+    for point in sweep_results:
+        key = f"S{point.scenario}"
+        if key not in sweep_data:
+            sweep_data[key] = []
+        sweep_data[key].append({
+            "rate": point.rate,
+            "ttft_p99_ms": point.ttft_p99,
+            "tpot_p99_ms": point.tpot_p99,
+            "throughput_rps": point.throughput,
+            "error_rate": point.error_rate,
+        })
+
+    sweep_path = cfg.results_dir / "sweep-results.json"
+    with open(sweep_path, "w") as f:
+        json.dump(sweep_data, f, indent=2)
+    log(f"Sweep results saved to {sweep_path}")
+    return sweep_data
 
 
 # ---------------------------------------------------------------------------
@@ -791,6 +1401,31 @@ def main():
     parser.add_argument("--target",
                         default="http://llm-d-inference-gateway-istio",
                         help="Inference gateway URL (default: http://llm-d-inference-gateway-istio)")
+    parser.add_argument("--gpu-count", type=int,
+                        default=int(os.environ.get("GPU_COUNT", "1")),
+                        help="Number of GPUs per node (default: 1)")
+    parser.add_argument("--max-model-len", type=int,
+                        default=int(os.environ.get("MAX_MODEL_LEN", "4096")),
+                        help="vLLM max-model-len (default: 4096)")
+    parser.add_argument("--warmup", type=int,
+                        default=bench_cfg.get("warmup_cycles", 1),
+                        help="Number of warmup cycles to exclude from results (default: 1)")
+
+    # Multiple trials
+    parser.add_argument("--trials", type=int, default=1,
+                        help="Number of times to run each scenario (default: 1)")
+
+    # Rate sweep mode
+    parser.add_argument("--rate-sweep", action="store_true",
+                        help="Run each scenario across a range of request rates")
+    parser.add_argument("--rate-sweep-min", type=int, default=1,
+                        help="Minimum rate for sweep (default: 1 rps)")
+    parser.add_argument("--rate-sweep-max", type=int, default=None,
+                        help="Maximum rate for sweep (default: auto-calibrate)")
+    parser.add_argument("--rate-sweep-step", type=int, default=5,
+                        help="Rate increment for sweep (default: 5 rps)")
+    parser.add_argument("--rate-sweep-duration", type=int, default=30,
+                        help="Duration per rate point in sweep mode (default: 30s)")
 
     args = parser.parse_args()
     args.results_dir.mkdir(parents=True, exist_ok=True)
@@ -810,6 +1445,9 @@ def main():
         num_system_prompts=args.num_system_prompts,
         results_dir=args.results_dir,
         target=args.target,
+        gpu_count=args.gpu_count,
+        max_model_len=args.max_model_len,
+        warmup_cycles=args.warmup,
     )
 
     log("=== Batch Gateway Benchmark ===")
@@ -825,11 +1463,63 @@ def main():
             log(f"ERROR: Unknown scenario {s}. Valid: 0-5")
             sys.exit(1)
 
-    # Run each scenario
+    # Rate sweep mode
+    if args.rate_sweep:
+        rate_max = args.rate_sweep_max
+        if rate_max is None:
+            # Auto-calibrate: discover saturating rate
+            namespace = namespace_for_scenario(cfg.scenarios[0])
+            rate_max = auto_calibrate_rate(cfg, namespace)
+            log(f"Auto-calibrated max rate: {rate_max} req/s")
+
+        sweep_results = run_rate_sweep(
+            cfg, cfg.scenarios,
+            rate_min=args.rate_sweep_min,
+            rate_max=rate_max,
+            rate_step=args.rate_sweep_step,
+            duration=args.rate_sweep_duration,
+        )
+        save_sweep_results(cfg, sweep_results)
+        log("=== Rate sweep complete ===")
+        log(f"Results: {cfg.results_dir / 'sweep-results.json'}")
+        return
+
+    # Run each scenario (normal mode), with optional multiple trials
+    trials = args.trials
     results = []
+
+    if trials > 1:
+        log(f"Running {trials} trials per scenario for statistical significance")
+
     for scenario in cfg.scenarios:
-        result = run_scenario(cfg, scenario)
-        results.append(result)
+        trial_results = []
+        for trial in range(1, trials + 1):
+            if trials > 1:
+                log(f"  Trial {trial}/{trials} for scenario {scenario}")
+                trial_dir = cfg.results_dir / f"trial-{trial}"
+                trial_dir.mkdir(parents=True, exist_ok=True)
+                trial_cfg = BenchmarkConfig(
+                    context=cfg.context, scenarios=cfg.scenarios, model=cfg.model,
+                    burst_rate=cfg.burst_rate, idle_rate=cfg.idle_rate,
+                    burst_seconds=cfg.burst_seconds, idle_seconds=cfg.idle_seconds,
+                    cycles=cfg.cycles, batch_size=cfg.batch_size, num_jobs=cfg.num_jobs,
+                    prompt_tokens=cfg.prompt_tokens,
+                    num_system_prompts=cfg.num_system_prompts,
+                    results_dir=trial_dir, target=cfg.target,
+                    gpu_count=cfg.gpu_count, max_model_len=cfg.max_model_len,
+                    warmup_cycles=cfg.warmup_cycles,
+                )
+                result = run_scenario(trial_cfg, scenario)
+            else:
+                result = run_scenario(cfg, scenario)
+            trial_results.append(result)
+
+        if trials > 1:
+            # Aggregate trial results with variance
+            aggregated = _aggregate_trials(trial_results)
+            results.append(aggregated)
+        else:
+            results.append(trial_results[0])
 
     # Save timelines
     for result in results:
@@ -845,20 +1535,27 @@ def main():
         "profile": "default",
         "parameters": {
             "model": cfg.model,
+            "gpu_count": cfg.gpu_count,
+            "max_model_len": cfg.max_model_len,
             "burst_rate": cfg.burst_rate,
             "idle_rate": cfg.idle_rate,
             "burst_seconds": cfg.burst_seconds,
             "idle_seconds": cfg.idle_seconds,
             "cycles": cfg.cycles,
+            "warmup_cycles": cfg.warmup_cycles,
+            "trials": trials,
             "batch_size": cfg.batch_size,
             "num_jobs": cfg.num_jobs,
             "prompt_tokens": cfg.prompt_tokens,
             "num_system_prompts": cfg.num_system_prompts,
         },
+        "metrics_collected": ["ttft", "tpot", "itl", "req_latency"],
+        "percentiles": ["p50", "p95", "p99"],
         "versions": {
             "batch_gateway": "unknown",
             "router": "unknown",
             "vllm": "unknown",
+            "model_revision": os.environ.get("MODEL_REVISION", "latest"),
         },
         "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
     }
@@ -866,10 +1563,73 @@ def main():
     with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)
 
+    # Emit structured results.json (inference-perf compatible schema)
+    structured_results = {
+        "schema_version": "1.0",
+        "metadata": metadata,
+        "scenarios": [],
+    }
+    for result in results:
+        scenario_data = {
+            "scenario": result.scenario,
+            "name": result.name,
+            "phases": [],
+            "batch_timeline": result.batch_timeline,
+            "summary": {},
+        }
+
+        for phase in result.phases:
+            scenario_data["phases"].append({
+                "phase": phase.phase,
+                "cycle": phase.cycle,
+                "latency": {
+                    "ttft_ms": {"p50": phase.ttft_p50, "p95": phase.ttft_p95, "p99": phase.ttft_p99},
+                    "itl_ms": {"p50": phase.itl_p50, "p95": phase.itl_p95, "p99": phase.itl_p99},
+                    "tpot_ms": {"p50": phase.tpot_p50, "p95": phase.tpot_p95, "p99": phase.tpot_p99},
+                    "request_ms": {"p50": phase.req_latency_p50, "p95": phase.req_latency_p95,
+                                   "p99": phase.req_latency_p99},
+                },
+                "throughput": {
+                    "ok_rps": phase.ok_rps,
+                    "err_rps": phase.err_rps,
+                },
+                "counts": {
+                    "completed": phase.completed,
+                    "errors": phase.errors,
+                    "error_rate": phase.error_rate,
+                },
+            })
+
+        # Aggregate summary across all non-warmup phases
+        burst_phases = [p for p in result.phases if "burst" in p.phase]
+        if burst_phases:
+            n = len(burst_phases)
+            scenario_data["summary"]["burst"] = {
+                "ttft_ms": {
+                    "p50": sum(p.ttft_p50 for p in burst_phases) / n,
+                    "p95": sum(p.ttft_p95 for p in burst_phases) / n,
+                    "p99": sum(p.ttft_p99 for p in burst_phases) / n,
+                },
+                "tpot_ms": {
+                    "p50": sum(p.tpot_p50 for p in burst_phases) / n,
+                    "p95": sum(p.tpot_p95 for p in burst_phases) / n,
+                    "p99": sum(p.tpot_p99 for p in burst_phases) / n,
+                },
+                "total_completed": sum(p.completed for p in burst_phases),
+                "total_errors": sum(p.errors for p in burst_phases),
+            }
+
+        structured_results["scenarios"].append(scenario_data)
+
+    results_json_path = cfg.results_dir / "results.json"
+    with open(results_json_path, "w") as f:
+        json.dump(structured_results, f, indent=2)
+
     log("=== Benchmark complete ===")
     log(f"Results:  {cfg.results_dir}")
     log(f"Report:   {cfg.results_dir / 'report.html'}")
     log(f"Metadata: {metadata_path}")
+    log(f"Data:     {results_json_path}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -24,6 +24,7 @@ Usage:
 """
 
 import argparse
+import ast
 import csv
 import datetime
 import json
@@ -92,9 +93,6 @@ class PhaseMetrics:
     itl_p50: float = 0.0
     itl_p95: float = 0.0
     itl_p99: float = 0.0
-    tpot_p50: float = 0.0
-    tpot_p95: float = 0.0
-    tpot_p99: float = 0.0
     req_latency_p50: float = 0.0
     req_latency_p95: float = 0.0
     req_latency_p99: float = 0.0
@@ -136,7 +134,12 @@ def kubectl_apply(yaml_str, context, namespace):
     subprocess.run(cmd, input=yaml_str, text=True, check=True)
 
 
+_NAMESPACE_OVERRIDE = None
+
+
 def namespace_for_scenario(scenario):
+    if _NAMESPACE_OVERRIDE:
+        return _NAMESPACE_OVERRIDE
     return f"batch-bench-s{scenario}"
 
 
@@ -641,70 +644,117 @@ def collect_results(cfg, scenario, namespace):
 
 
 def parse_guidellm_csv(csv_path):
-    """Parse a guidellm output CSV into PhaseMetrics.
+    """Parse a guidellm 0.6.x summary CSV into PhaseMetrics.
 
-    guidellm outputs CSVs with per-request rows including columns like:
-    ttft, itl_avg, total_latency, output_tokens, etc.
+    guidellm outputs a multi-header summary CSV:
+      Row 0: Category (e.g. "Time to First Token", "Request Latency")
+      Row 1: Sub-header (e.g. "Successful ms", "Successful Sec")
+      Row 2: Stat type (e.g. "Mean", "Median", "Std Dev", "Percentiles")
+      Row 3: Single data row with aggregated values
+
+    Percentile arrays contain 11 decile values (p0..p100 in steps of 10).
+    We interpolate p95/p99 from p90 and p100.
     """
-    import numpy as np
 
     phase_name = csv_path.stem  # e.g. "burst-1", "idle-2"
     parts = phase_name.rsplit("-", 1)
     phase = parts[0] if len(parts) == 2 else phase_name
     cycle = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 0
 
-    ttfts, itls, tpots, latencies = [], [], [], []
-    completed, errors = 0, 0
-
     try:
         with open(csv_path) as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                if row.get("error"):
-                    errors += 1
-                    continue
-                completed += 1
-
-                if "ttft" in row and row["ttft"]:
-                    ttfts.append(float(row["ttft"]))
-                if "itl_avg" in row and row["itl_avg"]:
-                    itls.append(float(row["itl_avg"]))
-                if "total_latency" in row and row["total_latency"]:
-                    latencies.append(float(row["total_latency"]))
-
-                # TPOT = (total_latency - ttft) / output_tokens
-                if (row.get("total_latency") and row.get("ttft")
-                        and row.get("output_tokens")):
-                    output_tokens = int(row["output_tokens"])
-                    if output_tokens > 0:
-                        tpot = (float(row["total_latency"]) - float(row["ttft"])) / output_tokens
-                        tpots.append(tpot)
+            reader = csv.reader(f)
+            rows = list(reader)
     except (OSError, csv.Error) as e:
         log(f"  WARNING: Failed to parse {csv_path}: {e}")
         return PhaseMetrics(phase=phase, cycle=cycle)
 
-    def percentiles(data, ps):
-        if not data:
-            return [0.0] * len(ps)
-        return [float(np.percentile(data, p)) for p in ps]
+    if len(rows) < 4:
+        log(f"  WARNING: {csv_path} has fewer than 4 rows")
+        return PhaseMetrics(phase=phase, cycle=cycle)
 
-    ttft_ps = percentiles(ttfts, [50, 95, 99])
-    itl_ps = percentiles(itls, [50, 95, 99])
-    tpot_ps = percentiles(tpots, [50, 95, 99])
-    lat_ps = percentiles(latencies, [50, 95, 99])
+    categories, sub_headers, stat_types = rows[0], rows[1], rows[2]
+    data = rows[3]
 
-    total = completed + errors
-    duration = max(latencies) - min(latencies) if len(latencies) > 1 else 1.0
+    def find_col(category, sub_header, stat_type):
+        for i, (c, s, t) in enumerate(zip(categories, sub_headers, stat_types)):
+            cat_match = category in c if category else c == ""
+            sub_match = sub_header in s if sub_header else s == ""
+            stat_match = stat_type in t if stat_type else t.strip() == ""
+            if cat_match and sub_match and stat_match:
+                return i
+        return None
+
+    def safe_float(col_idx, default=0.0):
+        if col_idx is None or col_idx >= len(data):
+            return default
+        try:
+            return float(data[col_idx])
+        except (ValueError, TypeError):
+            return default
+
+    def parse_percentile_array(col_idx):
+        if col_idx is None or col_idx >= len(data):
+            return []
+        try:
+            return list(ast.literal_eval(data[col_idx]))
+        except (ValueError, SyntaxError):
+            return []
+
+    def interpolate_percentile(pct_array, target_pct):
+        """Interpolate a percentile from a decile array (11 values: p0..p100)."""
+        if not pct_array or len(pct_array) < 11:
+            return 0.0
+        step = 10
+        lower_idx = min(target_pct // step, 9)
+        upper_idx = min(lower_idx + 1, 10)
+        frac = (target_pct - lower_idx * step) / step
+        return pct_array[lower_idx] + frac * (pct_array[upper_idx] - pct_array[lower_idx])
+
+    # Request counts
+    completed = int(safe_float(find_col("Request Counts", "Successful", "")))
+    errors = int(safe_float(find_col("Request Counts", "Errored", "")))
+    total = int(safe_float(find_col("Request Counts", "Total", "")))
+
+    # TTFT (milliseconds)
+    ttft_median = safe_float(find_col("Time to First Token", "Successful ms", "Median"))
+    ttft_pct = parse_percentile_array(find_col("Time to First Token", "Successful ms", "Percentiles"))
+
+    # TPOT (milliseconds)
+    tpot_median = safe_float(find_col("Time per Output Token", "Successful ms", "Median"))
+    tpot_pct = parse_percentile_array(find_col("Time per Output Token", "Successful ms", "Percentiles"))
+
+    # ITL (milliseconds)
+    itl_median = safe_float(find_col("Inter Token Latency", "Successful ms", "Median"))
+    itl_pct = parse_percentile_array(find_col("Inter Token Latency", "Successful ms", "Percentiles"))
+
+    # Request latency (seconds → convert to ms for consistency)
+    req_lat_median = safe_float(find_col("Request Latency", "Successful Sec", "Median")) * 1000
+    req_lat_pct_raw = parse_percentile_array(find_col("Request Latency", "Successful Sec", "Percentiles"))
+    req_lat_pct = [v * 1000 for v in req_lat_pct_raw]
+
+    # Duration (seconds) for throughput calculation
+    duration = safe_float(find_col("Timings", "Duration", "Sec"), default=1.0)
+
+    error_rate = errors / total if total > 0 else 0.0
 
     return PhaseMetrics(
         phase=phase, cycle=cycle,
-        ttft_p50=ttft_ps[0], ttft_p95=ttft_ps[1], ttft_p99=ttft_ps[2],
-        itl_p50=itl_ps[0], itl_p95=itl_ps[1], itl_p99=itl_ps[2],
-        tpot_p50=tpot_ps[0], tpot_p95=tpot_ps[1], tpot_p99=tpot_ps[2],
-        req_latency_p50=lat_ps[0], req_latency_p95=lat_ps[1], req_latency_p99=lat_ps[2],
+        ttft_p50=ttft_median,
+        ttft_p95=interpolate_percentile(ttft_pct, 95),
+        ttft_p99=interpolate_percentile(ttft_pct, 99),
+        itl_p50=itl_median,
+        itl_p95=interpolate_percentile(itl_pct, 95),
+        itl_p99=interpolate_percentile(itl_pct, 99),
+        tpot_p50=tpot_median,
+        tpot_p95=interpolate_percentile(tpot_pct, 95),
+        tpot_p99=interpolate_percentile(tpot_pct, 99),
+        req_latency_p50=req_lat_median,
+        req_latency_p95=interpolate_percentile(req_lat_pct, 95),
+        req_latency_p99=interpolate_percentile(req_lat_pct, 99),
         ok_rps=completed / duration if duration > 0 else 0,
         err_rps=errors / duration if duration > 0 else 0,
-        error_rate=errors / total if total > 0 else 0,
+        error_rate=error_rate,
         completed=completed, errors=errors,
     )
 
@@ -1074,6 +1124,16 @@ def run_scenario(cfg, scenario):
                 pass
             time.sleep(10)
 
+        # Scenario 1: also wait for the batch-as-interactive job
+        if scenario == 1:
+            log("  Waiting for guidellm-batch job to complete...")
+            try:
+                kubectl(["wait", "--for=condition=complete", "job/guidellm-batch",
+                         f"--timeout={total_wait}s"],
+                        cfg.context, namespace, check=False)
+            except Exception:
+                pass
+
     # Collect results
     results_dir = collect_results(cfg, scenario, namespace)
 
@@ -1119,26 +1179,24 @@ def _aggregate_trials(trial_results):
                 phase_groups[key] = []
             phase_groups[key].append(phase)
 
+    def mean_and_ci(values):
+        """Return (mean, ci_95) for a list of values."""
+        n = len(values)
+        if n == 0:
+            return 0.0, 0.0
+        m = sum(values) / n
+        if n < 2:
+            return m, 0.0
+        variance = sum((v - m) ** 2 for v in values) / (n - 1)
+        stderr = math.sqrt(variance / n)
+        return m, stderr * 1.96
+
     aggregated_phases = []
     for (phase_name, cycle), phases in sorted(phase_groups.items()):
         n = len(phases)
         if n == 0:
             continue
 
-        def mean_and_ci(values):
-            """Return (mean, ci_95) for a list of values."""
-            m = sum(values) / n
-            if n < 2:
-                return m, 0.0
-            variance = sum((v - m) ** 2 for v in values) / (n - 1)
-            stderr = math.sqrt(variance / n)
-            ci = stderr * 1.96  # 95% CI
-            return m, ci
-
-        ttft_p99_vals = [p.ttft_p99 for p in phases]
-        tpot_p99_vals = [p.tpot_p99 for p in phases]
-
-        # Use mean for the aggregated phase
         agg = PhaseMetrics(
             phase=phase_name, cycle=cycle,
             ttft_p50=sum(p.ttft_p50 for p in phases) / n,
@@ -1171,14 +1229,15 @@ def _aggregate_trials(trial_results):
     # Attach variance metadata for reporting
     result._trial_count = len(trial_results)
     result._ttft_p99_ci = {}
+    result._tpot_p99_ci = {}
     for (phase_name, cycle), phases in phase_groups.items():
-        vals = [p.ttft_p99 for p in phases]
-        n = len(vals)
-        if n >= 2:
-            m = sum(vals) / n
-            variance = sum((v - m) ** 2 for v in vals) / (n - 1)
-            stderr = math.sqrt(variance / n)
-            result._ttft_p99_ci[f"{phase_name}-{cycle}"] = stderr * 1.96
+        key = f"{phase_name}-{cycle}"
+        _, ttft_ci = mean_and_ci([p.ttft_p99 for p in phases])
+        _, tpot_ci = mean_and_ci([p.tpot_p99 for p in phases])
+        if ttft_ci > 0:
+            result._ttft_p99_ci[key] = ttft_ci
+        if tpot_ci > 0:
+            result._tpot_p99_ci[key] = tpot_ci
 
     return result
 
@@ -1207,6 +1266,7 @@ def auto_calibrate_rate(cfg, namespace):
 
     Runs short bursts at increasing rates until error rate exceeds 5%
     or TTFT p99 exceeds 3x the baseline (lowest rate).
+    Returns the last rate before saturation was detected.
     """
     log("  Auto-calibrating saturating rate...")
     calibration_rates = [1, 5, 10, 15, 20, 25, 30, 40, 50]
@@ -1228,11 +1288,16 @@ def auto_calibrate_rate(cfg, namespace):
         )
         probe_cfg.results_dir.mkdir(parents=True, exist_ok=True)
 
-        # Run a short burst and check results
         start_interactive_traffic(probe_cfg, namespace)
-        time.sleep(20)
 
-        # Check for errors/high latency
+        # Wait for probe job to complete (15s burst + buffer)
+        try:
+            kubectl(["wait", "--for=condition=complete", "job/guidellm-interactive",
+                     "--timeout=45s"], cfg.context, namespace, check=False)
+        except Exception:
+            pass
+
+        # Check pod status
         try:
             gs = kubectl(["get", "pods", "-l", "job-name=guidellm-interactive",
                          "-o", "jsonpath={.items[0].status.phase}"],
@@ -1240,18 +1305,47 @@ def auto_calibrate_rate(cfg, namespace):
         except Exception:
             gs = "Unknown"
 
+        # Collect and parse probe results
+        probe_metrics = None
+        results_dir = collect_results(probe_cfg, 0, namespace)
+        if results_dir and results_dir.exists():
+            for csv_path in results_dir.glob("*.csv"):
+                m = parse_guidellm_csv(csv_path)
+                if m.completed > 0:
+                    probe_metrics = m
+                    break
+
+        # Clean up probe job
         kubectl(["delete", "job", "guidellm-interactive", "--ignore-not-found"],
                 cfg.context, namespace, check=False)
         time.sleep(5)
 
-        if gs == "Failed":
+        # Detect saturation via TTFT degradation or error rate
+        if probe_metrics and probe_metrics.completed > 0:
+            ttft_p99 = probe_metrics.ttft_p99
+            log(f"    Rate {rate}: TTFT p99={ttft_p99:.1f}ms, "
+                f"errors={probe_metrics.error_rate*100:.1f}%")
+
+            if baseline_ttft is None:
+                baseline_ttft = ttft_p99
+                log(f"    Baseline TTFT p99: {baseline_ttft:.1f}ms")
+            elif baseline_ttft > 0 and ttft_p99 > 3 * baseline_ttft:
+                saturating_rate = max(1, rate - calibration_rates[1])
+                log(f"    Saturating rate: {saturating_rate} req/s "
+                    f"(TTFT p99 {ttft_p99:.1f}ms > 3x baseline {baseline_ttft:.1f}ms)")
+                break
+
+            if probe_metrics.error_rate > 0.05:
+                saturating_rate = max(1, rate - calibration_rates[1])
+                log(f"    Saturating rate: {saturating_rate} req/s "
+                    f"(error rate {probe_metrics.error_rate*100:.1f}% > 5%)")
+                break
+        elif gs == "Failed":
             saturating_rate = max(1, rate - calibration_rates[1])
-            log(f"    Saturating rate found: {saturating_rate} req/s (probe failed at {rate})")
+            log(f"    Saturating rate: {saturating_rate} req/s (probe failed at {rate})")
             break
 
-    if baseline_ttft is None:
-        log(f"    Using max probed rate as saturating rate: {saturating_rate} req/s")
-
+    log(f"    Final saturating rate: {saturating_rate} req/s")
     return saturating_rate
 
 
@@ -1368,6 +1462,8 @@ def main():
         description="Batch Gateway Benchmark Orchestrator"
     )
     parser.add_argument("--context", required=True, help="kubectl context")
+    parser.add_argument("--namespace", default=None,
+                        help="Override namespace (default: batch-bench-s{scenario})")
     parser.add_argument("--scenarios", type=int, nargs="+", default=[2],
                         help="Scenarios to run (default: [2])")
     parser.add_argument("--model",
@@ -1434,6 +1530,9 @@ def main():
 
     args = parser.parse_args()
     args.results_dir.mkdir(parents=True, exist_ok=True)
+
+    global _NAMESPACE_OVERRIDE
+    _NAMESPACE_OVERRIDE = args.namespace
 
     cfg = BenchmarkConfig(
         context=args.context,

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -201,6 +201,7 @@ def load_sharegpt_dataset(num_requests: int, seed: int):
 
     print("  Loading ShareGPT dataset from HuggingFace...", file=sys.stderr)
     ds = load_dataset("anon8231489123/ShareGPT_Vicuna_unfiltered",
+                      data_files="ShareGPT_V3_unfiltered_cleaned_split.json",
                       split="train", trust_remote_code=True)
 
     import random

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -280,11 +280,11 @@ def generate_jsonl(
             if data_source == "sharegpt":
                 system_prompt, user_prompt = sharegpt_data[i]
             elif data_source == "synthetic":
-                system_prompt = system_prompts[i % num_system_prompts]
+                system_prompt = system_prompts[i % num_system_prompts] if num_system_prompts > 0 else ""
                 isl_tokens = sample_from_distribution(rng, isl_distribution, isl_mean, isl_stdev, min_val=16, max_val=isl_max)
                 user_prompt = generate_synthetic_prompt(isl_tokens, seed + i)
             else:
-                system_prompt = system_prompts[i % num_system_prompts]
+                system_prompt = system_prompts[i % num_system_prompts] if num_system_prompts > 0 else ""
                 # Sample ISL for this request (user prompt portion)
                 isl_tokens = sample_from_distribution(rng, isl_distribution, isl_mean, isl_stdev, min_val=16, max_val=isl_max)
                 target_chars = isl_tokens * 4

--- a/benchmarks/generate_prompts.py
+++ b/benchmarks/generate_prompts.py
@@ -1,27 +1,43 @@
 #!/usr/bin/env python3
 """
-Generate JSONL batch input files with Faker-based prompts and system-prompt diversity.
+Generate JSONL batch input files with pluggable data sources.
+
+Supports three data sources:
+- faker: Faker-based random text with system-prompt diversity (default)
+- synthetic: inference-perf style deterministic token generation (reproducible)
+- sharegpt: Real conversations from HuggingFace ShareGPT dataset
 
 Produces OpenAI-compatible batch input files with configurable:
 - Number of requests
 - Number of distinct system prompts (for prefix-cache evaluation)
-- Prompt token length
+- Prompt token length / ISL/OSL distributions
 - Model name
 
 Usage:
+    # Faker-based (default):
     python3 benchmarks/generate_prompts.py \
         --num-requests 1000 \
-        --num-system-prompts 5 \
-        --prompt-tokens 256 \
         --model "Qwen/Qwen3-8B" \
         --output job-a.jsonl
 
-    # Generate all 3 benchmark jobs at once:
+    # inference-perf synthetic:
+    python3 benchmarks/generate_prompts.py \
+        --data-source synthetic \
+        --num-requests 1000 \
+        --prompt-tokens 512 \
+        --model "Qwen/Qwen3-8B" \
+        --output job-a.jsonl
+
+    # ShareGPT real dataset:
+    python3 benchmarks/generate_prompts.py \
+        --data-source sharegpt \
+        --num-requests 1000 \
+        --model "Qwen/Qwen3-8B" \
+        --output job-a.jsonl
+
+    # Multi-job mode:
     python3 benchmarks/generate_prompts.py \
         --num-requests 1000 \
-        --num-system-prompts 5 \
-        --prompt-tokens 256 \
-        --model "Qwen/Qwen3-8B" \
         --multi-job \
         --output-dir benchmarks/results/
 """
@@ -117,6 +133,78 @@ def generate_user_prompt(fake: Faker, target_chars: int) -> str:
     return text[:target_chars].strip()
 
 
+def generate_synthetic_prompt(token_count: int, seed: int) -> str:
+    """Generate a deterministic prompt of exact token count (inference-perf style).
+
+    Uses a repeating word pattern that tokenizes predictably (~1 token per word).
+    This aligns with the llm-d ecosystem methodology for reproducible benchmarks.
+    """
+    words = ["hello", "world", "the", "quick", "brown", "fox", "jumps", "over",
+             "lazy", "dog", "alpha", "beta", "gamma", "delta", "epsilon"]
+    import random
+    rng = random.Random(seed)
+    rng.shuffle(words)
+    prompt_words = []
+    for i in range(token_count):
+        prompt_words.append(words[i % len(words)])
+    return " ".join(prompt_words)
+
+
+def load_sharegpt_dataset(num_requests: int, seed: int):
+    """Load conversations from the ShareGPT dataset on HuggingFace.
+
+    Returns list of (system_prompt, user_prompt) tuples.
+    Requires: pip install datasets
+    """
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("ERROR: 'datasets' package required for sharegpt source. "
+              "Install with: pip install datasets", file=sys.stderr)
+        sys.exit(1)
+
+    print("  Loading ShareGPT dataset from HuggingFace...", file=sys.stderr)
+    ds = load_dataset("anon8231489123/ShareGPT_Vicuna_unfiltered",
+                      split="train", trust_remote_code=True)
+
+    import random
+    rng = random.Random(seed)
+    indices = list(range(len(ds)))
+    rng.shuffle(indices)
+
+    conversations = []
+    for idx in indices:
+        if len(conversations) >= num_requests:
+            break
+        item = ds[idx]
+        convs = item.get("conversations", [])
+        if len(convs) < 2:
+            continue
+
+        system = ""
+        user = ""
+        for msg in convs:
+            role = msg.get("from", "")
+            value = msg.get("value", "")
+            if role == "system" and not system:
+                system = value
+            elif role == "human" and not user:
+                user = value
+            if user:
+                break
+
+        if user:
+            if not system:
+                system = "You are a helpful assistant."
+            conversations.append((system, user))
+
+    if len(conversations) < num_requests:
+        print(f"  WARNING: Only found {len(conversations)} usable conversations "
+              f"(requested {num_requests})", file=sys.stderr)
+
+    return conversations
+
+
 def generate_jsonl(
     num_requests: int,
     num_system_prompts: int,
@@ -125,19 +213,34 @@ def generate_jsonl(
     seed: int,
     output_path: Path,
     id_prefix: str = "req",
+    data_source: str = "faker",
 ):
-    """Generate a JSONL batch input file."""
-    fake = Faker()
-    fake.seed_instance(seed)
+    """Generate a JSONL batch input file using the specified data source."""
+    # Load data based on source
+    sharegpt_data = None
+    if data_source == "sharegpt":
+        sharegpt_data = load_sharegpt_dataset(num_requests, seed)
+        num_requests = min(num_requests, len(sharegpt_data))
 
-    system_prompts = generate_system_prompts(num_system_prompts, seed)
-    # Approximate: 1 token ≈ 4 characters
+    fake = None
+    system_prompts = None
+    if data_source in ("faker", "synthetic"):
+        fake = Faker()
+        fake.seed_instance(seed)
+        system_prompts = generate_system_prompts(num_system_prompts, seed)
+
     target_chars = prompt_tokens * 4
 
     with open(output_path, "w") as f:
         for i in range(num_requests):
-            system_prompt = system_prompts[i % num_system_prompts]
-            user_prompt = generate_user_prompt(fake, target_chars)
+            if data_source == "sharegpt":
+                system_prompt, user_prompt = sharegpt_data[i]
+            elif data_source == "synthetic":
+                system_prompt = system_prompts[i % num_system_prompts]
+                user_prompt = generate_synthetic_prompt(prompt_tokens, seed + i)
+            else:
+                system_prompt = system_prompts[i % num_system_prompts]
+                user_prompt = generate_user_prompt(fake, target_chars)
 
             line = {
                 "custom_id": f"{id_prefix}-{i:04d}",
@@ -157,6 +260,7 @@ def generate_jsonl(
                 print(f"  Generated {i + 1}/{num_requests}", file=sys.stderr)
 
     print(f"Generated {num_requests} requests -> {output_path}", file=sys.stderr)
+    print(f"  Data source: {data_source}", file=sys.stderr)
 
 
 def load_profile():
@@ -175,6 +279,10 @@ def main():
     parser = argparse.ArgumentParser(
         description="Generate JSONL batch input files for benchmarking"
     )
+    parser.add_argument("--data-source",
+                        choices=["faker", "synthetic", "sharegpt"],
+                        default=prompt_cfg.get("data_source", "faker"),
+                        help="Data source for prompt generation (default: faker)")
     parser.add_argument("--num-requests", type=int,
                         default=prompt_cfg.get("num_requests", 1000),
                         help="Number of requests per file (default: 1000)")
@@ -218,6 +326,7 @@ def main():
                 seed=args.seed + i,  # Different seed per job for variety
                 output_path=output_path,
                 id_prefix=name,
+                data_source=args.data_source,
             )
         print(f"\nAll jobs generated in {args.output_dir}/", file=sys.stderr)
         print("Submit with completion_window: job-a=30m, job-b=2h, job-c=24h", file=sys.stderr)
@@ -232,6 +341,7 @@ def main():
             model=args.model,
             seed=args.seed,
             output_path=args.output,
+            data_source=args.data_source,
         )
 
 

--- a/benchmarks/profiles/default.yaml
+++ b/benchmarks/profiles/default.yaml
@@ -9,6 +9,7 @@ benchmark:
   burst_seconds: 90
   idle_seconds: 90
   cycles: 3
+  warmup_cycles: 1
   batch_size: 1000
   num_jobs: 3
   model: Qwen/Qwen3-8B


### PR DESCRIPTION
## Summary

* Add scenario 1 orchestrator support — launches `guidellm-batch` as a second guidellm instance sending batch-equivalent prompts as regular requests (demonstrates latency degradation without batch-gateway)
* Implement full metrics collection — parse guidellm CSVs for TTFT/ITL/TPOT at p50/p95/p99, add Prometheus query functions for GPU utilization and running/waiting requests
* Generate side-by-side HTML report — latency comparison table, TTFT/TPOT bar charts per scenario, batch timeline chart
* Emit structured `results.json` per run — inference-perf compatible schema with per-phase latency, throughput, error rates, and batch timelines
* Add pluggable data generation — `--data-source` flag supporting `faker` (default), `synthetic` (inference-perf style deterministic), and `sharegpt` (HuggingFace real conversations)
* Add rate sweep mode — `--rate-sweep` runs each scenario across a range of request rates with auto-calibration to discover saturating rate
* Add multi-trial support — `--trials N` runs each scenario N times and reports mean with 95% confidence intervals
* Add `--gpu-count`, `--max-model-len`, `--warmup` CLI flags for full configurability

## Part of #491 (PR 2 of 4)

Baseline scenarios and metrics infrastructure for comparing dispatch strategies.

## Test plan

* `python3 -c "import ast; ast.parse(open('benchmarks/benchmark.py').read())"` — compiles
* `python3 -c "import ast; ast.parse(open('benchmarks/generate_prompts.py').read())"` — compiles
* `make benchmark-local` — full e2e on Kind: setup, generate, benchmark, report, results.json
* New `results.json` emitted alongside report and metadata
* Warmup cycle labeling visible in output (`3 cycles (1 warmup)`)


Made with [Cursor](https://cursor.com)