### PR TITLE
fix: use llm-d chart registry in deploy demo

### DIFF
--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -578,8 +578,7 @@ install_batch_gateway() {
 
     local chart version_args=()
     if [ -n "${BATCH_RELEASE_VERSION}" ]; then
-        # TODO: pre-graduation location; update to ghcr.io/llm-d in the next release
-        chart="oci://ghcr.io/llm-d-incubation/charts/batch-gateway"
+        chart="oci://ghcr.io/llm-d/charts/batch-gateway"
         version_args=(--version "${BATCH_RELEASE_VERSION#v}")
     elif [ "${BATCH_DEV_VERSION}" = "local" ]; then
         local repo_root


### PR DESCRIPTION
## Why is this PR needed?

The deploy demo still used the pre-graduation `llm-d-incubation` OCI location for the batch-gateway release chart. That left the scripted install path out of sync with the current published chart location.

## What does this PR do?

- updates `examples/deploy-demo/common.sh` to install the release chart from `oci://ghcr.io/llm-d/charts/batch-gateway`
- removes the now-stale TODO about switching registries in a future release

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

Manual checks:
- verified no other `batch-gateway` chart references in this repo still use `ghcr.io/llm-d-incubation/charts/batch-gateway`
- verified `examples/deploy-demo/common.sh` passes `bash -n`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

- Related to [llm-d/llm-d-batch-gateway#501](https://github.com/llm-d/llm-d-batch-gateway/issues/501)