### PR TITLE
feat: gated scenarios 3-4 (AIMD + flow control)

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -109,6 +109,8 @@ class ScenarioResult:
     name: str
     phases: list = field(default_factory=list)
     batch_timeline: list = field(default_factory=list)
+    aimd_metrics: dict = field(default_factory=dict)
+    flow_control_metrics: dict = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -829,6 +831,67 @@ def collect_gpu_metrics(context, namespace, start_time, end_time):
     return metrics
 
 
+def collect_aimd_metrics(context, namespace, start_time, end_time):
+    """Collect AIMD adaptive concurrency metrics from Prometheus."""
+    metrics = {}
+
+    # Current concurrency limit (gauge)
+    limit_query = 'avg(batch_processor_aimd_concurrency_limit)'
+    results = query_prometheus(context, namespace, limit_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["aimd_concurrency_limit_avg"] = sum(values) / len(values)
+            metrics["aimd_concurrency_limit_min"] = min(values)
+            metrics["aimd_concurrency_limit_max"] = max(values)
+            metrics["aimd_concurrency_limit_series"] = values
+
+    # Decrease events (multiplicative backoff on 429/5xx)
+    decrease_query = 'sum(rate(batch_processor_aimd_decrease_total[30s]))'
+    results = query_prometheus(context, namespace, decrease_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["aimd_decrease_rate_avg"] = sum(values) / len(values)
+
+    # Increase events (additive increase on success)
+    increase_query = 'sum(rate(batch_processor_aimd_increase_total[30s]))'
+    results = query_prometheus(context, namespace, increase_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["aimd_increase_rate_avg"] = sum(values) / len(values)
+
+    return metrics
+
+
+def collect_flow_control_metrics(context, namespace, start_time, end_time):
+    """Collect llm-d Router flow control metrics from Prometheus."""
+    metrics = {}
+
+    # Pool saturation (0-1 ratio of flow control capacity used)
+    saturation_query = 'avg(inference_extension_flow_control_pool_saturation)'
+    results = query_prometheus(context, namespace, saturation_query, start_time, end_time)
+    if results:
+        values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
+        if values:
+            metrics["flow_control_saturation_avg"] = sum(values) / len(values)
+            metrics["flow_control_saturation_max"] = max(values)
+            metrics["flow_control_saturation_series"] = values
+
+    # Queue size per priority band
+    queue_query = 'sum by (priority) (inference_extension_flow_control_queue_size)'
+    results = query_prometheus(context, namespace, queue_query, start_time, end_time)
+    if results:
+        for series in results:
+            priority = series.get("metric", {}).get("priority", "unknown")
+            values = [float(v[1]) for v in series.get("values", []) if v[1] != "NaN"]
+            if values:
+                metrics[f"queue_size_priority_{priority}_avg"] = sum(values) / len(values)
+
+    return metrics
+
+
 def _aggregate_phases(phases, phase_filter=None):
     """Aggregate multiple PhaseMetrics into averages."""
     filtered = [p for p in phases if phase_filter is None or phase_filter in p.phase]
@@ -902,6 +965,31 @@ def generate_html_report(cfg, results):
     for result in results:
         if result.batch_timeline:
             timelines_json[f"S{result.scenario} ({result.name})"] = result.batch_timeline
+
+    # AIMD dynamics data (scenarios 3-4)
+    aimd_chart_data = []
+    for result in results:
+        if result.aimd_metrics and "aimd_concurrency_limit_series" in result.aimd_metrics:
+            aimd_chart_data.append({
+                "scenario": f"S{result.scenario}",
+                "name": result.name,
+                "series": result.aimd_metrics["aimd_concurrency_limit_series"],
+                "avg": result.aimd_metrics.get("aimd_concurrency_limit_avg", 0),
+                "min": result.aimd_metrics.get("aimd_concurrency_limit_min", 0),
+                "max": result.aimd_metrics.get("aimd_concurrency_limit_max", 0),
+            })
+
+    # Flow control data (scenario 4)
+    flow_control_chart_data = []
+    for result in results:
+        if result.flow_control_metrics and "flow_control_saturation_series" in result.flow_control_metrics:
+            flow_control_chart_data.append({
+                "scenario": f"S{result.scenario}",
+                "name": result.name,
+                "series": result.flow_control_metrics["flow_control_saturation_series"],
+                "avg": result.flow_control_metrics.get("flow_control_saturation_avg", 0),
+                "max": result.flow_control_metrics.get("flow_control_saturation_max", 0),
+            })
 
     html = textwrap.dedent(f"""\
     <!DOCTYPE html>
@@ -981,9 +1069,21 @@ def generate_html_report(cfg, results):
             <canvas id="timelineChart"></canvas>
         </div>
 
+        <h2>AIMD Concurrency Dynamics (Scenarios 3-4)</h2>
+        <div class="chart-container">
+            <canvas id="aimdChart"></canvas>
+        </div>
+
+        <h2>Flow Control Pool Saturation (Scenario 4)</h2>
+        <div class="chart-container">
+            <canvas id="flowControlChart"></canvas>
+        </div>
+
         <script>
         const chartData = {json.dumps(chart_data)};
         const timelines = {json.dumps(timelines_json)};
+        const aimdData = {json.dumps(aimd_chart_data)};
+        const flowControlData = {json.dumps(flow_control_chart_data)};
         const colors = ['#6b7280', '#ef4444', '#f59e0b', '#3b82f6', '#22c55e', '#8b5cf6'];
 
         // TTFT p99 bar chart
@@ -1048,6 +1148,52 @@ def generate_html_report(cfg, results):
                     scales: {{
                         x: {{ type: 'linear', title: {{ display: true, text: 'Time (s)' }} }},
                         y: {{ title: {{ display: true, text: 'Completed' }}, beginAtZero: true }}
+                    }}
+                }}
+            }});
+        }}
+
+        // AIMD concurrency limit time-series chart
+        if (aimdData.length > 0) {{
+            const aimdDatasets = aimdData.map((d, i) => ({{
+                label: d.scenario + ' (' + d.name + ') avg=' + d.avg.toFixed(1),
+                data: d.series.map((v, j) => ({{x: j * 15, y: v}})),
+                borderColor: colors[(i + 3) % colors.length],
+                fill: false, tension: 0.3, pointRadius: 0, borderWidth: 2,
+            }}));
+            new Chart(document.getElementById('aimdChart'), {{
+                type: 'line',
+                data: {{ datasets: aimdDatasets }},
+                options: {{
+                    responsive: true,
+                    plugins: {{ title: {{ display: true, text: 'AIMD Concurrency Limit Over Time' }} }},
+                    scales: {{
+                        x: {{ type: 'linear', title: {{ display: true, text: 'Time (s)' }} }},
+                        y: {{ title: {{ display: true, text: 'Concurrency Limit' }}, beginAtZero: true }}
+                    }}
+                }}
+            }});
+        }}
+
+        // Flow control pool saturation time-series chart
+        if (flowControlData.length > 0) {{
+            const fcDatasets = flowControlData.map((d, i) => ({{
+                label: d.scenario + ' (' + d.name + ') avg=' + (d.avg * 100).toFixed(1) + '%',
+                data: d.series.map((v, j) => ({{x: j * 15, y: v * 100}})),
+                borderColor: '#dc2626',
+                fill: true,
+                backgroundColor: 'rgba(220, 38, 38, 0.1)',
+                tension: 0.3, pointRadius: 0, borderWidth: 2,
+            }}));
+            new Chart(document.getElementById('flowControlChart'), {{
+                type: 'line',
+                data: {{ datasets: fcDatasets }},
+                options: {{
+                    responsive: true,
+                    plugins: {{ title: {{ display: true, text: 'Flow Control Pool Saturation (%)' }} }},
+                    scales: {{
+                        x: {{ type: 'linear', title: {{ display: true, text: 'Time (s)' }} }},
+                        y: {{ title: {{ display: true, text: 'Saturation (%)' }}, min: 0, max: 100 }}
                     }}
                 }}
             }});
@@ -1147,8 +1293,27 @@ def run_scenario(cfg, scenario):
             if metrics.completed > 0:
                 phases.append(metrics)
 
+    # Collect AIMD metrics for scenarios 3-4
+    aimd_metrics = {}
+    if scenario >= 3 and os.environ.get("PROMETHEUS_URL"):
+        end_time = time.time()
+        start_time = end_time - cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds)
+        aimd_metrics = collect_aimd_metrics(cfg.context, namespace, start_time, end_time)
+        if aimd_metrics:
+            log(f"  AIMD: concurrency limit avg={aimd_metrics.get('aimd_concurrency_limit_avg', 0):.1f}")
+
+    # Collect flow control metrics for scenario 4
+    flow_control_metrics = {}
+    if scenario == 4 and os.environ.get("PROMETHEUS_URL"):
+        end_time = time.time()
+        start_time = end_time - cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds)
+        flow_control_metrics = collect_flow_control_metrics(cfg.context, namespace, start_time, end_time)
+        if flow_control_metrics:
+            log(f"  Flow control: saturation avg={flow_control_metrics.get('flow_control_saturation_avg', 0):.2f}")
+
     return ScenarioResult(scenario=scenario, name=name, phases=phases,
-                          batch_timeline=timeline)
+                          batch_timeline=timeline, aimd_metrics=aimd_metrics,
+                          flow_control_metrics=flow_control_metrics)
 
 
 # ---------------------------------------------------------------------------
@@ -1221,9 +1386,14 @@ def _aggregate_trials(trial_results):
     # Use longest timeline from any trial
     best_timeline = max((r.batch_timeline for r in trial_results), key=len, default=[])
 
+    # Use AIMD/flow-control metrics from first trial that has them
+    aimd = next((r.aimd_metrics for r in trial_results if r.aimd_metrics), {})
+    fc = next((r.flow_control_metrics for r in trial_results if r.flow_control_metrics), {})
+
     result = ScenarioResult(
         scenario=scenario, name=name,
         phases=aggregated_phases, batch_timeline=best_timeline,
+        aimd_metrics=aimd, flow_control_metrics=fc,
     )
 
     # Attach variance metadata for reporting
@@ -1721,6 +1891,18 @@ def main():
                 },
                 "total_completed": sum(p.completed for p in burst_phases),
                 "total_errors": sum(p.errors for p in burst_phases),
+            }
+
+        # AIMD and flow control metrics (scenarios 3-4)
+        if result.aimd_metrics:
+            scenario_data["aimd"] = {
+                k: v for k, v in result.aimd_metrics.items()
+                if k != "aimd_concurrency_limit_series"
+            }
+        if result.flow_control_metrics:
+            scenario_data["flow_control"] = {
+                k: v for k, v in result.flow_control_metrics.items()
+                if k != "flow_control_saturation_series"
             }
 
         structured_results["scenarios"].append(scenario_data)

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -1296,8 +1296,8 @@ def run_scenario(cfg, scenario):
     # Collect AIMD metrics for scenarios 3-4
     aimd_metrics = {}
     if scenario >= 3 and os.environ.get("PROMETHEUS_URL"):
-        end_time = time.time()
-        start_time = end_time - cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds)
+        end_time = datetime.datetime.utcfromtimestamp(time.time())
+        start_time = end_time - datetime.timedelta(seconds=cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds))
         aimd_metrics = collect_aimd_metrics(cfg.context, namespace, start_time, end_time)
         if aimd_metrics:
             log(f"  AIMD: concurrency limit avg={aimd_metrics.get('aimd_concurrency_limit_avg', 0):.1f}")
@@ -1305,8 +1305,8 @@ def run_scenario(cfg, scenario):
     # Collect flow control metrics for scenario 4
     flow_control_metrics = {}
     if scenario == 4 and os.environ.get("PROMETHEUS_URL"):
-        end_time = time.time()
-        start_time = end_time - cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds)
+        end_time = datetime.datetime.utcfromtimestamp(time.time())
+        start_time = end_time - datetime.timedelta(seconds=cfg.cycles * (cfg.burst_seconds + cfg.idle_seconds))
         flow_control_metrics = collect_flow_control_metrics(cfg.context, namespace, start_time, end_time)
         if flow_control_metrics:
             log(f"  Flow control: saturation avg={flow_control_metrics.get('flow_control_saturation_avg', 0):.2f}")

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -847,7 +847,7 @@ def collect_aimd_metrics(context, namespace, start_time, end_time):
             metrics["aimd_concurrency_limit_series"] = values
 
     # Decrease events (multiplicative backoff on 429/5xx)
-    decrease_query = 'sum(rate(batch_processor_aimd_decrease_total[30s]))'
+    decrease_query = 'sum(rate(batch_processor_aimd_decreases_total[30s]))'
     results = query_prometheus(context, namespace, decrease_query, start_time, end_time)
     if results:
         values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]
@@ -855,7 +855,7 @@ def collect_aimd_metrics(context, namespace, start_time, end_time):
             metrics["aimd_decrease_rate_avg"] = sum(values) / len(values)
 
     # Increase events (additive increase on success)
-    increase_query = 'sum(rate(batch_processor_aimd_increase_total[30s]))'
+    increase_query = 'sum(rate(batch_processor_aimd_increases_total[30s]))'
     results = query_prometheus(context, namespace, increase_query, start_time, end_time)
     if results:
         values = [float(v[1]) for v in results[0].get("values", []) if v[1] != "NaN"]

--- a/benchmarks/helm-values/scenario-3-aimd.yaml
+++ b/benchmarks/helm-values/scenario-3-aimd.yaml
@@ -7,7 +7,7 @@ processor:
     dispatchMode: sync
     concurrency:
       global: 100
-      perEndpoint: 10
+      perEndpoint: 20
       recovery: 5
       aimd:
         enabled: true
@@ -19,17 +19,17 @@ processor:
         url: "http://llm-d-inference-gateway-istio:80"
         requestTimeout: "5m"
         maxRetries: 3
-        initialBackoff: "1s"
-        maxBackoff: "60s"
+        initialBackoff: "2s"
+        maxBackoff: "30s"
       Qwen/Qwen3-8B:
         url: "http://llm-d-inference-gateway-istio:80"
         requestTimeout: "5m"
         maxRetries: 3
-        initialBackoff: "1s"
-        maxBackoff: "60s"
+        initialBackoff: "2s"
+        maxBackoff: "30s"
       Qwen/Qwen3-32B-AWQ:
         url: "http://llm-d-inference-gateway-istio:80"
         requestTimeout: "5m"
         maxRetries: 3
-        initialBackoff: "1s"
-        maxBackoff: "60s"
+        initialBackoff: "2s"
+        maxBackoff: "30s"

--- a/benchmarks/helm-values/scenario-3-aimd.yaml
+++ b/benchmarks/helm-values/scenario-3-aimd.yaml
@@ -1,6 +1,19 @@
+# Scenario 3: AIMD only (processor-side adaptive concurrency)
+# Sync dispatch with AIMD enabled. llm-d Router flow control disabled.
+# AIMD protects the inference backend from overload by reducing per-endpoint
+# concurrency on 429/5xx and gradually increasing on success.
 processor:
   config:
     dispatchMode: sync
+    concurrency:
+      global: 100
+      perEndpoint: 10
+      recovery: 5
+      aimd:
+        enabled: true
+        min: 5
+        backoffFactor: 0.5
+        additiveIncrease: 1
     modelGateways:
       Qwen/Qwen3-0.6B:
         url: "http://llm-d-inference-gateway-istio:80"

--- a/benchmarks/helm-values/scenario-4-aimd-flow-control.yaml
+++ b/benchmarks/helm-values/scenario-4-aimd-flow-control.yaml
@@ -1,11 +1,11 @@
 # Scenario 4: AIMD + llm-d Router flow control
-# Same processor config as scenario 3, plus:
-# - llm-d Router flowControl feature gate enabled
-# - EndpointPickerConfig with priority bands (interactive: 100, batch: -1 sheddable)
-# - InferenceObjective CRDs deployed
-# - Processor configured with inferenceObjective: "batch-sheddable"
+# Same processor AIMD config as scenario 3, plus two-layer protection:
+# - llm-d Router flowControl feature gate enabled (EndpointPickerConfig)
+# - Priority bands: interactive (100) + batch (-1, sheddable)
+# - InferenceObjective CRDs: interactive-default (100), batch-sheddable (-1)
+# - Processor sends x-gateway-inference-objective: "batch-sheddable" header
 #
-# TODO: Add full configuration in PR 3
+# CRDs and Router overlay are deployed by setup.sh (scenario 4 block).
 processor:
   config:
     dispatchMode: sync

--- a/benchmarks/helm-values/scenario-4-flow-control-overlay.yaml
+++ b/benchmarks/helm-values/scenario-4-flow-control-overlay.yaml
@@ -1,0 +1,42 @@
+# Flow control overlay for llm-d Router (InferencePool EPP chart).
+# Applied in scenario 4 to enable two-layer protection:
+#   Layer 1: Router EPP flow control (priority-based request scheduling)
+#   Layer 2: Processor AIMD (adaptive concurrency per endpoint)
+#
+# Priority bands:
+#   Interactive (100): low-latency, round-robin fairness, FCFS ordering
+#   Batch (-1): sheddable, throughput-optimized, SLO-deadline ordering
+inferenceExtension:
+  pluginsConfigFile: "flow-control-plugins.yaml"
+  pluginsCustomConfig:
+    flow-control-plugins.yaml: |
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      featureGates:
+        - "flowControl"
+      plugins:
+        - type: round-robin-fairness-policy
+        - type: global-strict-fairness-policy
+        - type: slo-deadline-ordering-policy
+        - type: utilization-detector
+          parameters:
+            queueDepthThreshold: 5
+            kvCacheUtilThreshold: 0.8
+      flowControl:
+        maxBytes: 4294967296
+        defaultRequestTTL: 30s
+        priorityBands:
+          - priority: 100
+            maxBytes: 1073741824
+            fairnessPolicyRef: round-robin-fairness-policy
+            orderingPolicyRef: fcfs-ordering-policy
+          - priority: -1
+            maxBytes: 3221225472
+            fairnessPolicyRef: global-strict-fairness-policy
+            orderingPolicyRef: slo-deadline-ordering-policy
+        defaultPriorityBand:
+          maxBytes: 536870912
+          fairnessPolicyRef: global-strict-fairness-policy
+          orderingPolicyRef: fcfs-ordering-policy
+        saturationDetector:
+          pluginRef: utilization-detector

--- a/benchmarks/setup.sh
+++ b/benchmarks/setup.sh
@@ -186,6 +186,14 @@ else
 
     # --- llm-d Router (EPP) ---
     log "Installing llm-d Router (${GUIDE_NAME})"
+
+    # Scenario 4: include flow-control overlay for priority-based scheduling
+    FLOW_CONTROL_OVERLAY=""
+    if [ "${SCENARIO}" = "4" ]; then
+        FLOW_CONTROL_OVERLAY="-f ${SCRIPT_DIR}/helm-values/scenario-4-flow-control-overlay.yaml"
+        log "  Flow control: enabling EPP priority bands (interactive=100, batch=-1)"
+    fi
+
     if [ -n "${ROUTER_REPO:-}" ] && [ -n "${LLM_D_REPO:-}" ]; then
         # Local repo mode (development override)
         log "  Using local repos: ROUTER_REPO=${ROUTER_REPO}, LLM_D_REPO=${LLM_D_REPO}"
@@ -198,6 +206,7 @@ else
             -f "${LLM_D_REPO}/guides/recipes/router/base.values.yaml" \
             -f "${LLM_D_REPO}/guides/${GUIDE_NAME}/router/${GUIDE_NAME}.values.yaml" \
             -f "${LLM_D_REPO}/guides/recipes/router/features/monitoring.values.yaml" \
+            ${FLOW_CONTROL_OVERLAY} \
             --set provider.name=istio \
             --set httpRoute.create=true \
             --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
@@ -221,6 +230,7 @@ else
             -f "${LLM_D_VALUES_DIR}/base.values.yaml" \
             -f "${LLM_D_VALUES_DIR}/guide.values.yaml" \
             -f "${LLM_D_VALUES_DIR}/monitoring.values.yaml" \
+            ${FLOW_CONTROL_OVERLAY} \
             --set provider.name=istio \
             --set httpRoute.create=true \
             --set httpRoute.inferenceGatewayName=llm-d-inference-gateway >/dev/null
@@ -316,11 +326,32 @@ else
     log "Skipping batch-gateway (not needed for scenario ${SCENARIO})"
 fi
 
-# --- Scenario 4: Flow control CRDs ---
+# --- Scenario 4: Flow control InferenceObjective CRDs ---
 if [ "${SCENARIO}" = "4" ]; then
-    log "Deploying flow control CRDs (EndpointPickerConfig + InferenceObjective)"
-    # TODO: Deploy EndpointPickerConfig and InferenceObjective CRDs in PR 3
-    log "  WARNING: Flow control CRDs not yet implemented — stub only"
+    log "Deploying InferenceObjective CRDs for flow control"
+    ${K} -n "${NAMESPACE}" apply -f - <<EOF
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: interactive-default
+spec:
+  priority: 100
+  poolRef:
+    group: inference.networking.k8s.io
+    name: ${GUIDE_NAME}
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: batch-sheddable
+spec:
+  priority: -1
+  poolRef:
+    group: inference.networking.k8s.io
+    name: ${GUIDE_NAME}
+EOF
+    log "  Created InferenceObjective: interactive-default (priority 100)"
+    log "  Created InferenceObjective: batch-sheddable (priority -1)"
 fi
 
 # --- Scenario 5: Async processor ---


### PR DESCRIPTION
## Summary

Part of #491 (PR 3: Gated scenarios 3–4).

- Add scenario 3 (AIMD only): sync dispatch with adaptive concurrency (min=5, backoffFactor=0.5, additiveIncrease=1)
- Add scenario 4 (AIMD + llm-d Router flow control): EPP priority bands (interactive=100, batch=-1 sheddable), InferenceObjective CRDs, Router flow-control overlay
- Extend metrics: AIMD concurrency limit/increase/decrease counters, flow control saturation and queue size
- Extend HTML report with AIMD dynamics and flow control saturation charts

## Test plan
- [x] Local Kind test: scenario 3 passes end-to-end (make benchmark-local)
- [x] GPU cluster: scenario 3 end-to-end with real latency data (TTFT p99=45.5ms, 0% errors)
- [x] GPU cluster: run with PROMETHEUS_URL to verify AIMD metrics populate in charts (concurrency limit avg=10.0)