### PR TITLE
fix: return errShutdown when SIGTERM cancels all dispatched requests

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -425,10 +425,11 @@ func (p *Processor) processModel(
 	endpointSem := epLimit.sem
 
 	var (
-		wg              sync.WaitGroup
-		errOnce         sync.Once
-		modelErr        error
-		dispatchedCount int
+		wg                sync.WaitGroup
+		errOnce           sync.Once
+		modelErr          error
+		dispatchedCount   int
+		shutdownCancelled atomic.Int32
 	)
 
 dispatch:
@@ -532,6 +533,10 @@ dispatch:
 				return
 			}
 
+			if result.Error != nil && mainCtx.Err() != nil {
+				shutdownCancelled.Add(1)
+			}
+
 			progress.record(requestAbortCtx, result.isSuccess())
 
 			lineBytes, marshalErr := json.Marshal(result)
@@ -593,10 +598,12 @@ dispatch:
 		returnErr = modelErr
 
 	default:
-		if mainCtx.Err() != nil && len(undispatched) > 0 {
+		if mainCtx.Err() != nil && (len(undispatched) > 0 || shutdownCancelled.Load() > 0) {
 			// Pod shutdown (SIGTERM): main processor context is cancelled.
-			// Do not drain here — startup recovery or the re-enqueued worker
-			// will process these entries from scratch.
+			// Do not drain here — the re-enqueued worker will process the
+			// entire job from scratch. The undispatched check catches SIGTERM
+			// arriving during dispatch; shutdownCancelled catches SIGTERM
+			// cancelling already-dispatched in-flight requests.
 			returnErr = errShutdown
 		} else if requestAbortCtx.Err() != nil && len(undispatched) > 0 {
 			// Sibling model abort: requestAbortCtx was cancelled by another

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -1087,6 +1087,56 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 	}
 }
 
+// TestProcessModel_SIGTERMCancelsAllDispatched verifies that when SIGTERM arrives after all
+// requests have been dispatched as goroutines, processModel returns errShutdown so the job
+// is re-enqueued. This covers the case where undispatched is empty but in-flight requests
+// were cancelled by context propagation.
+func TestProcessModel_SIGTERMCancelsAllDispatched(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.WorkDir = t.TempDir()
+
+	started := make(chan struct{})
+	mainCtx, mainCancel := context.WithCancel(testLoggerCtx(t))
+
+	mock := &mockInferenceClient{
+		generateFn: func(ctx context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+			close(started)
+			mainCancel()
+			<-ctx.Done()
+			return nil, &inference.ClientError{
+				Category: httpclient.ErrCategoryServer,
+				Message:  "request cancelled",
+				RawError: ctx.Err(),
+			}
+		},
+	}
+
+	requests := []batch_types.Request{
+		{CustomID: "a", Method: "POST", URL: "/v1/chat/completions", Body: map[string]interface{}{"model": "m1"}},
+	}
+	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
+
+	inputPath, _ := env.p.jobInputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	inputFile, _ := os.Open(inputPath)
+	defer inputFile.Close()
+
+	plansDir, _ := env.p.jobPlansDir(jobInfo.JobID, jobInfo.TenantID)
+
+	var outBuf, errBuf bytes.Buffer
+	writers := &outputWriters{output: bufio.NewWriter(&outBuf), errors: bufio.NewWriter(&errBuf)}
+
+	progress := &executionProgress{
+		total:   int64(len(requests)),
+		updater: env.updater,
+		jobID:   jobInfo.JobID,
+	}
+
+	err := env.p.processModel(mainCtx, mainCtx, mainCtx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
+	if !errors.Is(err, errShutdown) {
+		t.Fatalf("expected errShutdown when SIGTERM cancels all dispatched requests, got: %v", err)
+	}
+}
+
 // TestProcessModel_SiblingAbort_ReturnsNil verifies that when requestAbortCtx is cancelled
 // by a sibling model error (via requestAbortFn), processModel returns nil rather than errShutdown.
 //


### PR DESCRIPTION
## Summary

- Fixes a bug where the processor finalized batches with partial results instead of re-enqueueing when SIGTERM cancelled all already-dispatched in-flight requests
- The shutdown detection in `processModel` only checked `len(undispatched) > 0`, missing the case where all requests were dispatched as goroutines and then cancelled by context propagation
- Adds an atomic counter (`shutdownCancelled`) to track SIGTERM-cancelled dispatched requests and includes it in the shutdown condition
- Preserves existing behavior: fully-complete jobs are not re-enqueued (`TestExecuteJob_SIGTERMAfterAllComplete` still passes)

See [root cause analysis](https://github.com/llm-d/llm-d-batch-gateway/issues/515#issuecomment-4813336037) for the full trace.

Closes #515

## Test plan

- [x] New unit test `TestProcessModel_SIGTERMCancelsAllDispatched` — SIGTERM after all requests dispatched returns `errShutdown`
- [x] Existing `TestExecuteJob_SIGTERMAfterAllComplete` — all requests complete before SIGTERM, returns nil (not re-enqueued)
- [x] Existing `TestProcessModel_SiblingAbort_ReturnsNil` — sibling abort returns nil (not confused with SIGTERM)
- [x] `make pre-commit` passes (fmt, vet, lint, unit tests, security scan)
- [x] `make test-integration` — run `ProcessorGracefulShutdown` tests against Kind cluster to confirm end-to-end fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)