### PR TITLE
fix: use graduated chart registry for releases after v0.2.0

### DIFF
--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -639,8 +639,10 @@ do_deploy_batch_gateway_helm() {
 
     local chart version_args=()
     if [ -n "${BATCH_RELEASE_VERSION}" ]; then
-        # TODO: pre-graduation location; update to ghcr.io/llm-d in the next release
-        chart="oci://ghcr.io/llm-d-incubation/charts/batch-gateway"
+        case "${BATCH_RELEASE_VERSION}" in
+            v0.1.0|v0.2.0) chart="oci://ghcr.io/llm-d-incubation/charts/batch-gateway" ;;
+            *)              chart="oci://ghcr.io/llm-d/charts/batch-gateway" ;;
+        esac
         version_args=(--version "${BATCH_RELEASE_VERSION#v}")
     elif [ "${BATCH_DEV_VERSION}" = "local" ]; then
         local repo_root


### PR DESCRIPTION
## What does this PR do?

Use the graduated `ghcr.io/llm-d` chart registry for releases after v0.2.0. Releases v0.1.0 and v0.2.0 remain on `ghcr.io/llm-d-incubation`.