### PR TITLE
refactor: simplified `executionProgress` tracker

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -174,11 +174,20 @@ func (ep *executionProgress) run(ctx context.Context) {
 	defer ticker.Stop()
 	dirty := false
 
+	// pushCtx returns ctx if it is still active, otherwise context.Background()
+	// so that the final push after cancellation still reaches the status store.
+	pushCtx := func() context.Context {
+		if ctx.Err() != nil {
+			return context.Background()
+		}
+		return ctx
+	}
+
 	for {
 		select {
 		case ev, ok := <-ep.ch:
 			if !ok {
-				ep.push(ctx)
+				ep.push(pushCtx())
 				return
 			}
 			if ev.success {
@@ -190,27 +199,8 @@ func (ep *executionProgress) run(ctx context.Context) {
 
 		case <-ticker.C:
 			if dirty {
-				ep.push(ctx)
+				ep.push(pushCtx())
 				dirty = false
-			}
-
-		case <-ctx.Done():
-			for {
-				select {
-				case ev, ok := <-ep.ch:
-					if !ok {
-						ep.push(context.Background())
-						return
-					}
-					if ev.success {
-						ep.completed++
-					} else {
-						ep.failed++
-					}
-				default:
-					ep.push(context.Background())
-					return
-				}
 			}
 		}
 	}

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -195,6 +195,10 @@ func (ep *executionProgress) run(ctx context.Context) {
 			} else {
 				ep.failed++
 			}
+			if !dirty {
+				ep.push(pushCtx())
+				ticker.Reset(ep.interval)
+			}
 			dirty = true
 
 		case <-ticker.C:

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -96,65 +96,133 @@ func (o *outputLine) isSuccess() bool {
 	return o.Error == nil && o.Response != nil && o.Response.StatusCode == 200
 }
 
-// progressUpdateInterval is the minimum time between Redis progress updates.
+// progressUpdateInterval is the minimum time between progress status updates.
 // Updates within this window are skipped — the next update after the interval
 // will include all accumulated progress. Declared as var so tests can override.
 var progressUpdateInterval = time.Second
 
-// executionProgress tracks per-request progress across goroutines
-// and pushes throttled updates to the status store.
+// executionProgress tracks per-request completion counts and pushes throttled
+// updates to the status store. It runs as a single goroutine — no atomics or locks needed.
+//
+// Usage:
+//
+//	progress := newExecutionProgress(updater, jobID, total, initialFailed)
+//	progress.start(ctx)
+//	// ... call progress.record(ctx, success) from any goroutine ...
+//	progress.flush(ctx) // stops goroutine, performs final push
+//	counts := progress.counts()
 type executionProgress struct {
-	completed  atomic.Int64
-	failed     atomic.Int64
-	total      int64
-	updater    *StatusUpdater
-	jobID      string
-	lastUpdate atomic.Int64 // unix nanoseconds of last Redis push
+	total     int64
+	completed int64
+	failed    int64
+	updater   *StatusUpdater
+	jobID     string
+	interval  time.Duration
+
+	ch   chan progressEvent
+	done chan struct{}
 }
 
-// record increments the appropriate counter and pushes a throttled progress
-// update to Redis. Updates are skipped if less than progressUpdateInterval
-// has elapsed since the last push, reducing Redis writes from O(requests)
-// to O(job_duration / interval).
-func (ep *executionProgress) record(ctx context.Context, success bool) {
-	if success {
-		ep.completed.Add(1)
-	} else {
-		ep.failed.Add(1)
-	}
-	now := time.Now().UnixNano()
-	last := ep.lastUpdate.Load()
-	if now-last < int64(progressUpdateInterval) {
-		return
-	}
-	// Best-effort CAS: if another goroutine raced us, skip this update.
-	if !ep.lastUpdate.CompareAndSwap(last, now) {
-		return
-	}
-	ep.push(ctx)
+// progressEvent signals one completed request to the execution progress tracker.
+type progressEvent struct {
+	success bool
 }
 
-// flush pushes the final progress to Redis unconditionally, ensuring the
-// last update reflects the true counts regardless of throttling.
-func (ep *executionProgress) flush(ctx context.Context) {
-	ep.push(ctx)
+func newExecutionProgress(updater *StatusUpdater, jobID string, total, initialFailed int64) *executionProgress {
+	return &executionProgress{
+		total:    total,
+		failed:   initialFailed,
+		updater:  updater,
+		jobID:    jobID,
+		interval: progressUpdateInterval,
+		ch:       make(chan progressEvent, 1024),
+		done:     make(chan struct{}),
+	}
+}
+
+// start launches the tracker goroutine.
+func (ep *executionProgress) start(ctx context.Context) {
+	go func() {
+		ep.run(ctx)
+		close(ep.done)
+	}()
+}
+
+// record sends a progress event to the tracker goroutine.
+func (ep *executionProgress) record(_ context.Context, success bool) {
+	ep.ch <- progressEvent{success: success}
+}
+
+// flush stops the tracker goroutine and performs a final push to the status
+// store, ensuring the last update reflects the true counts regardless of throttling.
+func (ep *executionProgress) flush(_ context.Context) {
+	close(ep.ch)
+	<-ep.done
+}
+
+// counts returns the current request counts. Safe to call after flush returns.
+func (ep *executionProgress) counts() *openai.BatchRequestCounts {
+	return &openai.BatchRequestCounts{
+		Total:     ep.total,
+		Completed: ep.completed,
+		Failed:    ep.failed,
+	}
+}
+
+func (ep *executionProgress) run(ctx context.Context) {
+	ticker := time.NewTicker(ep.interval)
+	defer ticker.Stop()
+	dirty := false
+
+	for {
+		select {
+		case ev, ok := <-ep.ch:
+			if !ok {
+				ep.push(ctx)
+				return
+			}
+			if ev.success {
+				ep.completed++
+			} else {
+				ep.failed++
+			}
+			dirty = true
+
+		case <-ticker.C:
+			if dirty {
+				ep.push(ctx)
+				dirty = false
+			}
+
+		case <-ctx.Done():
+			for {
+				select {
+				case ev, ok := <-ep.ch:
+					if !ok {
+						ep.push(context.Background())
+						return
+					}
+					if ev.success {
+						ep.completed++
+					} else {
+						ep.failed++
+					}
+				default:
+					ep.push(context.Background())
+					return
+				}
+			}
+		}
+	}
 }
 
 func (ep *executionProgress) push(ctx context.Context) {
 	if err := ep.updater.UpdateProgressCounts(ctx, ep.jobID, &openai.BatchRequestCounts{
 		Total:     ep.total,
-		Completed: ep.completed.Load(),
-		Failed:    ep.failed.Load(),
+		Completed: ep.completed,
+		Failed:    ep.failed,
 	}); err != nil {
 		logr.FromContextOrDiscard(ctx).Error(err, "Failed to update progress counts (best-effort)")
-	}
-}
-
-func (ep *executionProgress) counts() *openai.BatchRequestCounts {
-	return &openai.BatchRequestCounts{
-		Total:     ep.total,
-		Completed: ep.completed.Load(),
-		Failed:    ep.failed.Load(),
 	}
 }
 
@@ -247,13 +315,8 @@ func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx conte
 	// requestAbortCtx and requestAbortFn are set in runJob before watchCancel starts,
 	// eliminating the race window where a cancel event could arrive before the fn is assigned.
 
-	progress := &executionProgress{
-		total:   modelMap.LineCount,
-		updater: params.updater,
-		jobID:   params.jobInfo.JobID,
-	}
-	// Seed with requests already rejected during ingestion (model not found).
-	progress.failed.Store(modelMap.RejectedCount)
+	progress := newExecutionProgress(params.updater, params.jobInfo.JobID, modelMap.LineCount, modelMap.RejectedCount)
+	progress.start(ctx)
 
 	errCh := make(chan error, len(modelMap.SafeToModel))
 

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -805,11 +805,8 @@ func TestProcessModel_Success(t *testing.T) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
 
-	progress := &executionProgress{
-		total:   int64(len(requests)),
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+	progress.start(testLoggerCtx(t))
 
 	var errBuf bytes.Buffer
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
@@ -828,6 +825,7 @@ func TestProcessModel_Success(t *testing.T) {
 		t.Fatalf("inference calls = %d, want %d", callCount.Load(), len(requests))
 	}
 
+	progress.flush(ctx)
 	counts := progress.counts()
 	if counts.Completed != int64(len(requests)) {
 		t.Fatalf("completed = %d, want %d", counts.Completed, len(requests))
@@ -859,11 +857,9 @@ func TestProcessModel_CancelStopsDispatch(t *testing.T) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
 
-	progress := &executionProgress{
-		total:   1,
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, 1, 0)
+	progress.start(testLoggerCtx(t))
+	defer progress.flush(testLoggerCtx(t))
 
 	var errBuf bytes.Buffer
 	errWriter := bufio.NewWriter(&errBuf)
@@ -935,11 +931,8 @@ func TestProcessModel_CancelWritesInFlightToErrorFile(t *testing.T) {
 	errWriter := bufio.NewWriter(&errBuf)
 	writers := &outputWriters{output: outWriter, errors: errWriter}
 
-	progress := &executionProgress{
-		total:   1,
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, 1, 0)
+	progress.start(testLoggerCtx(t))
 
 	ctx := testLoggerCtx(t)
 	modelErr := env.p.processModel(ctx, ctx, ctx, userCancelCtx, inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
@@ -983,6 +976,7 @@ func TestProcessModel_CancelWritesInFlightToErrorFile(t *testing.T) {
 		t.Errorf("expected nil response for cancelled entry, got %+v", entry.Response)
 	}
 
+	progress.flush(ctx)
 	counts := progress.counts()
 	if counts.Failed != 1 {
 		t.Errorf("failed count = %d, want 1", counts.Failed)
@@ -1014,11 +1008,9 @@ func TestProcessModel_InferenceFatalError(t *testing.T) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
 
-	progress := &executionProgress{
-		total:   int64(len(requests)),
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+	progress.start(testLoggerCtx(t))
+	defer progress.flush(testLoggerCtx(t))
 
 	var errBuf bytes.Buffer
 	writers := &outputWriters{output: writer, errors: bufio.NewWriter(&errBuf)}
@@ -1061,11 +1053,9 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
 
-	progress := &executionProgress{
-		total:   int64(len(requests)),
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+	progress.start(testLoggerCtx(t))
+	defer progress.flush(testLoggerCtx(t))
 
 	ctx, cancel := context.WithCancel(testLoggerCtx(t))
 
@@ -1125,11 +1115,9 @@ func TestProcessModel_SIGTERMCancelsAllDispatched(t *testing.T) {
 	var outBuf, errBuf bytes.Buffer
 	writers := &outputWriters{output: bufio.NewWriter(&outBuf), errors: bufio.NewWriter(&errBuf)}
 
-	progress := &executionProgress{
-		total:   int64(len(requests)),
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+	progress.start(testLoggerCtx(t))
+	defer progress.flush(testLoggerCtx(t))
 
 	err := env.p.processModel(mainCtx, mainCtx, mainCtx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 	if !errors.Is(err, errShutdown) {
@@ -1163,11 +1151,9 @@ func TestProcessModel_SiblingAbort_ReturnsNil(t *testing.T) {
 	var buf bytes.Buffer
 	writers := &outputWriters{output: bufio.NewWriter(&buf), errors: bufio.NewWriter(&buf)}
 
-	progress := &executionProgress{
-		total:   1,
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, 1, 0)
+	progress.start(testLoggerCtx(t))
+	defer progress.flush(testLoggerCtx(t))
 
 	// mainCtx is not cancelled — only requestAbortCtx is, simulating a sibling model calling
 	// requestAbortFn() on error. SLO and user-cancel signals are both absent.
@@ -2782,11 +2768,8 @@ func TestExecutionProgress_Throttle(t *testing.T) {
 	statusClient := &countingStatusClient{BatchStatusClient: mockdb.NewMockBatchStatusClient()}
 	updater := NewStatusUpdater(newMockBatchDBClient(), statusClient, 86400)
 
-	progress := &executionProgress{
-		total:   100,
-		updater: updater,
-		jobID:   "job-throttle",
-	}
+	progress := newExecutionProgress(updater, "job-throttle", 100, 0)
+	progress.start(testLoggerCtx(t))
 
 	ctx := testLoggerCtx(t)
 
@@ -2795,6 +2778,7 @@ func TestExecutionProgress_Throttle(t *testing.T) {
 		progress.record(ctx, true)
 	}
 
+	progress.flush(ctx)
 	throttled := statusClient.count.Load()
 	if throttled >= 100 {
 		t.Fatalf("expected throttled updates < 100, got %d (no throttling occurred)", throttled)
@@ -2813,11 +2797,8 @@ func TestExecutionProgress_Flush(t *testing.T) {
 	statusClient := &countingStatusClient{BatchStatusClient: mockdb.NewMockBatchStatusClient()}
 	updater := NewStatusUpdater(newMockBatchDBClient(), statusClient, 86400)
 
-	progress := &executionProgress{
-		total:   10,
-		updater: updater,
-		jobID:   "job-flush",
-	}
+	progress := newExecutionProgress(updater, "job-flush", 10, 0)
+	progress.start(testLoggerCtx(t))
 
 	ctx := testLoggerCtx(t)
 
@@ -3393,17 +3374,15 @@ func TestProcessModel_AIMDSignaling(t *testing.T) {
 			output: bufio.NewWriter(&outBuf),
 			errors: bufio.NewWriter(&errBuf),
 		}
-		progress := &executionProgress{
-			total:   int64(len(requests)),
-			updater: env.updater,
-			jobID:   jobInfo.JobID,
-		}
+		progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+		progress.start(testLoggerCtx(t))
 
 		ctx := testLoggerCtx(t)
 		err = env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, jobInfo.TenantID)
 		if err != nil {
 			t.Fatalf("processModel error: %v", err)
 		}
+		progress.flush(ctx)
 		return env.p
 	}
 
@@ -3552,17 +3531,15 @@ func TestProcessModel_AIMDSignaling(t *testing.T) {
 			output: bufio.NewWriter(&outBuf),
 			errors: bufio.NewWriter(&errBuf),
 		}
-		progress := &executionProgress{
-			total:   int64(len(requests)),
-			updater: env.updater,
-			jobID:   jobInfo.JobID,
-		}
+		progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+		progress.start(testLoggerCtx(t))
 
 		ctx := testLoggerCtx(t)
 		err = env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, jobInfo.TenantID)
 		if err != nil {
 			t.Fatalf("processModel error: %v", err)
 		}
+		progress.flush(ctx)
 
 		// If non-HTTP errors were incorrectly counted as RecordSuccess,
 		// the window (size=reducedLimit) would fill and push the limit
@@ -3676,12 +3653,15 @@ func TestProcessModel_AIMDEndpointIsolation(t *testing.T) {
 		output: bufio.NewWriter(&outBuf),
 		errors: bufio.NewWriter(&errBuf),
 	}
-	progress := &executionProgress{total: 4, updater: updater, jobID: jobID}
+	progress := newExecutionProgress(updater, jobID, 4, 0)
+	progress.start(testLoggerCtx(t))
 
 	_ = p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, tenantID)
 
 	// Process m2 (200s) — should NOT affect m2's endpoint AIMD.
 	_ = p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m2", "m2", writers, progress, nil, tenantID)
+
+	progress.flush(ctx)
 
 	limitA := p.endpointLimits[clientA].aimd.Limit()
 	limitB := p.endpointLimits[clientB].aimd.Limit()
@@ -3736,17 +3716,15 @@ func TestProcessModel_EndpointLimitNil_DrainsAsModelNotFound(t *testing.T) {
 		output: bufio.NewWriter(&outBuf),
 		errors: bufio.NewWriter(&errBuf),
 	}
-	progress := &executionProgress{
-		total:   int64(len(requests)),
-		updater: env.updater,
-		jobID:   jobInfo.JobID,
-	}
+	progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
+	progress.start(testLoggerCtx(t))
 
 	ctx := testLoggerCtx(t)
 	err = env.p.processModel(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, jobInfo.TenantID)
 	if err != nil {
 		t.Fatalf("processModel error: %v", err)
 	}
+	progress.flush(ctx)
 
 	if err := writers.errors.Flush(); err != nil {
 		t.Fatalf("flush errors: %v", err)

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2818,6 +2818,53 @@ func TestExecutionProgress_Flush(t *testing.T) {
 	}
 }
 
+// TestExecutionProgress_RecordAfterContextCancel verifies that record() does not
+// block when the context passed to start() is cancelled. Before the fix, run()
+// would exit on ctx.Done(), leaving no receiver on ep.ch — subsequent record()
+// calls would deadlock once the channel buffer filled.
+func TestExecutionProgress_RecordAfterContextCancel(t *testing.T) {
+	orig := progressUpdateInterval
+	progressUpdateInterval = time.Hour
+	t.Cleanup(func() { progressUpdateInterval = orig })
+
+	statusClient := &countingStatusClient{BatchStatusClient: mockdb.NewMockBatchStatusClient()}
+	updater := NewStatusUpdater(newMockBatchDBClient(), statusClient, 86400)
+
+	ctx, cancel := context.WithCancel(testLoggerCtx(t))
+	progress := newExecutionProgress(updater, "job-ctx-cancel", 2048, 0)
+	progress.start(ctx)
+
+	// Cancel the context before sending any events. In the buggy code this
+	// would cause run() to exit immediately.
+	cancel()
+
+	// Send more events than the channel buffer (1024) to guarantee a
+	// deadlock if nobody is receiving.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 2048; i++ {
+			progress.record(ctx, i%2 == 0)
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("record() blocked after context cancellation — run() exited and left no receiver")
+	}
+
+	progress.flush(ctx)
+
+	counts := progress.counts()
+	if counts.Completed != 1024 {
+		t.Fatalf("completed = %d, want 1024", counts.Completed)
+	}
+	if counts.Failed != 1024 {
+		t.Fatalf("failed = %d, want 1024", counts.Failed)
+	}
+}
+
 // =====================================================================
 // Tests: jsonNumericToFloat64
 // =====================================================================
@@ -3891,13 +3938,15 @@ func TestProcessModelAsync(t *testing.T) {
 
 		var outBuf, errBuf bytes.Buffer
 		writers := &outputWriters{output: bufio.NewWriter(&outBuf), errors: bufio.NewWriter(&errBuf)}
-		progress := &executionProgress{total: int64(len(requests)), updater: env.updater, jobID: jobInfo.JobID}
+		progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
 
 		ctx := testLoggerCtx(t)
+		progress.start(ctx)
 		err := env.p.processModelAsync(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 		if err != nil {
 			t.Fatalf("processModelAsync error: %v", err)
 		}
+		progress.flush(ctx)
 
 		_ = writers.output.Flush()
 		_ = writers.errors.Flush()
@@ -3962,9 +4011,10 @@ func TestProcessModelAsync(t *testing.T) {
 
 		var outBuf, errBuf bytes.Buffer
 		writers := &outputWriters{output: bufio.NewWriter(&outBuf), errors: bufio.NewWriter(&errBuf)}
-		progress := &executionProgress{total: int64(len(requests)), updater: env.updater, jobID: jobInfo.JobID}
+		progress := newExecutionProgress(env.updater, jobInfo.JobID, int64(len(requests)), 0)
 
 		ctx := testLoggerCtx(t)
+		progress.start(ctx)
 		abortCtx, abortFn := context.WithCancel(ctx)
 
 		// Run processModelAsync in a goroutine so we can intercept submitted IDs.
@@ -3987,6 +4037,7 @@ func TestProcessModelAsync(t *testing.T) {
 		abortFn()
 
 		<-done
+		progress.flush(ctx)
 
 		_ = writers.output.Flush()
 		_ = writers.errors.Flush()
@@ -4024,13 +4075,15 @@ func TestProcessModelAsync(t *testing.T) {
 
 		var outBuf, errBuf bytes.Buffer
 		writers := &outputWriters{output: bufio.NewWriter(&outBuf), errors: bufio.NewWriter(&errBuf)}
-		progress := &executionProgress{total: 1, updater: env.updater, jobID: jobInfo.JobID}
+		progress := newExecutionProgress(env.updater, jobInfo.JobID, 1, 0)
 
 		ctx := testLoggerCtx(t)
+		progress.start(ctx)
 		err := env.p.processModelAsync(ctx, ctx, ctx, context.Background(), inputFile, plansDir, "m1", "m1", writers, progress, nil, "")
 		if err != nil {
 			t.Fatalf("processModelAsync error: %v", err)
 		}
+		progress.flush(ctx)
 
 		_ = writers.output.Flush()
 		_ = writers.errors.Flush()

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -116,17 +116,15 @@ func TestResolveOutputExpiration_NilTags(t *testing.T) {
 
 func TestExecutionProgress_RecordAndCounts(t *testing.T) {
 	updater := NewStatusUpdater(newMockBatchDBClient(), mockdb.NewMockBatchStatusClient(), 86400)
-	ep := &executionProgress{
-		total:   10,
-		updater: updater,
-		jobID:   "job-1",
-	}
+	ep := newExecutionProgress(updater, "job-1", 10, 0)
+	ep.start(testLoggerCtx(t))
 
 	ctx := testLoggerCtx(t)
 	ep.record(ctx, true)
 	ep.record(ctx, true)
 	ep.record(ctx, false)
 
+	ep.flush(ctx)
 	counts := ep.counts()
 	if counts.Total != 10 {
 		t.Fatalf("Total = %d, want 10", counts.Total)


### PR DESCRIPTION
## Why is this PR needed?

Current progress tracking is tangled in the execution code and it uses different locking primitives. This won't scale if we eventually decouple request dispatching from response handling (needed for the async dispatcher, beneficial for synchronous calls too)

## What does this PR do?

The `executionProgress` methods are unchanged on the surface, but instead a channel is internally used for synchronization. This will scale better in the future if we centralize progress handling:

e.g. we could introduce some sort of `globalExecutionProgress` that receives all progress events and dispatches them to each per-job `executionProgress` tracker. This is however left for a follow-up.


## How was this tested?

All tests still pass.

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #527, related #528 