### PR TITLE
fix: align LLMBatchGateway CR with v1alpha1 CRD schema

### DIFF
--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -794,10 +794,11 @@ do_deploy_batch_gateway_dsc() {
         IFS=',' read -ra _headers <<< "${pass_through_headers}"
         for h in "${_headers[@]}"; do
             header_items="${header_items}
-      - ${h}"
+        - ${h}"
         done
-        apiserver_batch_api_yaml="    batchAPI:
-      passThroughHeaders:${header_items}"
+        apiserver_batch_api_yaml="    config:
+      batchAPI:
+        passThroughHeaders:${header_items}"
     fi
 
     step "Creating LLMBatchGateway CR..."
@@ -818,6 +819,13 @@ ${file_storage_yaml}
 ${apiserver_batch_api_yaml}
   processor:
     replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
     globalInferenceGateway:
       url: ${model_url}
       requestTimeout: ${GW_REQUEST_TIMEOUT}


### PR DESCRIPTION
## Why is this PR needed?

## What does this PR do?

- Move `passThroughHeaders` from `spec.apiServer.batchAPI` to `spec.apiServer.config.batchAPI` to match the operator CRD schema.
- Add default processor resource requests (100m CPU) to avoid scheduling failures on resource-constrained CI clusters.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
