### PR TITLE
fix: remove SIGTERM re-enqueue and make heartbeat interval configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ test-e2e:
 	@echo "Running E2E tests..."
 	@OUT=$$(mktemp); \
 	echo "Processor observability endpoint: auto-resolved by the e2e test helpers"; \
-	cd test/e2e && $(GO) test -v -count=1 $(if $(TEST_RUN),-run $(TEST_RUN)) ./... 2>&1 | tee $$OUT; \
+	cd test/e2e && $(GO) test -v -count=1 -timeout=20m $(if $(TEST_RUN),-run $(TEST_RUN)) ./... 2>&1 | tee $$OUT; \
 	TEST_EXIT=$${PIPESTATUS[0]}; \
 	PASS_COUNT=$$(grep -- '--- PASS:' $$OUT 2>/dev/null | wc -l | tr -d ' '); \
 	FAIL_COUNT=$$(grep -- '--- FAIL:' $$OUT 2>/dev/null | wc -l | tr -d ' '); \

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -25,6 +25,7 @@ data:
 
     terminate_on_observability_failure: {{ .Values.processor.config.terminateOnObservabilityFailure }}
     shutdown_timeout: {{ .Values.processor.config.shutdownTimeout | quote }}
+    heartbeat_interval: {{ .Values.processor.config.heartbeatInterval | quote }}
     work_dir: {{ .Values.processor.config.workDir | quote }}
 
     db_client:

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -344,6 +344,7 @@ processor:
       count: 12
     terminateOnObservabilityFailure: false
     shutdownTimeout: "30s"
+    heartbeatInterval: "5m"
     workDir: "/var/lib/batch-gateway/processor"
     # REQUIRED: Configure exactly one of globalInferenceGateway or modelGateways.
     # The processor will fail to start if neither is set.

--- a/cmd/batch-processor/config.yaml
+++ b/cmd/batch-processor/config.yaml
@@ -34,6 +34,11 @@ terminate_on_observability_failure: false
 # Shutdown timeout for processor (should be less than k8s terminationGracePeriodSeconds)
 shutdown_timeout: "30s"
 
+# Heartbeat interval for in-flight entry refresh.
+# Must be shorter than the GC reconciler's interval so active jobs are not
+# mistaken for orphans. Default: 5m (matches GC default of 60m).
+heartbeat_interval: "5m"
+
 # Work directory for processor
 work_dir: "/var/lib/batch-gateway/processor"
 

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -167,6 +167,14 @@ type ProcessorConfig struct {
 	// FileClient holds configuration for the shared file storage client (fs or s3).
 	FileClientCfg sharedcfg.FileClientConfig `yaml:"file_client"`
 
+	// HeartbeatInterval controls how often the processor refreshes its in-flight
+	// entry for a running job. The orphan reconciler uses staleness (no heartbeat
+	// for > reconciler interval) to detect abandoned jobs.
+	// Must be shorter than the reconciler's interval so that active jobs are
+	// never mistaken for orphans.
+	// Zero means use the default (5 minutes).
+	HeartbeatInterval time.Duration `yaml:"heartbeat_interval"`
+
 	// DispatchMode selects the inference dispatch backend.
 	// "sync" (default): direct HTTP via InferenceClient.
 	// "async": submit via llm-d-async producer, collect from result queue.
@@ -321,7 +329,8 @@ func NewConfig() *ProcessorConfig {
 		DefaultOutputExpirationSeconds: 90 * 24 * 60 * 60, // 90 days
 		ProgressTTLSeconds:             24 * 60 * 60,      // 24 hours
 
-		DispatchMode: DispatchModeSync,
+		HeartbeatInterval: 5 * time.Minute,
+		DispatchMode:      DispatchModeSync,
 		AsyncDispatchConfig: AsyncDispatchConfig{
 			ResultPollTimeout: 5 * time.Second,
 		},
@@ -348,6 +357,9 @@ func (c *ProcessorConfig) Validate() error {
 
 	if c.ShutdownTimeout <= 0 {
 		return fmt.Errorf("shutdown_timeout must be > 0")
+	}
+	if c.HeartbeatInterval <= 0 {
+		return fmt.Errorf("heartbeat_interval must be > 0")
 	}
 	if c.Addr == "" {
 		return fmt.Errorf("addr cannot be empty")

--- a/internal/processor/worker/errors.go
+++ b/internal/processor/worker/errors.go
@@ -35,7 +35,8 @@ var (
 	errRequestInputRead = errors.New("failed to read request from input file")
 
 	// errShutdown signals that the processor is shutting down (SIGTERM).
-	// The job is re-enqueued so another worker can pick it up.
+	// The job is left in its current non-terminal state for the orphan
+	// reconciler to detect and transition to a terminal state.
 	errShutdown = errors.New("processor shutting down")
 
 	// errFinalizeFailedOver signals that a terminal status transition (completed,

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -168,8 +168,8 @@ func (ep *executionProgress) counts() *openai.BatchRequestCounts {
 //   - SLO expired:    (counts, errExpired)   — undispatched drained as batch_expired
 //   - User cancel:    (counts, errCancelled) — undispatched drained as batch_cancelled
 //   - System error:   (counts, firstErr)     — undispatched drained as batch_failed
-//   - Pod shutdown:   (counts, errShutdown)  — caller re-enqueues; counts reflect work done
-//     before SIGTERM, flush preserves partial output for startup recovery
+//   - Pod shutdown:   (counts, errShutdown)  — job left for orphan reconciler; counts reflect
+//     work done before SIGTERM
 //
 // requestAbortCtx controls the dispatch loop and all in-flight inference calls: cancelling it
 // stops dispatch and aborts in-flight requests. It is derived from sloCtx in runJob, so SLO
@@ -600,10 +600,10 @@ dispatch:
 	default:
 		if mainCtx.Err() != nil && (len(undispatched) > 0 || shutdownCancelled.Load() > 0) {
 			// Pod shutdown (SIGTERM): main processor context is cancelled.
-			// Do not drain here — the re-enqueued worker will process the
-			// entire job from scratch. The undispatched check catches SIGTERM
-			// arriving during dispatch; shutdownCancelled catches SIGTERM
-			// cancelling already-dispatched in-flight requests.
+			// Do not drain here — the job will be left for the orphan
+			// reconciler to transition to a terminal state. The undispatched
+			// check catches SIGTERM arriving during dispatch; shutdownCancelled
+			// catches SIGTERM cancelling already-dispatched in-flight requests.
 			returnErr = errShutdown
 		} else if requestAbortCtx.Err() != nil && len(undispatched) > 0 {
 			// Sibling model abort: requestAbortCtx was cancelled by another

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -1089,8 +1089,8 @@ func TestProcessModel_ContextCancelledDuringDispatch(t *testing.T) {
 
 // TestProcessModel_SIGTERMCancelsAllDispatched verifies that when SIGTERM arrives after all
 // requests have been dispatched as goroutines, processModel returns errShutdown so the job
-// is re-enqueued. This covers the case where undispatched is empty but in-flight requests
-// were cancelled by context propagation.
+// is left for the orphan reconciler. This covers the case where undispatched is empty but
+// in-flight requests were cancelled by context propagation.
 func TestProcessModel_SIGTERMCancelsAllDispatched(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -1142,8 +1142,8 @@ func TestProcessModel_SIGTERMCancelsAllDispatched(t *testing.T) {
 //
 // P1c regression: Before the fix, the drain-switch default checked ctx.Err() (which is
 // requestAbortCtx), so a sibling abort looked like a pod shutdown and returned errShutdown.
-// executeJob would then route the job to re-enqueue instead of failed-with-partial, breaking
-// retry safety for batches with partial results. After the fix, the default checks mainCtx
+// executeJob would then route the job to the errShutdown path instead of failed-with-partial,
+// breaking retry safety for batches with partial results. After the fix, the default checks mainCtx
 // (the main processor context), which is only cancelled on SIGTERM.
 func TestProcessModel_SiblingAbort_ReturnsNil(t *testing.T) {
 	cfg := config.NewConfig()
@@ -1422,7 +1422,7 @@ func TestExecuteJob_CancelAfterAllRequestsComplete(t *testing.T) {
 // TestExecuteJob_SIGTERMAfterAllComplete verifies that when all requests finish successfully
 // and SIGTERM arrives before executeJob returns, the function returns nil (not errShutdown).
 // This ensures the caller proceeds to finalizeJob (which uses a detached context) rather than
-// re-enqueueing a fully-complete job.
+// taking the errShutdown path (which leaves the job for the orphan reconciler).
 func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -2105,7 +2105,7 @@ func TestHandleJobError_errCancelled(t *testing.T) {
 	}
 }
 
-func TestHandleJobError_Shutdown_ReEnqueues(t *testing.T) {
+func TestHandleJobError_Shutdown_LeavesJobForReconciler(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
@@ -2118,8 +2118,6 @@ func TestHandleJobError_Shutdown_ReEnqueues(t *testing.T) {
 		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{CreatedAt: time.Now().Add(-10 * time.Second).Unix()}},
 	}
 
-	beforeFailed := gatherHistogramSampleCount(t, "batch_job_e2e_latency_seconds", map[string]string{"status": "failed"})
-
 	ctx := testLoggerCtx(t)
 	env.p.handleJobError(ctx, &jobExecutionParams{
 		updater: env.updater,
@@ -2128,17 +2126,26 @@ func TestHandleJobError_Shutdown_ReEnqueues(t *testing.T) {
 		jobInfo: ji,
 	}, errShutdown)
 
-	afterFailed := gatherHistogramSampleCount(t, "batch_job_e2e_latency_seconds", map[string]string{"status": "failed"})
-	if delta := afterFailed - beforeFailed; delta != 0 {
-		t.Fatalf("E2E latency failed: delta=%d, want 0 (re-enqueue succeeded, not terminal)", delta)
-	}
-
+	// Job must NOT be re-enqueued — reconciler handles recovery.
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
 	if err != nil {
 		t.Fatalf("PQDequeue: %v", err)
 	}
-	if len(tasks) == 0 {
-		t.Fatalf("expected re-enqueued task, got none")
+	if len(tasks) != 0 {
+		t.Fatalf("expected no re-enqueued tasks, got %d", len(tasks))
+	}
+
+	// Job status must remain in_progress (not transitioned by the processor).
+	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-ctx"}}}, true, 0, 1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("DBGet: err=%v len=%d", err, len(items))
+	}
+	var got openai.BatchStatusInfo
+	if err := json.Unmarshal(items[0].Status, &got); err != nil {
+		t.Fatalf("unmarshal status: %v", err)
+	}
+	if got.Status != openai.BatchStatusInProgress {
+		t.Fatalf("status = %s, want %s (unchanged, left for reconciler)", got.Status, openai.BatchStatusInProgress)
 	}
 }
 

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -47,11 +47,9 @@ import (
 // Declared as var (not const) so tests can shorten it.
 var panicRecoveryTimeout = time.Minute
 
-// heartbeatInterval controls how often the processor refreshes its in-flight
-// entry for a running job. The orphan reconciler uses staleness (no heartbeat
-// for > reconciler interval) to detect abandoned jobs.
-// Declared as var (not const) so tests can shorten it.
-var heartbeatInterval = 5 * time.Minute
+// defaultHeartbeatInterval is the fallback heartbeat interval used when
+// the config value is zero. Matches ProcessorConfig.HeartbeatInterval default.
+const defaultHeartbeatInterval = 5 * time.Minute
 
 func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	// Clean up in-flight entry on exit (first defer = last to run via LIFO),
@@ -323,35 +321,15 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 		}
 
 	case errors.Is(err, errShutdown):
-		// SIGTERM received — re-enqueue so another worker can pick up the job.
-		// Use a detached context because ctx is already cancelled.
+		// SIGTERM received — leave the job in its current state for the orphan
+		// reconciler to handle. The reconciler detects non-terminal jobs that
+		// are not in the queue and have a stale (or missing) in-flight entry,
+		// then transitions them to a terminal state (failed, cancelled, etc.).
 		//
-		// Known limitation: there is no way at SIGTERM time to distinguish a container
-		// restart (emptyDir survives, startup recovery can upload partial output) from a
-		// pod deletion (emptyDir destroyed, startup recovery cannot help). Re-enqueueing
-		// is therefore unconditional, which introduces a known race: if this was a
-		// container restart, startup recovery and the worker that picks up the re-enqueued
-		// job compete — startup recovery may mark the job failed while another worker
-		// runs it fresh.
-		// This race is accepted as a known limit until orphan reconciliation is
-		// implemented. Once it is, re-enqueue should be removed here and pod-deletion
-		// recovery delegated to the reconciler. (TODO: orphan reconciliation task)
-		if params.task != nil {
-			bgCtx, bgSpan := uotel.DetachedContext(ctx, "re-enqueue")
-			defer bgSpan.End()
-			if enqErr := p.poller.enqueueOne(bgCtx, params.task); enqErr != nil {
-				logger.Error(enqErr, "Failed to re-enqueue the job to the queue")
-				// executeJob flushed partial output/error files to disk before returning
-				// errShutdown. Upload them so the user can retrieve whatever completed
-				// before SIGTERM, rather than losing those results silently.
-				if failErr := p.handleFailed(bgCtx, params.updater, params.jobItem, params.requestCounts, params.jobInfo); failErr != nil {
-					logger.Error(failErr, "Failed to mark job as failed after re-enqueue failure")
-				}
-			} else {
-				metrics.RecordJobProcessed(metrics.ResultReEnqueued, metrics.ReasonSystemError)
-				logger.V(logging.INFO).Info("Re-enqueued the job to the queue")
-			}
-		}
+		// The in-flight entry is cleaned up by the defer at the top of runJob.
+		// If the process is killed (SIGKILL) before that defer runs, the entry
+		// remains and becomes stale, which the reconciler also handles.
+		logger.V(logging.INFO).Info("SIGTERM received, leaving job for orphan reconciler")
 
 	default:
 		if failErr := p.handleFailed(ctx, params.updater, params.jobItem, params.requestCounts, params.jobInfo); failErr != nil {

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -732,11 +732,10 @@ func TestRunJob_FinalizeFailedOver_PreservesFileIDsAndDoesNotCallHandleFailed(t 
 	}
 }
 
-// TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput verifies that when
-// errShutdown triggers a re-enqueue that fails, the fallback uploads partial output files
-// and preserves their file IDs in the DB. Before this fix, the fallback called handleFailed
-// with nil counts and empty file IDs, losing already-flushed results.
-func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.T) {
+// TestHandleJobError_Shutdown_LeavesJobInProgress verifies that errShutdown
+// does NOT re-enqueue or call handleFailed. The job stays in_progress for
+// the orphan reconciler to detect and transition to a terminal state.
+func TestHandleJobError_Shutdown_LeavesJobInProgress(t *testing.T) {
 	ctx := testLoggerCtx(t)
 
 	cfg := config.NewConfig()
@@ -745,7 +744,7 @@ func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.
 
 	dbClient := newMockBatchDBClient()
 	statusClient := mockdb.NewMockBatchStatusClient()
-	pqClient := &errPQClient{err: errors.New("queue unavailable")}
+	pqClient := mockdb.NewMockBatchPriorityQueueClient()
 
 	p := mustNewProcessor(t, cfg, &clientset.Clientset{
 		BatchDB:   dbClient,
@@ -758,7 +757,7 @@ func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.
 	})
 	p.poller = NewPoller(pqClient, dbClient)
 
-	jobID := "job-shutdown-enqueue-fail"
+	jobID := "job-shutdown-no-reenqueue"
 	tenantID := "tenant__tenantA"
 
 	jobItem := &db.BatchItem{
@@ -773,19 +772,6 @@ func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.
 
 	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
 	counts := &openai.BatchRequestCounts{Total: 5, Completed: 3, Failed: 2}
-
-	jobDir, _ := p.jobRootDir(jobID, tenantID)
-	if err := os.MkdirAll(jobDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	outputPath := filepath.Join(jobDir, "output.jsonl")
-	if err := os.WriteFile(outputPath, []byte(`{"custom_id":"r1"}`+"\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile output: %v", err)
-	}
-	errorPath := filepath.Join(jobDir, "error.jsonl")
-	if err := os.WriteFile(errorPath, []byte(`{"custom_id":"e1"}`+"\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile error: %v", err)
-	}
 
 	updater := NewStatusUpdater(dbClient, statusClient, 86400)
 	params := &jobExecutionParams{
@@ -806,14 +792,7 @@ func TestHandleJobError_Shutdown_ReEnqueueFails_UploadsPartialOutput(t *testing.
 	if err := json.Unmarshal(items[0].Status, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if got.Status != openai.BatchStatusFailed {
-		t.Fatalf("status = %s, want failed", got.Status)
-	}
-	if got.RequestCounts.Total != 5 || got.RequestCounts.Completed != 3 || got.RequestCounts.Failed != 2 {
-		t.Fatalf("request_counts = %+v, want {5,3,2}", got.RequestCounts)
-	}
-	// handleFailed uploads partial results when jobInfo is non-nil; at least one file ID should be present.
-	if got.OutputFileID == nil && got.ErrorFileID == nil {
-		t.Fatal("expected at least one file ID to be preserved from partial upload")
+	if got.Status != openai.BatchStatusInProgress {
+		t.Fatalf("status = %s, want in_progress (left for reconciler)", got.Status)
 	}
 }

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -490,8 +490,8 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 
 // TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled verifies that when both userCancelCtx
 // and ctx (SIGTERM) are cancelled, preProcessJob returns errCancelled — not errShutdown.
-// This matches processModel's priority (SLO > cancel > shutdown) and prevents re-enqueueing
-// a job the user asked to cancel.
+// This matches processModel's priority (SLO > cancel > shutdown) and ensures the job
+// is cancelled rather than left for the orphan reconciler.
 func TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled(t *testing.T) {
 	ctx := testLoggerCtx(t)
 

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -428,7 +428,11 @@ func (p *Processor) heartbeat(ctx context.Context, jobID string, abortFn context
 	logger := logr.FromContextOrDiscard(ctx).WithValues("jobId", jobID)
 	logger.V(logging.INFO).Info("Heartbeat: started")
 
-	ticker := time.NewTicker(heartbeatInterval)
+	interval := p.cfg.HeartbeatInterval
+	if interval <= 0 {
+		interval = defaultHeartbeatInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {

--- a/internal/processor/worker/worker_test.go
+++ b/internal/processor/worker/worker_test.go
@@ -118,12 +118,9 @@ func TestSemaphoreGuard_JobBaseCtxSurvives(t *testing.T) {
 }
 
 func TestHeartbeat_StopsOnContextCancel(t *testing.T) {
-	origInterval := heartbeatInterval
-	heartbeatInterval = 10 * time.Millisecond
-	t.Cleanup(func() { heartbeatInterval = origInterval })
-
 	mock := newCountingInFlightClient()
 	cfg := config.NewConfig()
+	cfg.HeartbeatInterval = 10 * time.Millisecond
 	p := mustNewProcessor(t, cfg, validProcessorClients(t))
 	p.inflight = mock
 
@@ -163,11 +160,8 @@ func TestHeartbeat_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestHeartbeat_AbortsWhenReconcilerActs(t *testing.T) {
-	origInterval := heartbeatInterval
-	heartbeatInterval = 10 * time.Millisecond
-	t.Cleanup(func() { heartbeatInterval = origInterval })
-
 	cfg := config.NewConfig()
+	cfg.HeartbeatInterval = 10 * time.Millisecond
 	p := mustNewProcessor(t, cfg, validProcessorClients(t))
 
 	statusBytes, _ := json.Marshal(openai.BatchStatusInfo{Status: openai.BatchStatusFailed})

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -1090,13 +1090,14 @@ install_batch_gateway() {
         --set "global.dbClient.type=${DB_CLIENT_TYPE}"
         --set "apiserver.config.enablePprof=true"
         --set "processor.config.enablePprof=true"
+        --set "processor.config.heartbeatInterval=10s"
         --set "processor.resources.requests.memory=256Mi"
         --set "gc.enabled=true"
         --set "gc.image.repository=${GC_IMG%:*}"
         --set "gc.image.pullPolicy=IfNotPresent"
         --set "gc.image.tag=${IMAGE_TAG}"
         --set "gc.config.collector.interval=5s"
-        --set "gc.config.reconciler.interval=60s"
+        --set "gc.config.reconciler.interval=30s"
         --namespace "${NAMESPACE}"
     )
 

--- a/test/e2e/orphan_recovery_test.go
+++ b/test/e2e/orphan_recovery_test.go
@@ -26,12 +26,13 @@ import (
 )
 
 // testOrphanRecovery covers the GC reconciler's orphan detection and recovery
-// after a processor hard crash (SIGKILL via --grace-period=0).
+// when no processor is running to handle a stranded job.
 //
-// Unlike testProcessorGracefulShutdown which tests the SIGTERM -> re-enqueue
-// path within the processor itself, this test validates the external safety net:
-// the GC reconciler detects jobs stranded in non-terminal states when the
-// processor had no chance to clean up.
+// Unlike testProcessorGracefulShutdown which tests SIGTERM with a replacement
+// pod available, these tests scale the processor deployment to 0 replicas
+// before killing the pod, ensuring no processor can pick up the job.
+// The reconciler (running in the GC pod) then detects the stale in-flight
+// entry and transitions the orphaned job to a terminal state.
 //
 // Requires:
 //   - batch-gc running with reconciler enabled and a short interval (60s in dev-deploy)
@@ -42,16 +43,19 @@ func testOrphanRecovery(t *testing.T) {
 }
 
 // doTestHardCrashOrphanRecovery submits a batch with long-running requests,
-// force-kills the processor pod (--grace-period=0, immediate SIGKILL) while the
-// batch is in_progress, and verifies the GC reconciler transitions the orphaned
-// job to failed.
+// force-kills the processor pod and scales the deployment to 0, then verifies
+// the GC reconciler transitions the orphaned job to failed.
+//
+// Since the errShutdown handler does NOT re-enqueue, the job stays in_progress
+// in the DB regardless of whether SIGTERM or SIGKILL kills the process. Scaling
+// the deployment to 0 ensures no replacement pod can interfere.
 //
 // Timeline:
 //  1. Submit batch → wait for in_progress
-//  2. kubectl delete pod --grace-period=0 (SIGKILL, no re-enqueue possible)
-//  3. Wait for replacement processor pod to become ready
-//  4. Reconciler detects orphan (staleness threshold = reconciler interval)
-//  5. in_progress + unexpired SLO → reconciler transitions to failed
+//  2. Force-kill pod + scale to 0 (no replacement, no re-enqueue)
+//  3. Reconciler detects orphan (staleness threshold = reconciler interval)
+//  4. in_progress + stale/missing in-flight → reconciler transitions to failed
+//  5. Scale processor back to 1 (cleanup for subsequent tests)
 func doTestHardCrashOrphanRecovery(t *testing.T) {
 	t.Helper()
 
@@ -59,11 +63,8 @@ func doTestHardCrashOrphanRecovery(t *testing.T) {
 		t.Skip("kubectl not available, skipping orphan recovery test")
 	}
 
-	// Use enough slow requests to guarantee the batch is still in_progress
-	// when the force-kill arrives. Each request takes ~20s (sim-model:
-	// 50ms TTFT + 200 tokens * 100ms inter-token). The processor handles
-	// requests concurrently, so we need more requests than the concurrency
-	// limit to ensure work is still queued at kill time.
+	deployment := fmt.Sprintf("%s-processor", testHelmRelease)
+
 	var lines []string
 	for i := 1; i <= 50; i++ {
 		lines = append(lines, fmt.Sprintf(
@@ -75,70 +76,33 @@ func doTestHardCrashOrphanRecovery(t *testing.T) {
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 	time.Sleep(2 * time.Second)
 
-	// Force-kill the processor pod with --grace-period=0 (immediate SIGKILL).
-	// Unlike the graceful shutdown test (kubectl delete pod without
-	// --grace-period=0), the processor gets no chance to catch SIGTERM and
-	// re-enqueue in-flight jobs. The job remains in_progress with no
-	// processor working on it.
-	t.Log("force-killing processor pod (--grace-period=0)...")
-	out, err := exec.Command("kubectl", "delete", "pod",
-		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
-		"-n", testNamespace,
-		"--grace-period=0", "--force",
-	).CombinedOutput()
-	if err != nil {
-		t.Fatalf("kubectl delete pod --grace-period=0 failed: %v\n%s", err, out)
-	}
-	t.Logf("processor pod force-killed: %s", strings.TrimSpace(string(out)))
-
-	// Wait for the replacement pod via kubectl wait instead of port-forward.
-	// After --grace-period=0, the service endpoints may be stale for a few
-	// seconds, causing port-forward-based waitForProcessorReady to hang.
-	t.Log("waiting for replacement processor pod...")
-	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer waitCancel()
-	waitOut, waitErr := exec.CommandContext(waitCtx, "kubectl", "wait",
-		"--for=condition=Ready",
-		"pod",
-		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
-		"-n", testNamespace,
-		"--timeout=120s",
-	).CombinedOutput()
-	if waitErr != nil {
-		t.Fatalf("waiting for replacement processor pod: %v\n%s", waitErr, waitOut)
-	}
-	t.Logf("replacement processor pod ready: %s", strings.TrimSpace(string(waitOut)))
+	killAndScaleDown(t, deployment)
+	t.Cleanup(func() { scaleUp(t, deployment) })
 
 	// Wait for the reconciler to detect the orphan and transition it to failed.
 	// With reconciler interval=60s (dev-deploy):
-	//   - Staleness threshold: 60s after last heartbeat
+	//   - Staleness threshold: 60s after last heartbeat (or immediate if in-flight
+	//     entry was deleted by the processor's defer before process death)
 	//   - Next cycle: up to 60s after staleness
 	//   - Total: ~2m + buffer
-	// The reconciler runs in batch-gc, not the processor, so killing the
-	// processor does not affect reconciler cycles.
-	//
-	// Use waitForOrphanTerminal instead of waitForBatchStatus because the
-	// reconciler preserves whatever request counts existed at crash time
-	// (Completed+Failed != Total) and does not upload output/error files,
-	// which validateTerminalBatch/validateBatchResults would reject.
 	finalBatch := waitForOrphanTerminal(t, batchID, 5*time.Minute, openai.BatchStatusFailed)
 
 	t.Logf("orphan recovery: batch %s reached %s", batchID, finalBatch.Status)
 }
 
 // doTestCancellingOrphanRecovery submits a batch, waits for it to reach
-// in_progress, cancels it (status becomes cancelling), then immediately
-// force-kills the processor pod so it cannot complete the cancellation.
-// The GC reconciler should detect the orphaned cancelling job and transition
-// it to cancelled.
+// in_progress, cancels it (status becomes cancelling), then force-kills the
+// processor pod and scales to 0 so it cannot complete the cancellation. The
+// GC reconciler should detect the orphaned cancelling job and transition it
+// to cancelled.
 //
 // Timeline:
 //  1. Submit batch → wait for in_progress
 //  2. Wait for at least 1 request to complete (deterministic timing)
 //  3. Cancel batch → verify cancelling status
-//  4. Immediately kubectl delete pod --grace-period=0 (SIGKILL)
-//  5. Wait for replacement processor pod
-//  6. Reconciler detects orphan → cancelling transitions to cancelled
+//  4. Force-kill pod + scale to 0 (no replacement, no cancel handling)
+//  5. Reconciler detects orphan → cancelling transitions to cancelled
+//  6. Scale processor back to 1 (cleanup)
 func doTestCancellingOrphanRecovery(t *testing.T) {
 	t.Helper()
 
@@ -146,11 +110,8 @@ func doTestCancellingOrphanRecovery(t *testing.T) {
 		t.Skip("kubectl not available, skipping cancelling orphan recovery test")
 	}
 
-	// Mix fast and slow requests (same pattern as doTestBatchCancel):
-	//   - Fast requests (max_tokens=1): complete in ~150ms, giving us a
-	//     deterministic signal to proceed with cancel.
-	//   - Slow requests (max_tokens=200): take ~20s each, ensuring
-	//     work is still in-flight when we cancel and kill.
+	deployment := fmt.Sprintf("%s-processor", testHelmRelease)
+
 	var lines []string
 	for i := 1; i <= 5; i++ {
 		lines = append(lines, fmt.Sprintf(
@@ -165,12 +126,8 @@ func doTestCancellingOrphanRecovery(t *testing.T) {
 
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 
-	// Wait for at least one fast request to complete before cancelling,
-	// ensuring the batch is fully in_progress and processing.
 	waitForCompletedRequests(t, batchID, 1, 2*time.Minute)
 
-	// Cancel the batch — apiserver writes cancelling to DB first, then
-	// sends the cancel event to the processor.
 	client := newClient()
 	batch, err := client.Batches.Cancel(context.Background(), batchID)
 	if err != nil {
@@ -181,21 +138,80 @@ func doTestCancellingOrphanRecovery(t *testing.T) {
 	}
 	t.Logf("batch %s is now cancelling", batchID)
 
-	// Immediately force-kill the processor pod so it cannot complete the
-	// cancel handling (handleCancelled → partial upload → cancelled).
-	t.Log("force-killing processor pod (--grace-period=0)...")
-	out, err := exec.Command("kubectl", "delete", "pod",
-		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
+	killAndScaleDown(t, deployment)
+	t.Cleanup(func() { scaleUp(t, deployment) })
+
+	finalBatch := waitForOrphanTerminal(t, batchID, 5*time.Minute, openai.BatchStatusCancelled)
+
+	t.Logf("cancelling orphan recovery: batch %s reached %s (cancelled_at=%d)",
+		batchID, finalBatch.Status, finalBatch.CancelledAt)
+
+	if finalBatch.CancelledAt == 0 {
+		t.Error("expected cancelled_at to be set")
+	}
+}
+
+// killAndScaleDown force-kills all processor pods and scales the deployment
+// to 0 replicas. Since the processor does NOT re-enqueue on SIGTERM (the
+// errShutdown handler is a no-op), a simple force-kill is sufficient — the
+// scale-to-0 just prevents replacement pods from interfering with the
+// reconciler's orphan detection.
+func killAndScaleDown(t *testing.T, deployment string) {
+	t.Helper()
+
+	podSelector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease)
+
+	killOut, killErr := exec.Command("kubectl", "delete", "pod",
+		"-l", podSelector,
 		"-n", testNamespace,
 		"--grace-period=0", "--force",
 	).CombinedOutput()
-	if err != nil {
-		t.Fatalf("kubectl delete pod --grace-period=0 failed: %v\n%s", err, out)
+	if killErr != nil {
+		t.Logf("force-kill pods (may be already gone): %v\n%s", killErr, killOut)
+	} else {
+		t.Logf("force-killed processor pods: %s", strings.TrimSpace(string(killOut)))
 	}
-	t.Logf("processor pod force-killed: %s", strings.TrimSpace(string(out)))
 
-	// Wait for the replacement pod.
-	t.Log("waiting for replacement processor pod...")
+	scaleOut, scaleErr := exec.Command("kubectl", "scale",
+		fmt.Sprintf("deployment/%s", deployment),
+		"--replicas=0",
+		"-n", testNamespace,
+	).CombinedOutput()
+	if scaleErr != nil {
+		t.Fatalf("kubectl scale --replicas=0 failed: %v\n%s", scaleErr, scaleOut)
+	}
+	t.Logf("scaled %s to 0: %s", deployment, strings.TrimSpace(string(scaleOut)))
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer waitCancel()
+	waitOut, waitErr := exec.CommandContext(waitCtx, "kubectl", "wait",
+		"--for=delete",
+		"pod",
+		"-l", podSelector,
+		"-n", testNamespace,
+		"--timeout=120s",
+	).CombinedOutput()
+	if waitErr != nil {
+		t.Logf("wait for pod deletion (may be already gone): %v\n%s", waitErr, waitOut)
+	}
+}
+
+// scaleUp scales the given deployment back to 1 replica and waits for it
+// to become ready. Used in t.Cleanup to restore the processor for subsequent tests.
+func scaleUp(t *testing.T, deployment string) {
+	t.Helper()
+
+	out, err := exec.Command("kubectl", "scale",
+		fmt.Sprintf("deployment/%s", deployment),
+		"--replicas=1",
+		"-n", testNamespace,
+	).CombinedOutput()
+	if err != nil {
+		t.Logf("kubectl scale --replicas=1 failed (cleanup): %v\n%s", err, out)
+		return
+	}
+	t.Logf("scaled %s back to 1: %s", deployment, strings.TrimSpace(string(out)))
+
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer waitCancel()
 	waitOut, waitErr := exec.CommandContext(waitCtx, "kubectl", "wait",
@@ -206,19 +222,10 @@ func doTestCancellingOrphanRecovery(t *testing.T) {
 		"--timeout=120s",
 	).CombinedOutput()
 	if waitErr != nil {
-		t.Fatalf("waiting for replacement processor pod: %v\n%s", waitErr, waitOut)
+		t.Logf("waiting for processor pod ready (cleanup): %v\n%s", waitErr, waitOut)
+		return
 	}
-	t.Logf("replacement processor pod ready: %s", strings.TrimSpace(string(waitOut)))
+	t.Logf("processor pod ready after scale-up: %s", strings.TrimSpace(string(waitOut)))
 
-	// Wait for the reconciler to detect the orphan and transition
-	// cancelling → cancelled. Use waitForOrphanTerminal because the
-	// reconciler does not upload partial results or update request counts.
-	finalBatch := waitForOrphanTerminal(t, batchID, 5*time.Minute, openai.BatchStatusCancelled)
-
-	t.Logf("cancelling orphan recovery: batch %s reached %s (cancelled_at=%d)",
-		batchID, finalBatch.Status, finalBatch.CancelledAt)
-
-	if finalBatch.CancelledAt == 0 {
-		t.Error("expected cancelled_at to be set")
-	}
+	waitForProcessorReady(t, 2*time.Minute)
 }

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -25,31 +25,33 @@ import (
 	"github.com/openai/openai-go/v3"
 )
 
-// testProcessorGracefulShutdown covers the processor's SIGTERM -> context.Canceled
-// -> re-enqueue path using two different Kubernetes triggers:
-//   - PodDeleteMidJob: kubectl delete pod (standard termination grace period)
-//   - RollingRestartReEnqueue: kubectl rollout restart
+// testProcessorGracefulShutdown covers the processor's behavior on SIGTERM:
+// the processor exits without re-enqueueing, and the GC reconciler detects
+// the orphaned job and transitions it to a terminal state.
 //
-// Both deliver SIGTERM and wait terminationGracePeriodSeconds (60s) before
-// SIGKILL, giving the processor ample time to re-enqueue in-flight jobs.
-// Neither test covers recoverStaleJobs (workdir scan on startup) or true
-// hard-crash (SIGKILL-only) scenarios.
+//   - PodDeleteMidJob: kubectl delete pod (standard termination grace period)
+//   - RollingRestartOrphan: kubectl rollout restart
+//
+// Both deliver SIGTERM. The processor catches SIGTERM via
+// interrupt.ContextWithSignal, cancels the polling context, and the
+// errShutdown handler leaves the job in its current state. The GC
+// reconciler then detects the stranded job and marks it failed.
 func testProcessorGracefulShutdown(t *testing.T) {
 	t.Run("PodDeleteMidJob", doTestPodDeleteMidJob)
-	t.Run("RollingRestartReEnqueue", doTestRollingRestartReEnqueue)
+	t.Run("RollingRestartOrphan", doTestRollingRestartReEnqueue)
 }
 
 // doTestPodDeleteMidJob submits a batch with long-running requests
 // (max_tokens=200 on testModel; dev-deploy's default sim-model uses ~50ms TTFT
 // and ~100ms inter-token latency), deletes the processor pod mid-execution, and
-// verifies the batch completes after a replacement pod comes up.
+// verifies the GC reconciler transitions the orphaned job to failed.
 //
 // kubectl delete pod sends SIGTERM and respects the pod's
 // terminationGracePeriodSeconds (60s). The processor catches SIGTERM via
-// interrupt.ContextWithSignal, cancels the polling context, and in-flight
-// workers re-enqueue the job via a detached context (see Processor.handleJobError
-// in job_runner.go). A new pod dequeues and reprocesses the job from scratch
-// (no checkpoint/resume).
+// interrupt.ContextWithSignal, cancels the polling context, and the
+// errShutdown handler exits without re-enqueueing. The job stays in_progress
+// in the DB with no queue entry. The GC reconciler detects this orphan on
+// its next cycle and transitions the job to failed.
 func doTestPodDeleteMidJob(t *testing.T) {
 	t.Helper()
 
@@ -65,12 +67,9 @@ func doTestPodDeleteMidJob(t *testing.T) {
 	fileID := mustCreateFile(t, fmt.Sprintf("test-pod-delete-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)
 
-	// Wait for in_progress so the processor has picked up the job.
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 	time.Sleep(2 * time.Second)
 
-	// Delete the processor pod. Kubelet delivers SIGTERM and waits
-	// terminationGracePeriodSeconds (60s) before SIGKILL.
 	t.Log("deleting processor pod...")
 	out, err := exec.Command("kubectl", "delete", "pod",
 		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=processor", testHelmRelease),
@@ -81,37 +80,26 @@ func doTestPodDeleteMidJob(t *testing.T) {
 	}
 	t.Logf("processor pod delete issued: %s", strings.TrimSpace(string(out)))
 
-	// Wait for the new pod to become ready.
 	waitForProcessorReady(t, 2*time.Minute)
 	t.Log("new processor pod is ready")
 
-	// The re-enqueue path should succeed reliably with the full grace period.
-	// failed is accepted in waitForBatchStatus to avoid a fatal on unlikely
-	// edge cases (e.g. transient Redis error), but we expect completed.
-	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
-		openai.BatchStatusCompleted, openai.BatchStatusFailed)
+	// The orphan reconciler detects the stranded in_progress job (not in
+	// queue, stale or missing in-flight entry) and transitions it to failed.
+	// Use waitForOrphanTerminal because the reconciler's transition preserves
+	// whatever request counts existed at crash time and does not upload files.
+	finalBatch := waitForOrphanTerminal(t, batchID, 5*time.Minute, openai.BatchStatusFailed)
 
 	t.Logf("pod delete: batch %s reached %s (completed=%d, failed=%d, total=%d)",
 		batchID, finalBatch.Status,
 		finalBatch.RequestCounts.Completed,
 		finalBatch.RequestCounts.Failed,
 		finalBatch.RequestCounts.Total)
-
-	if finalBatch.Status != openai.BatchStatusCompleted {
-		t.Errorf("expected batch to complete after pod delete, got %s", finalBatch.Status)
-	}
-	if finalBatch.RequestCounts.Completed != finalBatch.RequestCounts.Total {
-		t.Errorf("expected all %d requests to complete after graceful shutdown, got completed=%d failed=%d",
-			finalBatch.RequestCounts.Total,
-			finalBatch.RequestCounts.Completed,
-			finalBatch.RequestCounts.Failed)
-	}
 }
 
 // doTestRollingRestartReEnqueue submits a batch with the same slow-request
 // pattern as doTestPodDeleteMidJob, triggers a rolling restart of the processor
-// deployment, and verifies the batch eventually completes. Same SIGTERM ->
-// re-enqueue path, different trigger.
+// deployment, and verifies the GC reconciler transitions the orphaned job to
+// failed. Same SIGTERM -> orphan -> reconciler path, different trigger.
 func doTestRollingRestartReEnqueue(t *testing.T) {
 	t.Helper()
 
@@ -130,7 +118,6 @@ func doTestRollingRestartReEnqueue(t *testing.T) {
 	_, _ = waitForBatchStatus(t, batchID, 2*time.Minute, openai.BatchStatusInProgress)
 	time.Sleep(2 * time.Second)
 
-	// Trigger a rolling restart (graceful shutdown via SIGTERM).
 	deployment := fmt.Sprintf("%s-processor", testHelmRelease)
 	t.Logf("triggering rolling restart of %s...", deployment)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -144,30 +131,17 @@ func doTestRollingRestartReEnqueue(t *testing.T) {
 	}
 	t.Logf("rollout restart triggered: %s", strings.TrimSpace(string(out)))
 
-	// Wait for rollout to complete.
 	waitForRollout(t, deployment)
 	waitForProcessorReady(t, 2*time.Minute)
 	t.Log("processor rollout complete and ready")
 
-	// Same re-enqueue path as PodDeleteMidJob. completed is expected; failed
-	// is accepted in waitForBatchStatus to avoid a fatal on unlikely edge
-	// cases, but we assert completed below.
-	finalBatch, _ := waitForBatchStatus(t, batchID, 5*time.Minute,
-		openai.BatchStatusCompleted, openai.BatchStatusFailed)
+	// Same reconciler path as PodDeleteMidJob: the orphaned job is detected
+	// and transitioned to failed.
+	finalBatch := waitForOrphanTerminal(t, batchID, 5*time.Minute, openai.BatchStatusFailed)
 
 	t.Logf("rolling restart: batch %s reached %s (completed=%d, failed=%d, total=%d)",
 		batchID, finalBatch.Status,
 		finalBatch.RequestCounts.Completed,
 		finalBatch.RequestCounts.Failed,
 		finalBatch.RequestCounts.Total)
-
-	if finalBatch.Status != openai.BatchStatusCompleted {
-		t.Errorf("expected batch to complete after rolling restart, got %s", finalBatch.Status)
-	}
-	if finalBatch.RequestCounts.Completed != finalBatch.RequestCounts.Total {
-		t.Errorf("expected all %d requests to complete after graceful shutdown, got completed=%d failed=%d",
-			finalBatch.RequestCounts.Total,
-			finalBatch.RequestCounts.Completed,
-			finalBatch.RequestCounts.Failed)
-	}
 }


### PR DESCRIPTION
## Why is this PR needed?

The orphan recovery tests merged in #531 exposed two issues in CI (#532):

1. The `ProcessorGracefulShutdown/RollingRestartReEnqueue` test expected re-enqueue
   behavior on SIGTERM, but the reconciler (newly enabled in dev-deploy) marked the
   job as `failed` before re-enqueue could complete — a race between two recovery paths.
2. The hardcoded `heartbeatInterval` (5m) was far longer than the dev-deploy
   `reconciler.interval` (60s), causing the reconciler to falsely mark active jobs
   as orphaned when the first heartbeat tick hadn't fired yet.

Resolves the existing TODO to remove SIGTERM re-enqueue and delegate recovery
entirely to the orphan reconciler, eliminating the dual-path race.

## What does this PR do?

**Remove SIGTERM re-enqueue (stale TODO)**
- The `errShutdown` handler in `job_runner.go` no longer re-enqueues. On SIGTERM,
  the job stays in its current state for the reconciler to transition to `failed`.
- Simplifies the shutdown path: processor exits, reconciler cleans up.

**Make `heartbeat_interval` configurable**
- Add `HeartbeatInterval` to `ProcessorConfig` (default 5m, matching production
  reconciler default of 60m).
- dev-deploy sets it to 10s so the reconciler (30s interval) always sees fresh
  in-flight entries for active jobs.
- Fixes the false-orphan bug that caused AIMD/Recovery to fail intermittently.

**Update e2e tests**
- `ProcessorGracefulShutdown` tests now expect `failed` (reconciler-driven) instead
  of `completed` (re-enqueue-driven).
- `OrphanRecovery` tests simplified — no need to race against re-enqueue.
- Test timeout increased from 10m (Go default) to 20m to accommodate reconciler
  wait times.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed (full `make test-e2e` pass locally)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #532
Follow-up to #531 