### PR TITLE
fix(benchmark): use $(CONTAINER_TOOL) instead of hardcoded docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ BENCHMARK_RESULTS_DIR ?= benchmarks/results/local-run
 benchmark-local:
 	@kind get clusters 2>/dev/null | grep -q $(KIND_CLUSTER_NAME) || \
 		{ echo "ERROR: Kind cluster '$(KIND_CLUSTER_NAME)' not found. Run 'make dev-deploy' first."; exit 1; }
-	@docker exec $(KIND_CLUSTER_NAME)-control-plane crictl images 2>/dev/null | grep -q batch-gateway-apiserver || \
+	@$(CONTAINER_TOOL) exec $(KIND_CLUSTER_NAME)-control-plane crictl images 2>/dev/null | grep -q batch-gateway-apiserver || \
 		{ echo "ERROR: batch-gateway images not loaded in Kind. Run 'make dev-deploy' first."; exit 1; }
 	@echo "=== Benchmark local e2e (MODE=sim, scenario $(BENCHMARK_SCENARIO)) ==="
 	@echo "Step 1/4: Setting up infrastructure..."


### PR DESCRIPTION
## Why is this PR needed?

The `benchmark-local` target's image precheck calls `docker exec` directly. The Makefile already resolves the container tool into `$(CONTAINER_TOOL)` and uses it for every image build. On hosts where docker is not installed and podman is used, the precheck fails and reports "batch-gateway images not loaded in Kind" even when
the images are present, which makes `make benchmark-local` unrunnable.

## What does this PR do?

Replaces the hardcoded `docker exec` in the `benchmark-local` precheck with `$(CONTAINER_TOOL) exec`. `$(CONTAINER_TOOL)` resolves to `docker` when docker is present and `podman` otherwise, so docker users are unaffected and podman users can run the target. This was the only line in the benchmark path not already using
`$(CONTAINER_TOOL)`.

## How was this tested?

Ran `make benchmark-local` on a podman host. It failed before this change with a false "images not loaded" error and completed the full pipeline after.

- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

N/A