### PR TITLE
ci: add helm lint values matrix for multi-config coverage

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -46,4 +46,8 @@ jobs:
         run: make test-integration
 
       - name: Lint Helm chart
-        run: helm lint charts/batch-gateway
+        run: |
+          helm lint charts/batch-gateway
+          for f in charts/batch-gateway/ci/values-*.yaml; do
+            helm lint charts/batch-gateway -f "$f"
+          done

--- a/charts/batch-gateway/ci/values-aimd-disabled.yaml
+++ b/charts/batch-gateway/ci/values-aimd-disabled.yaml
@@ -1,0 +1,12 @@
+# Exercises: static concurrency path with AIMD disabled.
+# Default has aimd.enabled: true; this tests the false branch.
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"
+
+processor:
+  config:
+    concurrency:
+      aimd:
+        enabled: false

--- a/charts/batch-gateway/ci/values-flow-control.yaml
+++ b/charts/batch-gateway/ci/values-flow-control.yaml
@@ -1,0 +1,20 @@
+# Exercises: inferenceObjective conditional (processor-configmap.yaml:47-49),
+# sendFairnessHeader conditional (line 103-104),
+# and OTel env var block (apiserver/processor-deployment.yaml)
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"
+  otel:
+    endpoint: "http://otel-collector:4317"
+
+processor:
+  config:
+    globalInferenceGateway:
+      url: "http://inference-gateway:8000"
+      inferenceObjective: "batch-sheddable"
+      requestTimeout: "5m"
+      maxRetries: 3
+      initialBackoff: "1s"
+      maxBackoff: "60s"
+    sendFairnessHeader: true

--- a/charts/batch-gateway/ci/values-global-gateway.yaml
+++ b/charts/batch-gateway/ci/values-global-gateway.yaml
@@ -1,0 +1,14 @@
+# Exercises: globalInferenceGateway template path (processor-configmap.yaml:44-70)
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"
+
+processor:
+  config:
+    globalInferenceGateway:
+      url: "http://inference-gateway:8000"
+      requestTimeout: "5m"
+      maxRetries: 3
+      initialBackoff: "1s"
+      maxBackoff: "60s"

--- a/charts/batch-gateway/ci/values-image-digest.yaml
+++ b/charts/batch-gateway/ci/values-image-digest.yaml
@@ -1,0 +1,18 @@
+# Exercises: image digest template branches (_helpers.tpl:124-130, 184-190, 239-245).
+# Default uses tag; this tests the digest path (repo@sha256:... instead of repo:tag).
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"
+
+apiserver:
+  image:
+    digest: "sha256:abc123"
+
+processor:
+  image:
+    digest: "sha256:def456"
+
+gc:
+  image:
+    digest: "sha256:789ghi"

--- a/charts/batch-gateway/ci/values-minimal.yaml
+++ b/charts/batch-gateway/ci/values-minimal.yaml
@@ -1,0 +1,6 @@
+# Exercises: default values with only the minimum required override.
+# Validates that all templates render with near-default configuration.
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"

--- a/charts/batch-gateway/ci/values-model-gateways.yaml
+++ b/charts/batch-gateway/ci/values-model-gateways.yaml
@@ -1,0 +1,23 @@
+# Exercises: modelGateways template path with range loop (processor-configmap.yaml:72-101)
+# Includes inferenceObjective on one model to cover the per-model conditional (line 77-78)
+global:
+  fileClient:
+    fs:
+      pvcName: "batch-data"
+
+processor:
+  config:
+    modelGateways:
+      "llama-3":
+        url: "http://gie-a-epp:8081"
+        inferenceObjective: "batch-sheddable-a"
+        requestTimeout: "5m"
+        maxRetries: 3
+        initialBackoff: "1s"
+        maxBackoff: "60s"
+      "mistral":
+        url: "http://gie-b-epp:8081"
+        requestTimeout: "2m"
+        maxRetries: 1
+        initialBackoff: "1s"
+        maxBackoff: "30s"


### PR DESCRIPTION
## Why is this PR needed?

`helm lint` only runs against the default `values.yaml`. Template branches behind `globalInferenceGateway`, `modelGateways`, `inferenceObjective`, AIMD toggle, and image digest conditionals are never exercised. A broken template in any of those paths merges silently.

## What does this PR do?

Adds 6 values files in `charts/batch-gateway/ci/` and updates the pre-commit workflow to lint each one:

| File | Branch exercised |
|------|-----------------|
| `values-global-gateway.yaml` | `with .globalInferenceGateway` (configmap:44-70) |
| `values-model-gateways.yaml` | `if .modelGateways` + `range` loop (configmap:72-101) |
| `values-flow-control.yaml` | `inferenceObjective`, `sendFairnessHeader`, OTel env vars |
| `values-minimal.yaml` | All templates with near-default values |
| `values-aimd-disabled.yaml` | `aimd.enabled: false` static concurrency path |
| `values-image-digest.yaml` | `if .digest` image reference branches (helpers:124, 184, 239) |

## How was this tested?

- [x] Manual testing performed
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified

All 7 lint runs pass locally (1 default + 6 variants, exit 0, zero warnings on variants).

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #412