### PR TITLE
test: stabilize rolling restart graceful shutdown e2e

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -54,6 +54,7 @@ var (
 
 	// testSimService* hold the Kubernetes service names for the simulators.
 	// Must match VLLM_SIM_*_NAME in dev-common.sh (overridable via env).
+	testSimService     = getEnvOrDefault("TEST_SIM_SERVICE", "vllm-sim")
 	testSimService429  = getEnvOrDefault("TEST_SIM_SERVICE_429", "vllm-sim-429")
 	testSimServiceAIMD = getEnvOrDefault("TEST_SIM_SERVICE_AIMD", "vllm-sim-aimd")
 

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -96,16 +96,30 @@ func doTestPodDeleteMidJob(t *testing.T) {
 		finalBatch.RequestCounts.Total)
 }
 
-// doTestRollingRestartReEnqueue submits a batch with the same slow-request
-// pattern as doTestPodDeleteMidJob, triggers a rolling restart of the processor
-// deployment, and verifies the GC reconciler transitions the orphaned job to
-// failed. Same SIGTERM -> orphan -> reconciler path, different trigger.
+// doTestRollingRestartReEnqueue submits a batch, triggers a rolling restart of
+// the processor deployment, and verifies the GC reconciler transitions the
+// orphaned job to failed. Same SIGTERM -> orphan -> reconciler path as
+// PodDeleteMidJob, different trigger.
+//
+// Rolling restart delivers SIGTERM only after the new pod is Ready (~12s).
+// To guarantee requests are still in-flight when SIGTERM arrives, we set the
+// simulator's inter-token latency to 30s via /admin/config. This makes even a
+// single generated token take longer than the new-pod startup delay, eliminating
+// the race between request completion and SIGTERM delivery.
 func doTestRollingRestartReEnqueue(t *testing.T) {
 	t.Helper()
 
 	if !testKubectlAvailable {
 		t.Skip("kubectl not available, skipping rolling restart test")
 	}
+
+	// Slow down the simulator so requests cannot complete before SIGTERM arrives.
+	setSimAdminConfig(t, testSimService, `{"inter-token-latency":"30s"}`)
+	t.Cleanup(func() {
+		if err := trySetSimAdminConfig(t, testSimService, `{"inter-token-latency":"100ms"}`); err != nil {
+			t.Errorf("cleanup: failed to restore %s inter-token-latency: %v", testSimService, err)
+		}
+	})
 
 	var lines []string
 	for i := 1; i <= 10; i++ {


### PR DESCRIPTION
## Why is this PR needed?

The `ProcessorGracefulShutdown/RollingRestartOrphan` e2e test was flaky in CI and opened issue #542.
During a rolling restart, the old processor pod does not receive `SIGTERM` until the replacement pod becomes Ready, so the batch could finish before shutdown happened. When that race won, the test observed `completed` instead of exercising the orphan-recovery path.

## What does this PR do?

This PR makes the graceful shutdown expectation explicit and removes the rolling-restart timing race.

- Clarifies that the graceful shutdown tests cover the `SIGTERM -> orphaned job -> GC reconciler -> failed` path, not a re-enqueue-and-complete path
- Updates the pod-delete and rolling-restart cases to wait for orphan recovery to mark the batch `failed`
- Slows the default simulator used by the rolling-restart test via `/admin/config` so requests remain in flight until `SIGTERM` is delivered
- Restores the simulator latency in cleanup so the change does not leak into later e2e cases
- Adds the default simulator service name to the shared e2e config

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #542