### PR TITLE
fix(benchmarks): pin guidellm image to v0.6.1

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -416,7 +416,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: guidellm
-          image: ghcr.io/vllm-project/guidellm:latest
+          image: ghcr.io/vllm-project/guidellm:v0.6.1
           env:
             - name: USER
               value: "guidellm"
@@ -481,7 +481,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: guidellm
-          image: ghcr.io/vllm-project/guidellm:latest
+          image: ghcr.io/vllm-project/guidellm:v0.6.1
           env:
             - name: USER
               value: "guidellm"

--- a/benchmarks/manifests/guidellm-batch.yaml
+++ b/benchmarks/manifests/guidellm-batch.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: guidellm
-          image: ghcr.io/vllm-project/guidellm:latest
+          image: ghcr.io/vllm-project/guidellm:v0.6.1
           env:
             - name: USER
               value: "guidellm"

--- a/benchmarks/manifests/guidellm-interactive.yaml
+++ b/benchmarks/manifests/guidellm-interactive.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: guidellm
-          image: ghcr.io/vllm-project/guidellm:latest
+          image: ghcr.io/vllm-project/guidellm:v0.6.1
           env:
             - name: USER
               value: "guidellm"


### PR DESCRIPTION
## Summary
- Pin `ghcr.io/vllm-project/guidellm` from `latest` to `v0.6.1` across all benchmark manifests and `benchmark.py`
- guidellm v0.7.0 introduced breaking CLI changes (`--data`, `--profile`, `--max-seconds` syntax overhaul) that are incompatible with our current benchmark commands
- v0.6.1 is the last release before the CLI refactor

## Test plan
- [x] Verify `make benchmark-local` still works with pinned image
- [x] Confirm image `ghcr.io/vllm-project/guidellm:v0.6.1` is pullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)