### PR TITLE
ci: skip image build on forks

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   docker:
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## What does this PR do?

Skip CI release image build on forks.

## How was this tested?

Verified workflow condition logic; no functional code change.