### PR TITLE
fix(processor): make job dequeue and in-flight claim atomic

### DIFF
--- a/internal/database/api/database.go
+++ b/internal/database/api/database.go
@@ -139,6 +139,12 @@ type BatchPriorityQueueClient interface {
 	PQDequeue(ctx context.Context, timeout time.Duration, maxItems int) (
 		jobPriorities []*BatchJobPriority, err error)
 
+	// PQDequeueAndClaim atomically removes the highest-priority job from the
+	// queue and records an in-flight entry (see InFlightClient) owned by
+	// processorID. Returns (nil, nil) when the queue is empty.
+	PQDequeueAndClaim(ctx context.Context, processorID string) (
+		jobPriority *BatchJobPriority, err error)
+
 	// PQDelete deletes a job priority object from the queue.
 	// Specify the ID and SLO values for deleting. Other values are not required.
 	// It returns the number of deleted objects.

--- a/internal/database/api/database.go
+++ b/internal/database/api/database.go
@@ -127,21 +127,13 @@ type BatchPriorityQueueClient interface {
 	// PQEnqueue adds a job priority object to the queue.
 	PQEnqueue(ctx context.Context, jobPriority *BatchJobPriority) (err error)
 
-	// PQDequeue atomically removes and returns the job priority objects at the head of the queue,
-	// up to the maximum number of objects specified in maxItems.
-	// The function blocks up to the timeout value for a job priority object to be available.
-	// If the timeout value is zero or negative, the function returns immediately.
-	//
-	// Implementations MUST atomically remove dequeued items from the queue. The processor
-	// assumes exclusive dequeue semantics: a dequeued job will not be returned by any
-	// subsequent PQDequeue call. Non-atomic (peek/lease) implementations will cause the
-	// same job to be processed multiple times.
-	PQDequeue(ctx context.Context, timeout time.Duration, maxItems int) (
-		jobPriorities []*BatchJobPriority, err error)
-
 	// PQDequeueAndClaim atomically removes the highest-priority job from the
 	// queue and records an in-flight entry (see InFlightClient) owned by
 	// processorID. Returns (nil, nil) when the queue is empty.
+	//
+	// Implementations MUST pop and claim as one atomic operation: a dequeued
+	// job is never returned to a subsequent caller, and there is no
+	// intermediate state where the job is neither queued nor claimed.
 	PQDequeueAndClaim(ctx context.Context, processorID string) (
 		jobPriority *BatchJobPriority, err error)
 

--- a/internal/database/mock/mock_queue_client.go
+++ b/internal/database/mock/mock_queue_client.go
@@ -70,47 +70,6 @@ func (m *MockBatchPriorityQueueClient) PQEnqueue(ctx context.Context, jobPriorit
 	return nil
 }
 
-func (m *MockBatchPriorityQueueClient) PQDequeue(ctx context.Context, timeout time.Duration, maxObjs int) ([]*api.BatchJobPriority, error) {
-	deadline := time.Now().Add(timeout)
-
-	for {
-		m.mu.Lock()
-		if len(m.queue) > 0 {
-			// Determine how many objects to return
-			count := min(maxObjs, len(m.queue))
-
-			// Get the first 'count' items (highest priority)
-			result := make([]*api.BatchJobPriority, count)
-			copy(result, m.queue[:count])
-
-			// Remove them from the queue
-			m.queue = m.queue[count:]
-
-			m.mu.Unlock()
-			return result, nil
-		}
-		m.mu.Unlock()
-
-		// If timeout is zero, return immediately
-		if timeout == 0 {
-			return []*api.BatchJobPriority{}, nil
-		}
-
-		// Check if we've exceeded the timeout
-		if time.Now().After(deadline) {
-			return []*api.BatchJobPriority{}, nil
-		}
-
-		// Check if context is cancelled
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(10 * time.Millisecond):
-			// Small sleep before checking again
-		}
-	}
-}
-
 func (m *MockBatchPriorityQueueClient) PQDequeueAndClaim(ctx context.Context, processorID string) (*api.BatchJobPriority, error) {
 	if processorID == "" {
 		return nil, fmt.Errorf("processorID is empty")

--- a/internal/database/mock/mock_queue_client.go
+++ b/internal/database/mock/mock_queue_client.go
@@ -19,6 +19,7 @@ package mock
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -29,14 +30,23 @@ import (
 var _ api.BatchPriorityQueueClient = (*MockBatchPriorityQueueClient)(nil)
 
 type MockBatchPriorityQueueClient struct {
-	mu    sync.Mutex
-	queue []*api.BatchJobPriority
+	mu       sync.Mutex
+	queue    []*api.BatchJobPriority
+	inflight *MockInFlightClient
 }
 
 func NewMockBatchPriorityQueueClient() *MockBatchPriorityQueueClient {
 	return &MockBatchPriorityQueueClient{
 		queue: make([]*api.BatchJobPriority, 0),
 	}
+}
+
+// LinkInFlight connects an in-flight client so PQDequeueAndClaim records
+// claims in it. Without a link, claims are dropped.
+func (m *MockBatchPriorityQueueClient) LinkInFlight(inflight *MockInFlightClient) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inflight = inflight
 }
 
 func (m *MockBatchPriorityQueueClient) PQEnqueue(ctx context.Context, jobPriority *api.BatchJobPriority) error {
@@ -99,6 +109,28 @@ func (m *MockBatchPriorityQueueClient) PQDequeue(ctx context.Context, timeout ti
 			// Small sleep before checking again
 		}
 	}
+}
+
+func (m *MockBatchPriorityQueueClient) PQDequeueAndClaim(ctx context.Context, processorID string) (*api.BatchJobPriority, error) {
+	if processorID == "" {
+		return nil, fmt.Errorf("processorID is empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.queue) == 0 {
+		return nil, nil
+	}
+	item := m.queue[0]
+	m.queue = m.queue[1:]
+
+	if m.inflight != nil {
+		if err := m.inflight.InFlightSet(ctx, item.ID, processorID); err != nil {
+			return nil, err
+		}
+	}
+	return item, nil
 }
 
 func (m *MockBatchPriorityQueueClient) PQDelete(ctx context.Context, jobPriority *api.BatchJobPriority) (nDeleted int, err error) {

--- a/internal/database/mock/mock_queue_client.go
+++ b/internal/database/mock/mock_queue_client.go
@@ -32,7 +32,7 @@ var _ api.BatchPriorityQueueClient = (*MockBatchPriorityQueueClient)(nil)
 type MockBatchPriorityQueueClient struct {
 	mu       sync.Mutex
 	queue    []*api.BatchJobPriority
-	inflight *MockInFlightClient
+	inflight api.InFlightClient
 }
 
 func NewMockBatchPriorityQueueClient() *MockBatchPriorityQueueClient {
@@ -41,9 +41,9 @@ func NewMockBatchPriorityQueueClient() *MockBatchPriorityQueueClient {
 	}
 }
 
-// LinkInFlight connects an in-flight client so PQDequeueAndClaim records
-// claims in it. Without a link, claims are dropped.
-func (m *MockBatchPriorityQueueClient) LinkInFlight(inflight *MockInFlightClient) {
+// LinkInFlight connects an in-flight client so PQDequeueAndClaim records claims
+// in it.
+func (m *MockBatchPriorityQueueClient) LinkInFlight(inflight api.InFlightClient) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.inflight = inflight
@@ -123,13 +123,17 @@ func (m *MockBatchPriorityQueueClient) PQDequeueAndClaim(ctx context.Context, pr
 		return nil, nil
 	}
 	item := m.queue[0]
+	if item == nil {
+		return nil, fmt.Errorf("queued item is nil")
+	}
+	if m.inflight == nil {
+		return nil, fmt.Errorf("in-flight client is missing")
+	}
+	if err := m.inflight.InFlightSet(ctx, item.ID, processorID); err != nil {
+		return nil, err
+	}
 	m.queue = m.queue[1:]
 
-	if m.inflight != nil {
-		if err := m.inflight.InFlightSet(ctx, item.ID, processorID); err != nil {
-			return nil, err
-		}
-	}
 	return item, nil
 }
 

--- a/internal/database/redis/redis_ds_client.go
+++ b/internal/database/redis/redis_ds_client.go
@@ -100,6 +100,10 @@ var (
 	pqGetIDsLua         string
 	redisScriptPQGetIDs = goredis.NewScript(pqGetIDsLua)
 
+	//go:embed redis_pq_dequeue_claim.lua
+	pqDequeueClaimLua         string
+	redisScriptPQDequeueClaim = goredis.NewScript(pqDequeueClaimLua)
+
 	_ db_api.BatchDBClient            = (*BatchDBClientRedis)(nil)
 	_ db_api.FileDBClient             = (*FileDBClientRedis)(nil)
 	_ db_api.BatchPriorityQueueClient = (*ExchangeDBClientRedis)(nil)

--- a/internal/database/redis/redis_ds_client_test.go
+++ b/internal/database/redis/redis_ds_client_test.go
@@ -1149,10 +1149,7 @@ func TestRedisDSClient(t *testing.T) {
 		}
 
 		// Dequeue.
-		items, err := exchClient.PQDequeue(context.Background(), 6*time.Second, nHead)
-		if err != nil {
-			t.Fatalf("Failed to dequeue items: %v", err)
-		}
+		items := drainQueueWithClaims(t, exchClient, nHead)
 		if len(items) != nHead {
 			t.Fatalf("Invalid items list length %d", len(items))
 		}
@@ -1244,11 +1241,8 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("Expected 0 deleted items for non-existent item, got %d", nDel)
 		}
 
-		// Dequeue from empty queue with timeout.
-		items, err := exchClient.PQDequeue(context.Background(), 1*time.Second, 10)
-		if err != nil {
-			t.Fatalf("Dequeue from empty queue should not error: %v", err)
-		}
+		// Dequeue from empty queue.
+		items := drainQueueWithClaims(t, exchClient, 10)
 		if len(items) != 0 {
 			t.Fatalf("Expected no items from empty queue, got %d", len(items))
 		}
@@ -1280,10 +1274,7 @@ func TestRedisDSClient(t *testing.T) {
 		}
 
 		// Dequeue all items with identical SLO.
-		items, err := exchClient.PQDequeue(context.Background(), 1*time.Second, nIdentical)
-		if err != nil {
-			t.Fatalf("Failed to dequeue items: %v", err)
-		}
+		items := drainQueueWithClaims(t, exchClient, nIdentical)
 		if len(items) != nIdentical {
 			t.Fatalf("Expected %d items, got %d", nIdentical, len(items))
 		}
@@ -1303,11 +1294,8 @@ func TestRedisDSClient(t *testing.T) {
 			}
 		}
 
-		// Dequeue with maxItems larger than queue size.
-		items, err = exchClient.PQDequeue(context.Background(), 1*time.Second, 100)
-		if err != nil {
-			t.Fatalf("Failed to dequeue items: %v", err)
-		}
+		// Drain with a cap larger than queue size.
+		items = drainQueueWithClaims(t, exchClient, 100)
 		if len(items) != nItems {
 			t.Fatalf("Expected %d items (all available), got %d", nItems, len(items))
 		}
@@ -1323,16 +1311,12 @@ func TestRedisDSClient(t *testing.T) {
 			TTL:  1000,
 			Data: largeData,
 		}
-		err = exchClient.PQEnqueue(context.Background(), largeItem)
-		if err != nil {
+		if err := exchClient.PQEnqueue(context.Background(), largeItem); err != nil {
 			t.Fatalf("Failed to enqueue item with large data: %v", err)
 		}
 
 		// Dequeue and verify item identity (Data is not stored in queue member).
-		items, err = exchClient.PQDequeue(context.Background(), 1*time.Second, 1)
-		if err != nil {
-			t.Fatalf("Failed to dequeue large item: %v", err)
-		}
+		items = drainQueueWithClaims(t, exchClient, 1)
 		if len(items) != 1 {
 			t.Fatalf("Expected 1 item, got %d", len(items))
 		}
@@ -1340,24 +1324,11 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("ID mismatch after large data enqueue")
 		}
 
-		// Test dequeue with maxItems=0 - should error.
-		item := &db_api.BatchJobPriority{
-			ID:   uuid.New().String(),
-			SLO:  time.Now().Add(time.Hour),
-			TTL:  1000,
-			Data: []byte("test"),
-		}
-		_ = exchClient.PQEnqueue(context.Background(), item)
-		_, err = exchClient.PQDequeue(context.Background(), 1*time.Second, 0)
-		if err == nil {
-			t.Fatalf("Dequeue with maxItems=0 should error")
-		}
-
 		// Cleanup remaining items if any.
-		_, _ = exchClient.PQDequeue(context.Background(), 1*time.Second, 100)
+		drainQueueWithClaims(t, exchClient, 100)
 	})
 
-	t.Run("Queue exchange operations - Zero timeout uses ZMPop", func(t *testing.T) {
+	t.Run("Queue exchange operations - Priority ordering", func(t *testing.T) {
 		if minirds != nil {
 			t.Skip("Miniredis model")
 		}
@@ -1373,80 +1344,29 @@ func TestRedisDSClient(t *testing.T) {
 				ID:   uuid.New().String(),
 				SLO:  time.Now().Add(time.Duration(i+1) * time.Hour),
 				TTL:  1000,
-				Data: []byte(fmt.Sprintf("zero-timeout-%d", i)),
+				Data: []byte(fmt.Sprintf("ordering-%d", i)),
 			}
 			if err := exchClient.PQEnqueue(context.Background(), enqueued[i]); err != nil {
 				t.Fatalf("Failed to enqueue: %v", err)
 			}
 		}
 
-		// Dequeue with timeout=0 (non-blocking ZMPop path).
-		items, err := exchClient.PQDequeue(context.Background(), 0, 2)
-		if err != nil {
-			t.Fatalf("PQDequeue with zero timeout should not error: %v", err)
-		}
+		// Claims come out lowest SLO first.
+		items := drainQueueWithClaims(t, exchClient, 2)
 		if len(items) != 2 {
 			t.Fatalf("Expected 2 items, got %d", len(items))
 		}
-		// Verify priority ordering (lowest SLO first).
 		isSamePrio(t, items[0], enqueued[0])
 		isSamePrio(t, items[1], enqueued[1])
 
-		// Dequeue remaining item.
-		items, err = exchClient.PQDequeue(context.Background(), 0, 10)
-		if err != nil {
-			t.Fatalf("PQDequeue with zero timeout should not error: %v", err)
-		}
+		items = drainQueueWithClaims(t, exchClient, 10)
 		if len(items) != 1 {
 			t.Fatalf("Expected 1 item, got %d", len(items))
 		}
 		isSamePrio(t, items[0], enqueued[2])
 
-		// Dequeue from empty queue with zero timeout — should return immediately with no items.
-		items, err = exchClient.PQDequeue(context.Background(), 0, 10)
-		if err != nil {
-			t.Fatalf("PQDequeue from empty queue with zero timeout should not error: %v", err)
-		}
-		if len(items) != 0 {
-			t.Fatalf("Expected no items from empty queue, got %d", len(items))
-		}
-	})
-
-	t.Run("Queue exchange operations - Negative timeout uses ZMPop", func(t *testing.T) {
-		if minirds != nil {
-			t.Skip("Miniredis model")
-		}
-		baseClient, _, _, exchClient := setupRedisDSClients(t, redisUrl, redisCaCert)
-		t.Cleanup(func() {
-			_ = baseClient.Close()
-		})
-
-		// Enqueue an item.
-		item := &db_api.BatchJobPriority{
-			ID:   uuid.New().String(),
-			SLO:  time.Now().Add(time.Hour),
-			TTL:  1000,
-			Data: []byte("negative-timeout"),
-		}
-		if err := exchClient.PQEnqueue(context.Background(), item); err != nil {
-			t.Fatalf("Failed to enqueue: %v", err)
-		}
-
-		// Dequeue with negative timeout — should use non-blocking ZMPop path.
-		items, err := exchClient.PQDequeue(context.Background(), -1*time.Second, 1)
-		if err != nil {
-			t.Fatalf("PQDequeue with negative timeout should not error: %v", err)
-		}
-		if len(items) != 1 {
-			t.Fatalf("Expected 1 item, got %d", len(items))
-		}
-		isSamePrio(t, items[0], item)
-
-		// Dequeue from empty queue with negative timeout — should return immediately.
-		items, err = exchClient.PQDequeue(context.Background(), -5*time.Second, 10)
-		if err != nil {
-			t.Fatalf("PQDequeue from empty queue with negative timeout should not error: %v", err)
-		}
+		// Empty queue returns immediately with no items.
+		items = drainQueueWithClaims(t, exchClient, 10)
 		if len(items) != 0 {
 			t.Fatalf("Expected no items from empty queue, got %d", len(items))
 		}
@@ -2535,10 +2455,7 @@ func TestRedisDSClient(t *testing.T) {
 				}
 
 				if tt.dequeue > 0 {
-					items, err := exchClient.PQDequeue(context.Background(), 1*time.Second, tt.dequeue)
-					if err != nil {
-						t.Fatalf("Failed to dequeue: %v", err)
-					}
+					items := drainQueueWithClaims(t, exchClient, tt.dequeue)
 					if len(items) != tt.dequeue {
 						t.Fatalf("expected %d dequeued, got %d", tt.dequeue, len(items))
 					}
@@ -2568,7 +2485,7 @@ func TestRedisDSClient(t *testing.T) {
 
 				// Cleanup: drain remaining items.
 				if tt.wantSize > 0 {
-					_, _ = exchClient.PQDequeue(context.Background(), 1*time.Second, tt.wantSize)
+					drainQueueWithClaims(t, exchClient, tt.wantSize)
 				}
 			})
 		}
@@ -2605,10 +2522,7 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("Failed to enqueue without Data: %v", err)
 		}
 
-		items, err := exchClient.PQDequeue(context.Background(), 1*time.Second, 10)
-		if err != nil {
-			t.Fatalf("Failed to dequeue: %v", err)
-		}
+		items := drainQueueWithClaims(t, exchClient, 10)
 		if len(items) != 1 {
 			t.Fatalf("Expected 1 item (dedup), got %d", len(items))
 		}
@@ -2701,7 +2615,7 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("Surviving jobs missing from queue")
 		}
 
-		_, _ = exchClient.PQDequeue(context.Background(), 1*time.Second, 10)
+		drainQueueWithClaims(t, exchClient, 10)
 	})
 
 	t.Run("Queue - Backward compat with old-format member", func(t *testing.T) {
@@ -2732,10 +2646,7 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("Failed to ZADD old-format member: %v", err)
 		}
 
-		items, err := exchClient.PQDequeue(context.Background(), 1*time.Second, 1)
-		if err != nil {
-			t.Fatalf("PQDequeue failed: %v", err)
-		}
+		items := drainQueueWithClaims(t, exchClient, 1)
 		if len(items) != 1 {
 			t.Fatalf("Expected 1 item, got %d", len(items))
 		}
@@ -2746,6 +2657,28 @@ func TestRedisDSClient(t *testing.T) {
 			t.Fatalf("Expected Data to be populated from old-format member")
 		}
 	})
+}
+
+// drainQueueWithClaims claims up to max jobs via PQDequeueAndClaim, returning
+// them in priority order. Claims are deleted afterwards so the shared
+// in-flight hash does not leak state between subtests.
+func drainQueueWithClaims(t *testing.T, exchClient *dbredis.ExchangeDBClientRedis, max int) []*db_api.BatchJobPriority {
+	t.Helper()
+	var items []*db_api.BatchJobPriority
+	for len(items) < max {
+		item, err := exchClient.PQDequeueAndClaim(context.Background(), "test-proc")
+		if err != nil {
+			t.Fatalf("PQDequeueAndClaim failed: %v", err)
+		}
+		if item == nil {
+			break
+		}
+		if err := exchClient.InFlightDelete(context.Background(), item.ID); err != nil {
+			t.Fatalf("InFlightDelete failed: %v", err)
+		}
+		items = append(items, item)
+	}
+	return items
 }
 
 func isSamePrio(t *testing.T, a, b *db_api.BatchJobPriority) bool {

--- a/internal/database/redis/redis_pq_dequeue_claim.lua
+++ b/internal/database/redis/redis_pq_dequeue_claim.lua
@@ -18,7 +18,8 @@
 -- KEYS[2] = in-flight hash
 -- ARGV[1] = in-flight entry JSON (marshaled by the caller)
 -- Returns the popped member JSON, false when the queue is empty, or an error
--- if the popped member is corrupt.
+-- if the popped member is corrupt (the member stays dropped) or the claim
+-- write fails (the member is restored).
 
 local popped = redis.call("ZPOPMIN", KEYS[1])
 if #popped == 0 then
@@ -28,10 +29,15 @@ local member = popped[1]
 local score = popped[2]
 local ok, decoded = pcall(cjson.decode, member)
 if not ok or type(decoded) ~= "table" or type(decoded.id) ~= "string" or decoded.id == "" then
-    -- Redis scripts are not rolled back on error, so restore the popped member
-    -- before surfacing the corrupt queue entry to the caller.
-    redis.call("ZADD", KEYS[1], score, member)
-    return redis.error_reply("corrupt priority queue member")
+    -- Poison pill: restoring the member would put it back at the head of the
+    -- queue and starve every job behind it. Leave it dropped.
+    return redis.error_reply("corrupt priority queue member (dropped): " .. member)
 end
-redis.call("HSET", KEYS[2], decoded.id, ARGV[1])
+local hsetOk, hsetErr = pcall(redis.call, "HSET", KEYS[2], decoded.id, ARGV[1])
+if not hsetOk then
+    -- Script effects are not rolled back on error; restore the member so the
+    -- job is not lost between the queue and the in-flight hash.
+    redis.call("ZADD", KEYS[1], score, member)
+    return redis.error_reply("in-flight claim failed, member restored: " .. tostring(hsetErr))
+end
 return member

--- a/internal/database/redis/redis_pq_dequeue_claim.lua
+++ b/internal/database/redis/redis_pq_dequeue_claim.lua
@@ -17,18 +17,21 @@
 -- KEYS[1] = priority queue sorted set
 -- KEYS[2] = in-flight hash
 -- ARGV[1] = in-flight entry JSON (marshaled by the caller)
--- Returns the popped member JSON, or false when the queue is empty.
+-- Returns the popped member JSON, false when the queue is empty, or an error
+-- if the popped member is corrupt.
 
 local popped = redis.call("ZPOPMIN", KEYS[1])
 if #popped == 0 then
     return false
 end
 local member = popped[1]
+local score = popped[2]
 local ok, decoded = pcall(cjson.decode, member)
-if not ok or type(decoded) ~= "table" or decoded.id == nil then
-    -- Corrupt member: script effects are not rolled back on error, so raising
-    -- would eat the popped member. Return it unclaimed; the caller logs it.
-    return member
+if not ok or type(decoded) ~= "table" or type(decoded.id) ~= "string" or decoded.id == "" then
+    -- Redis scripts are not rolled back on error, so restore the popped member
+    -- before surfacing the corrupt queue entry to the caller.
+    redis.call("ZADD", KEYS[1], score, member)
+    return redis.error_reply("corrupt priority queue member")
 end
 redis.call("HSET", KEYS[2], decoded.id, ARGV[1])
 return member

--- a/internal/database/redis/redis_pq_dequeue_claim.lua
+++ b/internal/database/redis/redis_pq_dequeue_claim.lua
@@ -1,0 +1,34 @@
+-- Copyright 2026 The llm-d Authors
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+--     http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- PQDequeueAndClaim: atomically pop the highest-priority (lowest score) member
+-- from the priority queue and record an in-flight claim for it.
+-- KEYS[1] = priority queue sorted set
+-- KEYS[2] = in-flight hash
+-- ARGV[1] = in-flight entry JSON (marshaled by the caller)
+-- Returns the popped member JSON, or false when the queue is empty.
+
+local popped = redis.call("ZPOPMIN", KEYS[1])
+if #popped == 0 then
+    return false
+end
+local member = popped[1]
+local ok, decoded = pcall(cjson.decode, member)
+if not ok or type(decoded) ~= "table" or decoded.id == nil then
+    -- Corrupt member: script effects are not rolled back on error, so raising
+    -- would eat the popped member. Return it unclaimed; the caller logs it.
+    return member
+end
+redis.call("HSET", KEYS[2], decoded.id, ARGV[1])
+return member

--- a/internal/database/redis/redis_queue.go
+++ b/internal/database/redis/redis_queue.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -193,6 +194,55 @@ func (c *ExchangeDBClientRedis) PQDequeue(ctx context.Context, timeout time.Dura
 
 	logger.Info("PQDequeue: succeeded", "nItems", len(jobPriorities))
 	return
+}
+
+func (c *ExchangeDBClientRedis) PQDequeueAndClaim(ctx context.Context, processorID string) (
+	*db_api.BatchJobPriority, error) {
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	logger := logr.FromContextOrDiscard(ctx)
+	if processorID == "" {
+		return nil, fmt.Errorf("processorID is empty")
+	}
+
+	entry := db_api.InFlightEntry{
+		ProcessorID: processorID,
+		LastSeen:    time.Now().Unix(),
+	}
+	entryData, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal in-flight entry: %w", err)
+	}
+
+	cctx, ccancel := context.WithTimeout(ctx, c.timeout)
+	defer ccancel()
+	raw, err := redisScriptPQDequeueClaim.Run(cctx, c.redisClient,
+		[]string{priorityQueueKeyName, inFlightKeyName}, entryData).Result()
+	if err != nil {
+		// The script returns false on an empty queue, which go-redis maps to Nil.
+		if errors.Is(err, goredis.Nil) {
+			if time.Since(c.idleLogLast) >= c.idleLogFreq {
+				logger.Info("PQDequeueAndClaim: no items")
+				c.idleLogLast = time.Now()
+			}
+			return nil, nil
+		}
+		return nil, fmt.Errorf("PQDequeueAndClaim: %w", err)
+	}
+
+	member, ok := raw.(string)
+	if !ok {
+		return nil, fmt.Errorf("PQDequeueAndClaim: unexpected member type: %T", raw)
+	}
+	item := &db_api.BatchJobPriority{}
+	if err := json.Unmarshal([]byte(member), item); err != nil {
+		return nil, fmt.Errorf("PQDequeueAndClaim: unmarshal member: %w", err)
+	}
+
+	logger.Info("PQDequeueAndClaim: succeeded", "ID", item.ID)
+	return item, nil
 }
 
 func (c *ExchangeDBClientRedis) PQGetIDs(ctx context.Context) (map[string]bool, error) {

--- a/internal/database/redis/redis_queue.go
+++ b/internal/database/redis/redis_queue.go
@@ -164,11 +164,18 @@ func (c *ExchangeDBClientRedis) PQDequeueAndClaim(ctx context.Context, processor
 			return nil, nil
 		}
 		// The polling loop treats dequeue errors as "no work" and keeps
-		// spinning, so log here and probe the connection to surface Redis
-		// outages and read-only failovers that would otherwise be silent.
+		// spinning, so log here and (for connection-level failures) probe the
+		// connection to surface Redis outages and read-only failovers that
+		// would otherwise be silent.
 		logger.Error(err, "PQDequeueAndClaim: script failed")
-		if cerr := c.redisClientChecker.Check(ctx); cerr != nil {
-			logger.Error(cerr, "PQDequeueAndClaim: ClientCheck failed")
+		// Server-side (script) errors already prove Redis is reachable; only
+		// run the checker for connection-level failures.
+		if _, ok := err.(goredis.RedisError); !ok && ctx.Err() == nil {
+			checkCtx, cancel := context.WithTimeout(context.Background(), c.timeout)
+			defer cancel()
+			if cerr := c.redisClientChecker.Check(checkCtx); cerr != nil {
+				logger.Error(cerr, "PQDequeueAndClaim: ClientCheck failed")
+			}
 		}
 		return nil, fmt.Errorf("PQDequeueAndClaim: %w", err)
 	}

--- a/internal/database/redis/redis_queue.go
+++ b/internal/database/redis/redis_queue.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/go-logr/logr"
 	db_api "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
-	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 	goredis "github.com/redis/go-redis/v9"
 )
 
@@ -131,71 +130,6 @@ func (c *ExchangeDBClientRedis) PQDelete(ctx context.Context, item *db_api.Batch
 	return
 }
 
-func (c *ExchangeDBClientRedis) PQDequeue(ctx context.Context, timeout time.Duration, maxItems int) (
-	jobPriorities []*db_api.BatchJobPriority, err error) {
-
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	logger := logr.FromContextOrDiscard(ctx)
-
-	// Get items from the queue.
-	// Use non-blocking ZMPop when timeout is zero, blocking BZMPop otherwise.
-	var vals []goredis.Z
-	if timeout <= 0 {
-		logger.V(logging.DEBUG).Info("PQDequeue: Start ZMPop (non-blocking)")
-		_, vals, err = c.redisClient.ZMPop(
-			ctx, goredis.Min.String(), int64(maxItems), priorityQueueKeyName).Result()
-		logger.V(logging.DEBUG).Info("PQDequeue: End ZMPop")
-	} else {
-		logger.V(logging.DEBUG).Info("PQDequeue: Start BZMPop", "timeout", timeout)
-		_, vals, err = c.redisClient.BZMPop(
-			ctx, timeout, goredis.Min.String(), int64(maxItems), priorityQueueKeyName).Result()
-		logger.V(logging.DEBUG).Info("PQDequeue: End BZMPop")
-	}
-	if err != nil {
-		if unrecognizedBlockingError(err) {
-			logger.Error(err, "PQDequeue: B/ZMPop failed")
-			cerr := c.redisClientChecker.Check(ctx)
-			if cerr != nil {
-				logger.Error(err, "PQDequeue: ClientCheck failed")
-			}
-			return nil, err
-		}
-		if time.Since(c.idleLogLast) >= c.idleLogFreq {
-			logger.Info("PQDequeue: no items")
-			c.idleLogLast = time.Now()
-		}
-		return nil, nil
-	}
-	if len(vals) == 0 {
-		if time.Since(c.idleLogLast) >= c.idleLogFreq {
-			logger.Info("PQDequeue: no items")
-			c.idleLogLast = time.Now()
-		}
-		return nil, nil
-	}
-
-	jobPriorities = make([]*db_api.BatchJobPriority, 0, len(vals))
-	for _, val := range vals {
-		item := &db_api.BatchJobPriority{}
-		member, ok := val.Member.(string)
-		if !ok {
-			err = fmt.Errorf("unexpected member type: %T", val.Member)
-			return
-		}
-		err = json.Unmarshal([]byte(member), item)
-		if err != nil {
-			logger.Error(err, "PQDequeue: Unmarshal failed")
-			return
-		}
-		jobPriorities = append(jobPriorities, item)
-	}
-
-	logger.Info("PQDequeue: succeeded", "nItems", len(jobPriorities))
-	return
-}
-
 func (c *ExchangeDBClientRedis) PQDequeueAndClaim(ctx context.Context, processorID string) (
 	*db_api.BatchJobPriority, error) {
 
@@ -228,6 +162,13 @@ func (c *ExchangeDBClientRedis) PQDequeueAndClaim(ctx context.Context, processor
 				c.idleLogLast = time.Now()
 			}
 			return nil, nil
+		}
+		// The polling loop treats dequeue errors as "no work" and keeps
+		// spinning, so log here and probe the connection to surface Redis
+		// outages and read-only failovers that would otherwise be silent.
+		logger.Error(err, "PQDequeueAndClaim: script failed")
+		if cerr := c.redisClientChecker.Check(ctx); cerr != nil {
+			logger.Error(cerr, "PQDequeueAndClaim: ClientCheck failed")
 		}
 		return nil, fmt.Errorf("PQDequeueAndClaim: %w", err)
 	}

--- a/internal/database/redis/redis_queue_claim_test.go
+++ b/internal/database/redis/redis_queue_claim_test.go
@@ -18,7 +18,6 @@ package redis_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +25,13 @@ import (
 
 	db_api "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	dbredis "github.com/llm-d/llm-d-batch-gateway/internal/database/redis"
+)
+
+// Mirrors of the unexported key names in the redis package, for direct
+// store manipulation in sabotage tests.
+const (
+	queueKey    = "llmd_batch:queue:priority"
+	inFlightKey = "llmd_batch:inflight"
 )
 
 func TestPQDequeueAndClaim(t *testing.T) {
@@ -149,7 +155,7 @@ func TestPQDequeueAndClaim(t *testing.T) {
 		}
 	})
 
-	t.Run("corrupt queue member returns error without claiming", func(t *testing.T) {
+	t.Run("corrupt queue member is dropped with an error, without claiming", func(t *testing.T) {
 		for _, tc := range []struct {
 			name   string
 			member string
@@ -163,25 +169,6 @@ func TestPQDequeueAndClaim(t *testing.T) {
 				minirds, exch := newExchangeClient(t)
 				ctx := context.Background()
 
-				// Discover the (unexported) queue key by enqueueing a real job,
-				// then replace its contents with the corrupt member.
-				if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
-					ID:  "job-probe",
-					SLO: time.Now().Add(time.Hour),
-				}); err != nil {
-					t.Fatalf("PQEnqueue() err=%v", err)
-				}
-				var queueKey string
-				for _, key := range minirds.Keys() {
-					if strings.Contains(key, "priority") {
-						queueKey = key
-						break
-					}
-				}
-				if queueKey == "" {
-					t.Fatal("could not find priority queue key in miniredis")
-				}
-				minirds.Del(queueKey)
 				if _, err := minirds.ZAdd(queueKey, 1, tc.member); err != nil {
 					t.Fatalf("ZAdd() err=%v", err)
 				}
@@ -191,12 +178,11 @@ func TestPQDequeueAndClaim(t *testing.T) {
 					t.Fatalf("PQDequeueAndClaim() err=nil, want error (task=%v)", task)
 				}
 
-				members, err := minirds.ZMembers(queueKey)
-				if err != nil {
-					t.Fatalf("ZMembers() err=%v", err)
-				}
-				if len(members) != 1 || members[0] != tc.member {
-					t.Fatalf("queue members=%v, want [%s]", members, tc.member)
+				// The corrupt member must stay dropped: restoring it would put
+				// it back at the queue head and starve everything behind it.
+				members, _ := minirds.ZMembers(queueKey)
+				if len(members) != 0 {
+					t.Fatalf("queue members=%v, want empty (corrupt member dropped)", members)
 				}
 
 				entries, err := exch.InFlightGetAll(ctx)
@@ -207,6 +193,67 @@ func TestPQDequeueAndClaim(t *testing.T) {
 					t.Fatalf("corrupt member produced in-flight entries: %v", entries)
 				}
 			})
+		}
+	})
+
+	t.Run("valid job behind corrupt member is claimed on the next call", func(t *testing.T) {
+		t.Parallel()
+		minirds, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		// Corrupt member at the queue head, valid job behind it.
+		if _, err := minirds.ZAdd(queueKey, 1, "not-json"); err != nil {
+			t.Fatalf("ZAdd() err=%v", err)
+		}
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-behind",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		if _, err := exch.PQDequeueAndClaim(ctx, "proc-1"); err == nil {
+			t.Fatal("first PQDequeueAndClaim() err=nil, want corrupt-member error")
+		}
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+		if err != nil {
+			t.Fatalf("second PQDequeueAndClaim() err=%v, want valid job", err)
+		}
+		if task == nil || task.ID != "job-behind" {
+			t.Fatalf("second PQDequeueAndClaim() task=%v, want job-behind", task)
+		}
+	})
+
+	t.Run("claim write failure does not lose the job", func(t *testing.T) {
+		t.Parallel()
+		minirds, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-1",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		// Sabotage the in-flight key so HSET fails with WRONGTYPE.
+		if err := minirds.Set(inFlightKey, "not-a-hash"); err != nil {
+			t.Fatalf("Set() err=%v", err)
+		}
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+		if err == nil {
+			t.Fatalf("PQDequeueAndClaim() err=nil, want claim-write error (task=%v)", task)
+		}
+
+		// The job must be restored to the queue, not lost between the stores.
+		queued, err := exch.PQGetIDs(ctx)
+		if err != nil {
+			t.Fatalf("PQGetIDs() err=%v", err)
+		}
+		if !queued["job-1"] {
+			t.Fatal("job lost: not in queue after failed claim write")
 		}
 	})
 }

--- a/internal/database/redis/redis_queue_claim_test.go
+++ b/internal/database/redis/redis_queue_claim_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	db_api "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	dbredis "github.com/llm-d/llm-d-batch-gateway/internal/database/redis"
+)
+
+func TestPQDequeueAndClaim(t *testing.T) {
+	newExchangeClient := func(t *testing.T) (*miniredis.Miniredis, *dbredis.ExchangeDBClientRedis) {
+		t.Helper()
+		minirds := miniredis.NewMiniRedis()
+		if err := minirds.Start(); err != nil {
+			t.Fatalf("failed to start miniredis: %v", err)
+		}
+		t.Cleanup(minirds.Close)
+		baseClient, _, _, exchClient := setupRedisDSClients(t, "redis://"+minirds.Addr(), "")
+		t.Cleanup(func() { _ = baseClient.Close() })
+		return minirds, exchClient
+	}
+
+	t.Run("empty queue returns nil without claiming", func(t *testing.T) {
+		t.Parallel()
+		_, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+		if err != nil {
+			t.Fatalf("PQDequeueAndClaim() err=%v, want nil", err)
+		}
+		if task != nil {
+			t.Fatalf("PQDequeueAndClaim() task=%v, want nil", task)
+		}
+
+		entries, err := exch.InFlightGetAll(ctx)
+		if err != nil {
+			t.Fatalf("InFlightGetAll() err=%v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("in-flight entries=%d, want 0", len(entries))
+		}
+	})
+
+	t.Run("empty processorID is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, exch := newExchangeClient(t)
+
+		if _, err := exch.PQDequeueAndClaim(context.Background(), ""); err == nil {
+			t.Fatal("PQDequeueAndClaim(\"\") err=nil, want error")
+		}
+	})
+
+	t.Run("claim removes from queue and records owner in one step", func(t *testing.T) {
+		t.Parallel()
+		_, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-1",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		before := time.Now().Unix()
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+		if err != nil {
+			t.Fatalf("PQDequeueAndClaim() err=%v", err)
+		}
+		if task == nil || task.ID != "job-1" {
+			t.Fatalf("PQDequeueAndClaim() task=%v, want job-1", task)
+		}
+
+		queued, err := exch.PQGetIDs(ctx)
+		if err != nil {
+			t.Fatalf("PQGetIDs() err=%v", err)
+		}
+		if queued["job-1"] {
+			t.Fatal("claimed job still present in queue")
+		}
+
+		entries, err := exch.InFlightGetAll(ctx)
+		if err != nil {
+			t.Fatalf("InFlightGetAll() err=%v", err)
+		}
+		entry, ok := entries["job-1"]
+		if !ok {
+			t.Fatal("claimed job has no in-flight entry")
+		}
+		if entry.ProcessorID != "proc-1" {
+			t.Fatalf("in-flight owner=%q, want proc-1", entry.ProcessorID)
+		}
+		if entry.LastSeen < before || entry.LastSeen > time.Now().Unix() {
+			t.Fatalf("in-flight LastSeen=%d out of expected range", entry.LastSeen)
+		}
+	})
+
+	t.Run("claims follow SLO priority order", func(t *testing.T) {
+		t.Parallel()
+		_, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		now := time.Now()
+		// Enqueue out of priority order: the earliest SLO must come out first.
+		for _, job := range []struct {
+			id  string
+			slo time.Time
+		}{
+			{id: "job-late", slo: now.Add(3 * time.Hour)},
+			{id: "job-early", slo: now.Add(1 * time.Hour)},
+			{id: "job-mid", slo: now.Add(2 * time.Hour)},
+		} {
+			if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{ID: job.id, SLO: job.slo}); err != nil {
+				t.Fatalf("PQEnqueue(%s) err=%v", job.id, err)
+			}
+		}
+
+		wantOrder := []string{"job-early", "job-mid", "job-late"}
+		for _, want := range wantOrder {
+			task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+			if err != nil {
+				t.Fatalf("PQDequeueAndClaim() err=%v", err)
+			}
+			if task == nil || task.ID != want {
+				t.Fatalf("PQDequeueAndClaim() task=%v, want %s", task, want)
+			}
+		}
+	})
+
+	t.Run("corrupt queue member returns error without claiming", func(t *testing.T) {
+		t.Parallel()
+		minirds, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		// Discover the (unexported) queue key by enqueueing a real job, then
+		// replace its contents with a non-JSON member.
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-probe",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+		var queueKey string
+		for _, key := range minirds.Keys() {
+			if strings.Contains(key, "priority") {
+				queueKey = key
+				break
+			}
+		}
+		if queueKey == "" {
+			t.Fatal("could not find priority queue key in miniredis")
+		}
+		minirds.Del(queueKey)
+		if _, err := minirds.ZAdd(queueKey, 1, "not-json"); err != nil {
+			t.Fatalf("ZAdd() err=%v", err)
+		}
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+		if err == nil {
+			t.Fatalf("PQDequeueAndClaim() err=nil, want unmarshal error (task=%v)", task)
+		}
+
+		entries, err := exch.InFlightGetAll(ctx)
+		if err != nil {
+			t.Fatalf("InFlightGetAll() err=%v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("corrupt member produced in-flight entries: %v", entries)
+		}
+	})
+}

--- a/internal/database/redis/redis_queue_claim_test.go
+++ b/internal/database/redis/redis_queue_claim_test.go
@@ -150,44 +150,63 @@ func TestPQDequeueAndClaim(t *testing.T) {
 	})
 
 	t.Run("corrupt queue member returns error without claiming", func(t *testing.T) {
-		t.Parallel()
-		minirds, exch := newExchangeClient(t)
-		ctx := context.Background()
+		for _, tc := range []struct {
+			name   string
+			member string
+		}{
+			{name: "malformed JSON", member: "not-json"},
+			{name: "empty ID", member: `{"id":""}`},
+		} {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				minirds, exch := newExchangeClient(t)
+				ctx := context.Background()
 
-		// Discover the (unexported) queue key by enqueueing a real job, then
-		// replace its contents with a non-JSON member.
-		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
-			ID:  "job-probe",
-			SLO: time.Now().Add(time.Hour),
-		}); err != nil {
-			t.Fatalf("PQEnqueue() err=%v", err)
-		}
-		var queueKey string
-		for _, key := range minirds.Keys() {
-			if strings.Contains(key, "priority") {
-				queueKey = key
-				break
-			}
-		}
-		if queueKey == "" {
-			t.Fatal("could not find priority queue key in miniredis")
-		}
-		minirds.Del(queueKey)
-		if _, err := minirds.ZAdd(queueKey, 1, "not-json"); err != nil {
-			t.Fatalf("ZAdd() err=%v", err)
-		}
+				// Discover the (unexported) queue key by enqueueing a real job,
+				// then replace its contents with the corrupt member.
+				if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+					ID:  "job-probe",
+					SLO: time.Now().Add(time.Hour),
+				}); err != nil {
+					t.Fatalf("PQEnqueue() err=%v", err)
+				}
+				var queueKey string
+				for _, key := range minirds.Keys() {
+					if strings.Contains(key, "priority") {
+						queueKey = key
+						break
+					}
+				}
+				if queueKey == "" {
+					t.Fatal("could not find priority queue key in miniredis")
+				}
+				minirds.Del(queueKey)
+				if _, err := minirds.ZAdd(queueKey, 1, tc.member); err != nil {
+					t.Fatalf("ZAdd() err=%v", err)
+				}
 
-		task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
-		if err == nil {
-			t.Fatalf("PQDequeueAndClaim() err=nil, want unmarshal error (task=%v)", task)
-		}
+				task, err := exch.PQDequeueAndClaim(ctx, "proc-1")
+				if err == nil {
+					t.Fatalf("PQDequeueAndClaim() err=nil, want error (task=%v)", task)
+				}
 
-		entries, err := exch.InFlightGetAll(ctx)
-		if err != nil {
-			t.Fatalf("InFlightGetAll() err=%v", err)
-		}
-		if len(entries) != 0 {
-			t.Fatalf("corrupt member produced in-flight entries: %v", entries)
+				members, err := minirds.ZMembers(queueKey)
+				if err != nil {
+					t.Fatalf("ZMembers() err=%v", err)
+				}
+				if len(members) != 1 || members[0] != tc.member {
+					t.Fatalf("queue members=%v, want [%s]", members, tc.member)
+				}
+
+				entries, err := exch.InFlightGetAll(ctx)
+				if err != nil {
+					t.Fatalf("InFlightGetAll() err=%v", err)
+				}
+				if len(entries) != 0 {
+					t.Fatalf("corrupt member produced in-flight entries: %v", entries)
+				}
+			})
 		}
 	})
 }

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -2127,12 +2127,12 @@ func TestHandleJobError_Shutdown_LeavesJobForReconciler(t *testing.T) {
 	}, errShutdown)
 
 	// Job must NOT be re-enqueued — reconciler handles recovery.
-	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
+	queuedIDs, err := env.pqClient.PQGetIDs(ctx)
 	if err != nil {
-		t.Fatalf("PQDequeue: %v", err)
+		t.Fatalf("PQGetIDs: %v", err)
 	}
-	if len(tasks) != 0 {
-		t.Fatalf("expected no re-enqueued tasks, got %d", len(tasks))
+	if len(queuedIDs) != 0 {
+		t.Fatalf("expected no re-enqueued tasks, got %d", len(queuedIDs))
 	}
 
 	// Job status must remain in_progress (not transitioned by the processor).

--- a/internal/processor/worker/poller.go
+++ b/internal/processor/worker/poller.go
@@ -48,8 +48,10 @@ func (p *Poller) validate() error {
 	return nil
 }
 
-func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
-	tasks, err := p.pq.PQDequeue(ctx, 0, 1) // get only one job without blocking the queue
+// dequeueAndClaimOne atomically pops one job from the queue (non-blocking)
+// and records processorID as its in-flight owner.
+func (p *Poller) dequeueAndClaimOne(ctx context.Context, processorID string) (*db.BatchJobPriority, error) {
+	task, err := p.pq.PQDequeueAndClaim(ctx, processorID)
 	if err != nil {
 		return nil, err
 	}
@@ -57,13 +59,13 @@ func (p *Poller) dequeueOne(ctx context.Context) (*db.BatchJobPriority, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// there's no backlog
-	if len(tasks) == 0 {
+	if task == nil {
 		logger.V(logging.TRACE).Info("No jobs to fetch")
 		return nil, nil
 	}
 
-	logger.V(logging.DEBUG).Info("Successfully fetched a job", "jobID", tasks[0].ID)
-	return tasks[0], nil
+	logger.V(logging.DEBUG).Info("Successfully fetched a job", "jobID", task.ID)
+	return task, nil
 }
 
 func (p *Poller) enqueueOne(ctx context.Context, task *db.BatchJobPriority) error {

--- a/internal/processor/worker/poller_test.go
+++ b/internal/processor/worker/poller_test.go
@@ -48,6 +48,13 @@ func (p *pqSpy) PQDequeue(ctx context.Context, timeout time.Duration, maxObjs in
 	return p.inner.PQDequeue(ctx, timeout, maxObjs)
 }
 
+func (p *pqSpy) PQDequeueAndClaim(ctx context.Context, processorID string) (*db.BatchJobPriority, error) {
+	if p.dequeueErr != nil {
+		return nil, p.dequeueErr
+	}
+	return p.inner.PQDequeueAndClaim(ctx, processorID)
+}
+
 func (p *pqSpy) PQDelete(ctx context.Context, jobPriority *db.BatchJobPriority) (int, error) {
 	p.deleteCalled++
 	return p.inner.PQDelete(ctx, jobPriority)
@@ -99,7 +106,7 @@ func (d *dbGetErrWrapper) Close() error {
 }
 
 // tests
-func TestPoller_DequeueOne_EmptyQueue_ReturnsNil(t *testing.T) {
+func TestPoller_DequeueAndClaimOne_EmptyQueue_ReturnsNil(t *testing.T) {
 	ctx := context.Background()
 
 	pq := &pqSpy{inner: mockdb.NewMockBatchPriorityQueueClient()}
@@ -110,16 +117,16 @@ func TestPoller_DequeueOne_EmptyQueue_ReturnsNil(t *testing.T) {
 
 	p := NewPoller(pq, dbClient)
 
-	task, err := p.dequeueOne(ctx)
+	task, err := p.dequeueAndClaimOne(ctx, "proc-1")
 	if err != nil {
-		t.Fatalf("DequeueOne() err=%v, want nil", err)
+		t.Fatalf("dequeueAndClaimOne() err=%v, want nil", err)
 	}
 	if task != nil {
-		t.Fatalf("DequeueOne() task=%v, want nil", task)
+		t.Fatalf("dequeueAndClaimOne() task=%v, want nil", task)
 	}
 }
 
-func TestPoller_DequeueOne_PQError_ReturnsError(t *testing.T) {
+func TestPoller_DequeueAndClaimOne_PQError_ReturnsError(t *testing.T) {
 	ctx := context.Background()
 
 	pq := &pqSpy{
@@ -133,19 +140,22 @@ func TestPoller_DequeueOne_PQError_ReturnsError(t *testing.T) {
 
 	p := NewPoller(pq, dbClient)
 
-	task, err := p.dequeueOne(ctx)
+	task, err := p.dequeueAndClaimOne(ctx, "proc-1")
 	if err == nil {
-		t.Fatalf("DequeueOne() err=nil, want error")
+		t.Fatalf("dequeueAndClaimOne() err=nil, want error")
 	}
 	if task != nil {
-		t.Fatalf("DequeueOne() task=%v, want nil", task)
+		t.Fatalf("dequeueAndClaimOne() task=%v, want nil", task)
 	}
 }
 
-func TestPoller_DequeueOne_ReturnsFirstTask(t *testing.T) {
+func TestPoller_DequeueAndClaimOne_ReturnsFirstTaskAndClaimsIt(t *testing.T) {
 	ctx := context.Background()
 
-	pq := &pqSpy{inner: mockdb.NewMockBatchPriorityQueueClient()}
+	inner := mockdb.NewMockBatchPriorityQueueClient()
+	inflight := mockdb.NewMockInFlightClient()
+	inner.LinkInFlight(inflight)
+	pq := &pqSpy{inner: inner}
 	dbClient := mockdb.NewMockDBClient(
 		func(b *db.BatchItem) string { return b.ID },
 		func(q *db.BatchQuery) *db.BaseQuery { return &q.BaseQuery },
@@ -162,16 +172,28 @@ func TestPoller_DequeueOne_ReturnsFirstTask(t *testing.T) {
 
 	p := NewPoller(pq, dbClient)
 
-	task, err := p.dequeueOne(ctx)
+	task, err := p.dequeueAndClaimOne(ctx, "proc-1")
 	if err != nil {
-		t.Fatalf("DequeueOne() err=%v, want nil", err)
+		t.Fatalf("dequeueAndClaimOne() err=%v, want nil", err)
 	}
 	if task == nil {
-		t.Fatalf("DequeueOne() task=nil, want non-nil")
+		t.Fatalf("dequeueAndClaimOne() task=nil, want non-nil")
 		return
 	}
 	if task.ID != wantID {
-		t.Fatalf("DequeueOne() id=%q, want %q", task.ID, wantID)
+		t.Fatalf("dequeueAndClaimOne() id=%q, want %q", task.ID, wantID)
+	}
+
+	entries, err := inflight.InFlightGetAll(ctx)
+	if err != nil {
+		t.Fatalf("InFlightGetAll() err=%v", err)
+	}
+	entry, ok := entries[wantID]
+	if !ok {
+		t.Fatalf("dequeued job %q has no in-flight claim", wantID)
+	}
+	if entry.ProcessorID != "proc-1" {
+		t.Fatalf("in-flight claim owner=%q, want %q", entry.ProcessorID, "proc-1")
 	}
 }
 

--- a/internal/processor/worker/poller_test.go
+++ b/internal/processor/worker/poller_test.go
@@ -41,13 +41,6 @@ func (p *pqSpy) PQEnqueue(ctx context.Context, jobPriority *db.BatchJobPriority)
 	return p.inner.PQEnqueue(ctx, jobPriority)
 }
 
-func (p *pqSpy) PQDequeue(ctx context.Context, timeout time.Duration, maxObjs int) ([]*db.BatchJobPriority, error) {
-	if p.dequeueErr != nil {
-		return nil, p.dequeueErr
-	}
-	return p.inner.PQDequeue(ctx, timeout, maxObjs)
-}
-
 func (p *pqSpy) PQDequeueAndClaim(ctx context.Context, processorID string) (*db.BatchJobPriority, error) {
 	if p.dequeueErr != nil {
 		return nil, p.dequeueErr

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -1104,11 +1104,11 @@ func TestRunPollingLoop_FetchFailsWithCancelledCtx_ReEnqueuesViaDetachedCtx(t *t
 		t.Fatalf("runPollingLoop: %v", err)
 	}
 
-	tasks, err := pq.PQDequeue(ctx, 0, 10)
+	queuedIDs, err := pq.PQGetIDs(ctx)
 	if err != nil {
-		t.Fatalf("PQDequeue: %v", err)
+		t.Fatalf("PQGetIDs: %v", err)
 	}
-	if len(tasks) == 0 {
+	if len(queuedIDs) == 0 {
 		t.Fatalf("expected task to be back in queue after re-enqueue via detached context")
 	}
 }

--- a/internal/processor/worker/recovery_test.go
+++ b/internal/processor/worker/recovery_test.go
@@ -26,6 +26,8 @@ func newRecoveryTestProcessor(t *testing.T, workDir string) (*Processor, db.Batc
 
 	batchDB := newMockBatchDBClient()
 	pq := mockdb.NewMockBatchPriorityQueueClient()
+	inflightClient := mockdb.NewMockInFlightClient()
+	pq.LinkInFlight(inflightClient)
 	spyQueue := &spyPQ{inner: pq}
 	statusClient := mockdb.NewMockBatchStatusClient()
 
@@ -391,15 +393,15 @@ func TestRecoverJob_Validating_ReEnqueuesWithExactTaggedSLO(t *testing.T) {
 		t.Fatalf("recoverJob: %v", err)
 	}
 
-	tasks, err := spyQueue.PQDequeue(ctx, 0, 1)
+	task, err := spyQueue.PQDequeueAndClaim(ctx, "test-proc")
 	if err != nil {
-		t.Fatalf("PQDequeue: %v", err)
+		t.Fatalf("PQDequeueAndClaim: %v", err)
 	}
-	if len(tasks) != 1 {
-		t.Fatalf("expected 1 re-enqueued task, got %d", len(tasks))
+	if task == nil {
+		t.Fatal("expected 1 re-enqueued task, got none")
 	}
-	if !tasks[0].SLO.Equal(wantSLO) {
-		t.Fatalf("re-enqueued SLO = %v, want %v", tasks[0].SLO, wantSLO)
+	if !task.SLO.Equal(wantSLO) {
+		t.Fatalf("re-enqueued SLO = %v, want %v", task.SLO, wantSLO)
 	}
 
 	assertJobDirRemoved(t, p, jobID, tenantID)

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -232,13 +232,6 @@ func (s *spyPQ) PQEnqueue(ctx context.Context, jobPriority *db.BatchJobPriority)
 	}
 	return s.inner.PQEnqueue(ctx, jobPriority)
 }
-func (s *spyPQ) PQDequeue(ctx context.Context, timeout time.Duration, maxObjs int) ([]*db.BatchJobPriority, error) {
-	items, err := s.inner.PQDequeue(ctx, timeout, maxObjs)
-	if err == nil && len(items) > 0 && s.afterDequeueFn != nil {
-		s.afterDequeueFn()
-	}
-	return items, err
-}
 func (s *spyPQ) PQDequeueAndClaim(ctx context.Context, processorID string) (*db.BatchJobPriority, error) {
 	task, err := s.inner.PQDequeueAndClaim(ctx, processorID)
 	if err == nil && task != nil && s.afterDequeueFn != nil {

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -239,6 +239,13 @@ func (s *spyPQ) PQDequeue(ctx context.Context, timeout time.Duration, maxObjs in
 	}
 	return items, err
 }
+func (s *spyPQ) PQDequeueAndClaim(ctx context.Context, processorID string) (*db.BatchJobPriority, error) {
+	task, err := s.inner.PQDequeueAndClaim(ctx, processorID)
+	if err == nil && task != nil && s.afterDequeueFn != nil {
+		s.afterDequeueFn()
+	}
+	return task, err
+}
 func (s *spyPQ) PQDelete(ctx context.Context, jobPriority *db.BatchJobPriority) (int, error) {
 	s.mu.Lock()
 	s.delN++
@@ -377,14 +384,17 @@ func mustNewProcessor(t *testing.T, cfg *config.ProcessorConfig, clients *client
 
 func validProcessorClients(t testing.TB) *clientset.Clientset {
 	t.Helper()
+	queue := mockdb.NewMockBatchPriorityQueueClient()
+	inflight := mockdb.NewMockInFlightClient()
+	queue.LinkInFlight(inflight)
 	return &clientset.Clientset{
 		BatchDB:   newMockBatchDBClient(),
 		FileDB:    newMockFileDBClient(),
 		File:      mockfiles.NewMockBatchFilesClient(t.TempDir()),
-		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Queue:     queue,
 		Status:    mockdb.NewMockBatchStatusClient(),
 		Event:     mockdb.NewMockBatchEventChannelClient(),
-		InFlight:  mockdb.NewMockInFlightClient(),
+		InFlight:  inflight,
 		Inference: inference.NewSingleClientResolver(&fakeInferenceClient{}),
 	}
 }
@@ -405,6 +415,8 @@ func newTestProcessorEnv(t *testing.T, cfg *config.ProcessorConfig, inferClient 
 	dbClient := newMockBatchDBClient()
 	pqClient := mockdb.NewMockBatchPriorityQueueClient()
 	statusClient := mockdb.NewMockBatchStatusClient()
+	inflightClient := mockdb.NewMockInFlightClient()
+	pqClient.LinkInFlight(inflightClient)
 
 	p, err := NewProcessor(cfg, &clientset.Clientset{
 		BatchDB:   dbClient,
@@ -413,7 +425,7 @@ func newTestProcessorEnv(t *testing.T, cfg *config.ProcessorConfig, inferClient 
 		Queue:     pqClient,
 		Status:    statusClient,
 		Event:     mockdb.NewMockBatchEventChannelClient(),
-		InFlight:  mockdb.NewMockInFlightClient(),
+		InFlight:  inflightClient,
 		Inference: inference.NewSingleClientResolver(inferClient),
 	}, "test-processor", testLogger(t))
 	if err != nil {

--- a/internal/processor/worker/test_helpers_test.go
+++ b/internal/processor/worker/test_helpers_test.go
@@ -363,6 +363,7 @@ func mustNewProcessor(t *testing.T, cfg *config.ProcessorConfig, clients *client
 	if clients.InFlight == nil {
 		clients.InFlight = mockdb.NewMockInFlightClient()
 	}
+	linkMockQueueInFlight(clients.Queue, clients.InFlight)
 	p, err := NewProcessor(cfg, clients, "test-processor", testLogger(t))
 	if err != nil {
 		t.Fatalf("NewProcessor: %v", err)
@@ -380,6 +381,15 @@ func mustNewProcessor(t *testing.T, cfg *config.ProcessorConfig, clients *client
 	}
 	initTestEndpointLimits(t, p, cfg)
 	return p
+}
+
+func linkMockQueueInFlight(queue db.BatchPriorityQueueClient, inflight db.InFlightClient) {
+	switch q := queue.(type) {
+	case *mockdb.MockBatchPriorityQueueClient:
+		q.LinkInFlight(inflight)
+	case *spyPQ:
+		linkMockQueueInFlight(q.inner, inflight)
+	}
 }
 
 func validProcessorClients(t testing.TB) *clientset.Clientset {

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -251,7 +251,7 @@ func (p *Processor) runPollingLoop(pollingCtx, jobBaseCtx context.Context) error
 
 		// check queue for available tasks
 		logger.V(logging.DEBUG).Info("Checking queue for available tasks")
-		task, err := p.poller.dequeueOne(pollingCtx)
+		task, err := p.poller.dequeueAndClaimOne(pollingCtx, p.processorID)
 
 		// when there's no waiting tasks in the queue or poller returned an error
 		if task == nil || err != nil {
@@ -260,13 +260,6 @@ func (p *Processor) runPollingLoop(pollingCtx, jobBaseCtx context.Context) error
 				return nil
 			}
 			continue
-		}
-
-		// Record in-flight entry immediately after dequeue so the orphan
-		// reconciler can track this job. Non-fatal on error: the reconciler
-		// can still detect orphans via DB + queue cross-reference.
-		if err := p.inflight.InFlightSet(pollingCtx, task.ID, p.processorID); err != nil {
-			logr.FromContextOrDiscard(pollingCtx).Error(err, "Failed to set in-flight entry", "jobId", task.ID)
 		}
 
 		// Pre-launch: use pollingCtx so guard cancel / SIGTERM interrupts

--- a/test/regression/atomic_dequeue_claim_test.go
+++ b/test/regression/atomic_dequeue_claim_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package regression
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	db_api "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	dbredis "github.com/llm-d/llm-d-batch-gateway/internal/database/redis"
+	uredis "github.com/llm-d/llm-d-batch-gateway/internal/util/redis"
+)
+
+// Past bug guard: job pickup used to be two separate Redis operations — pop
+// from the priority queue, then write the in-flight claim. A processor crash
+// between the two left the job in neither store. PQDequeueAndClaim does both
+// in one Lua script; these tests pin that invariant.
+func TestRegression_AtomicDequeueClaim(t *testing.T) {
+	newExchangeClient := func(t *testing.T) *dbredis.ExchangeDBClientRedis {
+		t.Helper()
+		minirds := miniredis.NewMiniRedis()
+		if err := minirds.Start(); err != nil {
+			t.Fatalf("failed to start miniredis: %v", err)
+		}
+		t.Cleanup(minirds.Close)
+		exch, err := dbredis.NewExchangeDBClientRedis(context.Background(), nil,
+			&uredis.RedisClientConfig{
+				Url:         "redis://" + minirds.Addr(),
+				ServiceName: "regression-test",
+			}, 0)
+		if err != nil {
+			t.Fatalf("failed to create exchange client: %v", err)
+		}
+		t.Cleanup(func() { _ = exch.Close() })
+		return exch
+	}
+
+	t.Run("ClaimIsAtomicPair", func(t *testing.T) {
+		// Once a claim returns, both effects are visible: gone from the
+		// queue, owned in the in-flight hash.
+		exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-atomic",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-A")
+		if err != nil {
+			t.Fatalf("PQDequeueAndClaim() err=%v", err)
+		}
+		if task == nil || task.ID != "job-atomic" {
+			t.Fatalf("PQDequeueAndClaim() task=%v, want job-atomic", task)
+		}
+
+		queued, err := exch.PQGetIDs(ctx)
+		if err != nil {
+			t.Fatalf("PQGetIDs() err=%v", err)
+		}
+		inflight, err := exch.InFlightGetAll(ctx)
+		if err != nil {
+			t.Fatalf("InFlightGetAll() err=%v", err)
+		}
+
+		if queued["job-atomic"] {
+			t.Error("claimed job must not remain in the queue")
+		}
+		entry, ok := inflight["job-atomic"]
+		if !ok {
+			t.Fatal("claimed job must have an in-flight entry the moment the claim returns")
+		}
+		if entry.ProcessorID != "proc-A" {
+			t.Errorf("in-flight owner=%q, want proc-A", entry.ProcessorID)
+		}
+	})
+
+	t.Run("JobNeverInvisibleUnderConcurrentClaims", func(t *testing.T) {
+		// While claimers race to drain the queue, an observer must find every
+		// job in at least one of the two stores. Queue is read first: a job
+		// that left the queue before the read is already claimed, and claims
+		// are never deleted here, so the in-flight read that follows sees it.
+		exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		const nJobs = 60
+		const nClaimers = 8
+
+		allIDs := make(map[string]bool, nJobs)
+		for i := 0; i < nJobs; i++ {
+			id := fmt.Sprintf("job-%03d", i)
+			allIDs[id] = true
+			if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+				ID:  id,
+				SLO: time.Now().Add(time.Duration(i+1) * time.Minute),
+			}); err != nil {
+				t.Fatalf("PQEnqueue(%s) err=%v", id, err)
+			}
+		}
+
+		done := make(chan struct{})
+		var observerErr error
+		var observerWG sync.WaitGroup
+		observerWG.Add(1)
+		go func() {
+			defer observerWG.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				queued, err := exch.PQGetIDs(ctx)
+				if err != nil {
+					observerErr = fmt.Errorf("observer PQGetIDs: %w", err)
+					return
+				}
+				inflight, err := exch.InFlightGetAll(ctx)
+				if err != nil {
+					observerErr = fmt.Errorf("observer InFlightGetAll: %w", err)
+					return
+				}
+				for id := range allIDs {
+					if !queued[id] {
+						if _, claimed := inflight[id]; !claimed {
+							observerErr = fmt.Errorf("job %s invisible: not in queue and not in-flight", id)
+							return
+						}
+					}
+				}
+			}
+		}()
+
+		type claim struct {
+			jobID       string
+			processorID string
+		}
+		claimsCh := make(chan claim, nJobs)
+		var claimerWG sync.WaitGroup
+		for c := 0; c < nClaimers; c++ {
+			processorID := fmt.Sprintf("proc-%d", c)
+			claimerWG.Add(1)
+			go func() {
+				defer claimerWG.Done()
+				for {
+					task, err := exch.PQDequeueAndClaim(ctx, processorID)
+					if err != nil {
+						t.Errorf("PQDequeueAndClaim(%s) err=%v", processorID, err)
+						return
+					}
+					if task == nil {
+						return // queue drained
+					}
+					claimsCh <- claim{jobID: task.ID, processorID: processorID}
+				}
+			}()
+		}
+		claimerWG.Wait()
+		close(done)
+		observerWG.Wait()
+		close(claimsCh)
+
+		if observerErr != nil {
+			t.Fatalf("invariant violated: %v", observerErr)
+		}
+
+		// Exactly-once: every job claimed by exactly one claimer.
+		claimedBy := make(map[string]string, nJobs)
+		for cl := range claimsCh {
+			if prev, dup := claimedBy[cl.jobID]; dup {
+				t.Fatalf("job %s claimed twice: by %s and %s", cl.jobID, prev, cl.processorID)
+			}
+			claimedBy[cl.jobID] = cl.processorID
+		}
+		if len(claimedBy) != nJobs {
+			t.Fatalf("claimed %d jobs, want %d", len(claimedBy), nJobs)
+		}
+
+		// Ownership: every in-flight entry names the claimer that took the job.
+		inflight, err := exch.InFlightGetAll(ctx)
+		if err != nil {
+			t.Fatalf("InFlightGetAll() err=%v", err)
+		}
+		for id, owner := range claimedBy {
+			entry, ok := inflight[id]
+			if !ok {
+				t.Fatalf("claimed job %s missing from in-flight hash", id)
+			}
+			if entry.ProcessorID != owner {
+				t.Fatalf("job %s in-flight owner=%q, want claimer %q", id, entry.ProcessorID, owner)
+			}
+		}
+	})
+}

--- a/test/regression/atomic_dequeue_claim_test.go
+++ b/test/regression/atomic_dequeue_claim_test.go
@@ -35,7 +35,7 @@ import (
 // between the two left the job in neither store. PQDequeueAndClaim does both
 // in one Lua script; these tests pin that invariant.
 func TestRegression_AtomicDequeueClaim(t *testing.T) {
-	newExchangeClient := func(t *testing.T) *dbredis.ExchangeDBClientRedis {
+	newExchangeClient := func(t *testing.T) (*miniredis.Miniredis, *dbredis.ExchangeDBClientRedis) {
 		t.Helper()
 		minirds := miniredis.NewMiniRedis()
 		if err := minirds.Start(); err != nil {
@@ -51,13 +51,17 @@ func TestRegression_AtomicDequeueClaim(t *testing.T) {
 			t.Fatalf("failed to create exchange client: %v", err)
 		}
 		t.Cleanup(func() { _ = exch.Close() })
-		return exch
+		return minirds, exch
 	}
+
+	// Mirrors the unexported queue key in the redis package, for direct
+	// sabotage of queue contents.
+	const queueKey = "llmd_batch:queue:priority"
 
 	t.Run("ClaimIsAtomicPair", func(t *testing.T) {
 		// Once a claim returns, both effects are visible: gone from the
 		// queue, owned in the in-flight hash.
-		exch := newExchangeClient(t)
+		_, exch := newExchangeClient(t)
 		ctx := context.Background()
 
 		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
@@ -101,7 +105,7 @@ func TestRegression_AtomicDequeueClaim(t *testing.T) {
 		// job in at least one of the two stores. Queue is read first: a job
 		// that left the queue before the read is already claimed, and claims
 		// are never deleted here, so the in-flight read that follows sees it.
-		exch := newExchangeClient(t)
+		_, exch := newExchangeClient(t)
 		ctx := context.Background()
 
 		const nJobs = 60
@@ -210,6 +214,71 @@ func TestRegression_AtomicDequeueClaim(t *testing.T) {
 			if entry.ProcessorID != owner {
 				t.Fatalf("job %s in-flight owner=%q, want claimer %q", id, entry.ProcessorID, owner)
 			}
+		}
+	})
+
+	t.Run("CorruptMemberDoesNotStarveQueue", func(t *testing.T) {
+		// Past bug (caught in review of #559): a corrupt queue member was
+		// restored at its original score after failing validation, putting it
+		// back at the queue head forever — a poison pill starving every valid
+		// job behind it. Corrupt members must be dropped, and the next claim
+		// must return the job that was behind them.
+		minirds, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		if _, err := minirds.ZAdd(queueKey, 1, "poison-pill-not-json"); err != nil {
+			t.Fatalf("ZAdd() err=%v", err)
+		}
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-behind-pill",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		if _, err := exch.PQDequeueAndClaim(ctx, "proc-A"); err == nil {
+			t.Fatal("first claim err=nil, want corrupt-member error")
+		}
+
+		task, err := exch.PQDequeueAndClaim(ctx, "proc-A")
+		if err != nil {
+			t.Fatalf("second claim err=%v, want the job behind the pill", err)
+		}
+		if task == nil || task.ID != "job-behind-pill" {
+			t.Fatalf("second claim task=%v, want job-behind-pill", task)
+		}
+	})
+
+	t.Run("FailedClaimWriteDoesNotLoseJob", func(t *testing.T) {
+		// Past bug (caught in review of #559): if the in-flight HSET failed
+		// after ZPOPMIN, the script aborted without restoring the member —
+		// the job vanished from both stores, the exact state this fix exists
+		// to eliminate. A failed claim write must leave the job in the queue.
+		minirds, exch := newExchangeClient(t)
+		ctx := context.Background()
+
+		if err := exch.PQEnqueue(ctx, &db_api.BatchJobPriority{
+			ID:  "job-claim-fail",
+			SLO: time.Now().Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("PQEnqueue() err=%v", err)
+		}
+
+		// Sabotage the in-flight key so HSET fails with WRONGTYPE.
+		if err := minirds.Set("llmd_batch:inflight", "not-a-hash"); err != nil {
+			t.Fatalf("Set() err=%v", err)
+		}
+
+		if task, err := exch.PQDequeueAndClaim(ctx, "proc-A"); err == nil {
+			t.Fatalf("claim err=nil, want claim-write error (task=%v)", task)
+		}
+
+		queued, err := exch.PQGetIDs(ctx)
+		if err != nil {
+			t.Fatalf("PQGetIDs() err=%v", err)
+		}
+		if !queued["job-claim-fail"] {
+			t.Fatal("job lost: not in queue after failed claim write")
 		}
 	})
 }


### PR DESCRIPTION
Fixes #562

Job pickup was two separate Redis operations: pop from the priority queue, then write the in-flight claim. A processor crash between the two left the job in neither store, invisible to the orphan reconciler.

This replaces the two-step pickup with a single Lua script (`PQDequeueAndClaim`) that pops the queue head and records the in-flight owner atomically. A crash at any point now leaves the job either queued or claimed.

Includes unit tests (miniredis) and a regression guard that races concurrent claimers against a reconciler-style observer to pin the invariant.