### PR TITLE
fix(s3): use single bucket with key prefix instead of per-tenant buckets

### DIFF
--- a/charts/batch-gateway/templates/apiserver-configmap.yaml
+++ b/charts/batch-gateway/templates/apiserver-configmap.yaml
@@ -42,6 +42,7 @@ data:
         base_path: {{ .Values.global.fileClient.fs.basePath | quote }}
       s3:
         region: {{ .Values.global.fileClient.s3.region | quote }}
+        bucket: {{ .Values.global.fileClient.s3.bucket | quote }}
         endpoint: {{ .Values.global.fileClient.s3.endpoint | quote }}
         access_key_id: {{ .Values.global.fileClient.s3.accessKeyId | quote }}
         prefix: {{ .Values.global.fileClient.s3.prefix | quote }}

--- a/charts/batch-gateway/templates/gc-configmap.yaml
+++ b/charts/batch-gateway/templates/gc-configmap.yaml
@@ -32,6 +32,7 @@ data:
         base_path: {{ .Values.global.fileClient.fs.basePath | quote }}
       s3:
         region: {{ .Values.global.fileClient.s3.region | quote }}
+        bucket: {{ .Values.global.fileClient.s3.bucket | quote }}
         endpoint: {{ .Values.global.fileClient.s3.endpoint | quote }}
         access_key_id: {{ .Values.global.fileClient.s3.accessKeyId | quote }}
         prefix: {{ .Values.global.fileClient.s3.prefix | quote }}

--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -129,6 +129,7 @@ data:
         base_path: {{ .Values.global.fileClient.fs.basePath | quote }}
       s3:
         region: {{ .Values.global.fileClient.s3.region | quote }}
+        bucket: {{ .Values.global.fileClient.s3.bucket | quote }}
         endpoint: {{ .Values.global.fileClient.s3.endpoint | quote }}
         access_key_id: {{ .Values.global.fileClient.s3.accessKeyId | quote }}
         prefix: {{ .Values.global.fileClient.s3.prefix | quote }}

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -81,6 +81,7 @@ global:
     # S3 client configuration (required when type is "s3")
     s3:
       region: ""
+      bucket: ""
       endpoint: ""
       accessKeyId: ""
       prefix: ""

--- a/cmd/apiserver/config.yaml
+++ b/cmd/apiserver/config.yaml
@@ -54,9 +54,10 @@ file_client:
   # S3 client configuration (required when type is "s3")
   # s3:
   #   region: "us-west-2"
+  #   bucket: "llm-d-batch-gateway"  # Required: single bucket for all tenants
   #   endpoint: ""             # Optional: custom endpoint for S3-compatible storage
   #   access_key_id: ""        # Optional: defaults to AWS environment/IAM credentials
-  #   prefix: "batch-gateway"  # Optional: prefix for S3 object keys
+  #   prefix: ""               # Optional: prefix for S3 object keys
   #   use_path_style: false    # Optional: use path-style addressing
 
 # Database client configuration

--- a/cmd/batch-gc/config.yaml
+++ b/cmd/batch-gc/config.yaml
@@ -42,6 +42,7 @@ file_client:
   # S3-compatible storage (uncomment to use instead of fs)
   # s3:
   #   region: "us-east-1"
+  #   bucket: "llm-d-batch-gateway"  # Required: single bucket for all tenants
   #   endpoint: ""
   #   access_key_id: ""
   #   prefix: ""

--- a/internal/files_store/s3/client.go
+++ b/internal/files_store/s3/client.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -56,13 +55,13 @@ type uploaderAPI interface {
 }
 
 // Client implements api.BatchFilesClient using S3 storage.
-// The folderName parameter in Store/Retrieve/Delete is used as the S3 bucket name.
+// All objects are stored in a single configured bucket. The folderName parameter
+// in Store/Retrieve/Delete is used as part of the S3 key for tenant isolation.
 type Client struct {
-	s3Client         s3API
-	uploader         uploaderAPI
-	prefix           string
-	autoCreateBucket bool
-	knownBuckets     sync.Map // caches bucket names that have been verified to exist
+	s3Client s3API
+	uploader uploaderAPI
+	prefix   string
+	bucket   string
 }
 
 var _ api.BatchFilesClient = (*Client)(nil)
@@ -70,6 +69,7 @@ var _ api.BatchFilesClient = (*Client)(nil)
 // Config holds configuration for the S3 client.
 type Config struct {
 	Region           string `yaml:"region"`
+	Bucket           string `yaml:"bucket"`
 	Endpoint         string `yaml:"endpoint"`
 	AccessKeyID      string `yaml:"access_key_id"`
 	SecretAccessKey  string `yaml:"-"`
@@ -82,6 +82,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Region == "" {
 		return fmt.Errorf("s3.region cannot be empty")
+	}
+	if c.Bucket == "" {
+		return fmt.Errorf("s3.bucket cannot be empty")
 	}
 	return nil
 }
@@ -115,83 +118,76 @@ func New(ctx context.Context, cfg Config) (*Client, error) {
 
 	s3Client := s3.NewFromConfig(awsCfg, s3Opts...)
 
-	return &Client{
-		s3Client:         s3Client,
-		uploader:         manager.NewUploader(s3Client), //nolint:staticcheck // TODO: migrate to feature/s3/transfermanager
-		prefix:           cfg.Prefix,
-		autoCreateBucket: cfg.AutoCreateBucket,
-	}, nil
-}
-
-// buildKey constructs the full S3 key from the file name.
-func (c *Client) buildKey(fileName string) string {
-	if c.prefix == "" {
-		return fileName
-	}
-	return c.prefix + "/" + fileName
-}
-
-// ensureBucket checks that the bucket exists. When autoCreateBucket is true,
-// it creates the bucket if it does not exist; otherwise it returns an error.
-// Verified buckets are cached to avoid repeated HeadBucket calls.
-func (c *Client) ensureBucket(ctx context.Context, bucket string) error {
-	if _, ok := c.knownBuckets.Load(bucket); ok {
-		return nil
+	c := &Client{
+		s3Client: s3Client,
+		uploader: manager.NewUploader(s3Client), //nolint:staticcheck // TODO: migrate to feature/s3/transfermanager
+		prefix:   cfg.Prefix,
+		bucket:   cfg.Bucket,
 	}
 
+	if err := c.ensureBucket(ctx, cfg.AutoCreateBucket); err != nil {
+		return nil, fmt.Errorf("ensure bucket %s: %w", cfg.Bucket, err)
+	}
+
+	return c, nil
+}
+
+// buildKey constructs the full S3 key from the folder name and file name.
+func (c *Client) buildKey(folderName, fileName string) string {
+	key := folderName + "/" + fileName
+	if c.prefix != "" {
+		key = c.prefix + "/" + key
+	}
+	return key
+}
+
+// ensureBucket checks that the configured bucket exists. When autoCreate is
+// true, it creates the bucket if it does not exist; otherwise it returns an
+// error. Called once at startup.
+func (c *Client) ensureBucket(ctx context.Context, autoCreate bool) error {
 	_, err := c.s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 	})
 	if err == nil {
-		c.knownBuckets.Store(bucket, true)
 		return nil
 	}
 
 	var notFound *types.NotFound
 	if !errors.As(err, &notFound) {
-		// HeadBucket may also return 404 as a generic smithy error, so check for NoSuchBucket too.
 		var noSuchBucket *types.NoSuchBucket
 		if !errors.As(err, &noSuchBucket) {
-			return fmt.Errorf("head bucket %s: %w", bucket, err)
+			return fmt.Errorf("head bucket %s: %w", c.bucket, err)
 		}
 	}
 
-	if !c.autoCreateBucket {
-		return fmt.Errorf("bucket %s does not exist", bucket)
+	if !autoCreate {
+		return fmt.Errorf("bucket %s does not exist", c.bucket)
 	}
 
 	_, err = c.s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 	})
 	if err != nil {
-		// Bucket may have been created concurrently — check for BucketAlreadyOwnedByYou.
 		var alreadyOwned *types.BucketAlreadyOwnedByYou
-		var alreadyExists *types.BucketAlreadyExists
-		if errors.As(err, &alreadyOwned) || errors.As(err, &alreadyExists) {
-			c.knownBuckets.Store(bucket, true)
+		if errors.As(err, &alreadyOwned) {
 			return nil
 		}
-		return fmt.Errorf("create bucket %s: %w", bucket, err)
+		return fmt.Errorf("create bucket %s: %w", c.bucket, err)
 	}
 
-	c.knownBuckets.Store(bucket, true)
-	logr.FromContextOrDiscard(ctx).V(logging.INFO).Info("Bucket created", "bucket", bucket)
+	logr.FromContextOrDiscard(ctx).V(logging.INFO).Info("Bucket created", "bucket", c.bucket)
 	return nil
 }
 
 // Store stores a file in S3.
-// The bucket parameter specifies which S3 bucket to use.
-func (c *Client) Store(ctx context.Context, fileName, bucket string, fileSizeLimit, lineNumLimit int64, reader io.Reader) (
+// The folderName parameter is used as a key prefix for tenant isolation.
+func (c *Client) Store(ctx context.Context, fileName, folderName string, fileSizeLimit, lineNumLimit int64, reader io.Reader) (
 	*api.BatchFileMetadata, error,
 ) {
-	key := c.buildKey(fileName)
-
-	if err := c.ensureBucket(ctx, bucket); err != nil {
-		return nil, err
-	}
+	key := c.buildKey(folderName, fileName)
 
 	_, err := c.s3Client.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 		Key:    aws.String(key),
 	})
 	if err == nil {
@@ -210,7 +206,7 @@ func (c *Client) Store(ctx context.Context, fileName, bucket string, fileSizeLim
 	}
 
 	_, err = c.uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 		Key:    aws.String(key),
 		Body:   countingReader,
 	})
@@ -233,18 +229,18 @@ func (c *Client) Store(ctx context.Context, fileName, bucket string, fileSizeLim
 	}
 
 	logr.FromContextOrDiscard(ctx).V(logging.INFO).Info("File stored successfully",
-		"bucket", bucket, "key", key, "size", metadata.Size, "lines", metadata.LinesNumber)
+		"bucket", c.bucket, "key", key, "size", metadata.Size, "lines", metadata.LinesNumber)
 
 	return metadata, nil
 }
 
 // Retrieve retrieves a file from S3.
-// The bucket parameter specifies which S3 bucket to use.
-func (c *Client) Retrieve(ctx context.Context, fileName, bucket string) (io.ReadCloser, *api.BatchFileMetadata, error) {
-	key := c.buildKey(fileName)
+// The folderName parameter is used as a key prefix for tenant isolation.
+func (c *Client) Retrieve(ctx context.Context, fileName, folderName string) (io.ReadCloser, *api.BatchFileMetadata, error) {
+	key := c.buildKey(folderName, fileName)
 
 	out, err := c.s3Client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
@@ -273,18 +269,18 @@ func (c *Client) Retrieve(ctx context.Context, fileName, bucket string) (io.Read
 	}
 
 	logr.FromContextOrDiscard(ctx).V(logging.INFO).Info("File retrieved successfully",
-		"bucket", bucket, "key", key, "size", metadata.Size)
+		"bucket", c.bucket, "key", key, "size", metadata.Size)
 
 	return out.Body, metadata, nil
 }
 
 // Delete deletes a file from S3.
-// The bucket parameter specifies which S3 bucket to use.
-func (c *Client) Delete(ctx context.Context, fileName, bucket string) error {
-	key := c.buildKey(fileName)
+// The folderName parameter is used as a key prefix for tenant isolation.
+func (c *Client) Delete(ctx context.Context, fileName, folderName string) error {
+	key := c.buildKey(folderName, fileName)
 
 	_, err := c.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(bucket),
+		Bucket: aws.String(c.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
@@ -296,7 +292,7 @@ func (c *Client) Delete(ctx context.Context, fileName, bucket string) error {
 	}
 
 	logr.FromContextOrDiscard(ctx).V(logging.INFO).Info("File deleted successfully",
-		"bucket", bucket, "key", key)
+		"bucket", c.bucket, "key", key)
 
 	return nil
 }

--- a/internal/files_store/s3/client_test.go
+++ b/internal/files_store/s3/client_test.go
@@ -32,7 +32,10 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/internal/files_store/api"
 )
 
-const testBucketName = "test-bucket"
+const (
+	testBucketName = "test-bucket"
+	testFolderName = "test-folder"
+)
 
 type mockS3Client struct {
 	objects map[string]mockObject
@@ -56,7 +59,7 @@ type mockUploader struct {
 func newMockS3Client() *mockS3Client {
 	return &mockS3Client{
 		objects: make(map[string]mockObject),
-		buckets: make(map[string]bool),
+		buckets: map[string]bool{testBucketName: true},
 	}
 }
 
@@ -147,10 +150,10 @@ func (m *mockS3Client) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2
 
 func newTestClient(mock *mockS3Client) *Client {
 	return &Client{
-		s3Client:         mock,
-		uploader:         &mockUploader{s3Client: mock},
-		prefix:           "",
-		autoCreateBucket: true,
+		s3Client: mock,
+		uploader: &mockUploader{s3Client: mock},
+		prefix:   "",
+		bucket:   testBucketName,
 	}
 }
 
@@ -162,23 +165,20 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("hello world")
 
-		md, err := client.Store(ctx, "test.txt", testBucketName, 1024, 0, bytes.NewReader(content))
+		md, err := client.Store(ctx, "test.txt", testFolderName, 1024, 0, bytes.NewReader(content))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 		if md.Size != int64(len(content)) {
 			t.Errorf("expected size %d, got %d", len(content), md.Size)
 		}
-		if md.Location != "test.txt" {
-			t.Errorf("expected location test.txt, got %s", md.Location)
+		expectedKey := testFolderName + "/test.txt"
+		if md.Location != expectedKey {
+			t.Errorf("expected location %s, got %s", expectedKey, md.Location)
 		}
 
-		obj, ok := mock.objects["test.txt"]
-		if !ok {
+		if _, ok := mock.objects[expectedKey]; !ok {
 			t.Fatal("expected object to be stored")
-		}
-		if !bytes.Equal(obj.data, content) {
-			t.Errorf("expected content %q, got %q", content, obj.data)
 		}
 	})
 
@@ -187,12 +187,12 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("this content is too large")
 
-		_, err := client.Store(ctx, "large.txt", testBucketName, 5, 0, bytes.NewReader(content))
+		_, err := client.Store(ctx, "large.txt", testFolderName, 5, 0, bytes.NewReader(content))
 		if !errors.Is(err, api.ErrFileTooLarge) {
 			t.Errorf("expected ErrFileTooLarge, got %v", err)
 		}
 
-		if _, ok := mock.objects["large.txt"]; ok {
+		if _, ok := mock.objects[testFolderName+"/large.txt"]; ok {
 			t.Error("expected object not to be stored")
 		}
 	})
@@ -202,7 +202,7 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("line1\nline2\nline3\n")
 
-		_, err := client.Store(ctx, "toomany.txt", testBucketName, 1024, 2, bytes.NewReader(content))
+		_, err := client.Store(ctx, "toomany.txt", testFolderName, 1024, 2, bytes.NewReader(content))
 		if !errors.Is(err, api.ErrTooManyLines) {
 			t.Errorf("expected ErrTooManyLines, got %v", err)
 		}
@@ -213,7 +213,7 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("line1\nline2\n")
 
-		md, err := client.Store(ctx, "exactlines.txt", testBucketName, 1024, 2, bytes.NewReader(content))
+		md, err := client.Store(ctx, "exactlines.txt", testFolderName, 1024, 2, bytes.NewReader(content))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -227,7 +227,7 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("12345")
 
-		md, err := client.Store(ctx, "exact.txt", testBucketName, 5, 0, bytes.NewReader(content))
+		md, err := client.Store(ctx, "exact.txt", testFolderName, 5, 0, bytes.NewReader(content))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -240,12 +240,12 @@ func TestStore(t *testing.T) {
 		mock := newMockS3Client()
 		client := newTestClient(mock)
 
-		_, err := client.Store(ctx, "existing.txt", testBucketName, 1024, 0, bytes.NewReader([]byte("original")))
+		_, err := client.Store(ctx, "existing.txt", testFolderName, 1024, 0, bytes.NewReader([]byte("original")))
 		if err != nil {
 			t.Fatalf("expected no error on first store, got %v", err)
 		}
 
-		_, err = client.Store(ctx, "existing.txt", testBucketName, 1024, 0, bytes.NewReader([]byte("new content")))
+		_, err = client.Store(ctx, "existing.txt", testFolderName, 1024, 0, bytes.NewReader([]byte("new content")))
 		if !errors.Is(err, api.ErrFileExists) {
 			t.Errorf("expected ErrFileExists, got %v", err)
 		}
@@ -256,16 +256,39 @@ func TestStore(t *testing.T) {
 		client := newTestClient(mock)
 		client.prefix = "myprefix"
 
-		md, err := client.Store(ctx, "test.txt", testBucketName, 1024, 0, bytes.NewReader([]byte("content")))
+		md, err := client.Store(ctx, "test.txt", testFolderName, 1024, 0, bytes.NewReader([]byte("content")))
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if md.Location != "myprefix/test.txt" {
-			t.Errorf("expected location myprefix/test.txt, got %s", md.Location)
+		expectedKey := "myprefix/" + testFolderName + "/test.txt"
+		if md.Location != expectedKey {
+			t.Errorf("expected location %s, got %s", expectedKey, md.Location)
 		}
 
-		if _, ok := mock.objects["myprefix/test.txt"]; !ok {
+		if _, ok := mock.objects[expectedKey]; !ok {
 			t.Error("expected object to be stored with prefix")
+		}
+	})
+
+	t.Run("isolates files by folder name", func(t *testing.T) {
+		mock := newMockS3Client()
+		client := newTestClient(mock)
+
+		_, err := client.Store(ctx, "file.txt", "tenant-a", 1024, 0, bytes.NewReader([]byte("a")))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		_, err = client.Store(ctx, "file.txt", "tenant-b", 1024, 0, bytes.NewReader([]byte("b")))
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if _, ok := mock.objects["tenant-a/file.txt"]; !ok {
+			t.Error("expected tenant-a file to be stored")
+		}
+		if _, ok := mock.objects["tenant-b/file.txt"]; !ok {
+			t.Error("expected tenant-b file to be stored")
 		}
 	})
 }
@@ -278,12 +301,12 @@ func TestRetrieve(t *testing.T) {
 		client := newTestClient(mock)
 		content := []byte("retrieve me")
 
-		_, err := client.Store(ctx, "retrieve.txt", testBucketName, 1024, 0, bytes.NewReader(content))
+		_, err := client.Store(ctx, "retrieve.txt", testFolderName, 1024, 0, bytes.NewReader(content))
 		if err != nil {
 			t.Fatalf("failed to store: %v", err)
 		}
 
-		reader, md, err := client.Retrieve(ctx, "retrieve.txt", testBucketName)
+		reader, md, err := client.Retrieve(ctx, "retrieve.txt", testFolderName)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -307,7 +330,7 @@ func TestRetrieve(t *testing.T) {
 		mock := newMockS3Client()
 		client := newTestClient(mock)
 
-		_, _, err := client.Retrieve(ctx, "nonexistent.txt", testBucketName)
+		_, _, err := client.Retrieve(ctx, "nonexistent.txt", testFolderName)
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Errorf("expected os.ErrNotExist, got %v", err)
 		}
@@ -320,14 +343,14 @@ func TestDelete(t *testing.T) {
 	t.Run("deletes existing file", func(t *testing.T) {
 		mock := newMockS3Client()
 		client := newTestClient(mock)
-		_, _ = client.Store(ctx, "delete.txt", testBucketName, 1024, 0, bytes.NewReader([]byte("delete me")))
+		_, _ = client.Store(ctx, "delete.txt", testFolderName, 1024, 0, bytes.NewReader([]byte("delete me")))
 
-		err := client.Delete(ctx, "delete.txt", testBucketName)
+		err := client.Delete(ctx, "delete.txt", testFolderName)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		_, _, err = client.Retrieve(ctx, "delete.txt", testBucketName)
+		_, _, err = client.Retrieve(ctx, "delete.txt", testFolderName)
 		if !errors.Is(err, os.ErrNotExist) {
 			t.Error("expected file to be deleted")
 		}
@@ -337,9 +360,61 @@ func TestDelete(t *testing.T) {
 		mock := newMockS3Client()
 		client := newTestClient(mock)
 
-		err := client.Delete(ctx, "nonexistent.txt", testBucketName)
+		err := client.Delete(ctx, "nonexistent.txt", testFolderName)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}
+
+func TestEnsureBucket(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("auto-creates bucket when enabled", func(t *testing.T) {
+		mock := newMockS3Client()
+		delete(mock.buckets, testBucketName)
+
+		c := &Client{
+			s3Client: mock,
+			uploader: &mockUploader{s3Client: mock},
+			bucket:   testBucketName,
+		}
+
+		if err := c.ensureBucket(ctx, true); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !mock.buckets[testBucketName] {
+			t.Error("expected bucket to be created")
+		}
+	})
+
+	t.Run("returns error when bucket missing and auto-create disabled", func(t *testing.T) {
+		mock := newMockS3Client()
+		delete(mock.buckets, testBucketName)
+
+		c := &Client{
+			s3Client: mock,
+			uploader: &mockUploader{s3Client: mock},
+			bucket:   testBucketName,
+		}
+
+		err := c.ensureBucket(ctx, false)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("succeeds when bucket already exists", func(t *testing.T) {
+		mock := newMockS3Client()
+
+		c := &Client{
+			s3Client: mock,
+			uploader: &mockUploader{s3Client: mock},
+			bucket:   testBucketName,
+		}
+
+		if err := c.ensureBucket(ctx, false); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 }
@@ -395,23 +470,47 @@ func TestClose(t *testing.T) {
 
 func TestBuildKey(t *testing.T) {
 	tests := []struct {
-		name     string
-		prefix   string
-		fileName string
-		expected string
+		name       string
+		prefix     string
+		folderName string
+		fileName   string
+		expected   string
 	}{
-		{"no prefix", "", "file.txt", "file.txt"},
-		{"with prefix", "myprefix", "file.txt", "myprefix/file.txt"},
-		{"nested fileName", "prefix", "a/b/file.txt", "prefix/a/b/file.txt"},
+		{"no prefix", "", "folder", "file.txt", "folder/file.txt"},
+		{"with prefix", "myprefix", "folder", "file.txt", "myprefix/folder/file.txt"},
+		{"nested fileName", "prefix", "folder", "a/b/file.txt", "prefix/folder/a/b/file.txt"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := &Client{prefix: tt.prefix}
-			result := client.buildKey(tt.fileName)
+			result := client.buildKey(tt.folderName, tt.fileName)
 			if result != tt.expected {
 				t.Errorf("expected %s, got %s", tt.expected, result)
 			}
 		})
 	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		cfg := &Config{Region: "us-east-1", Bucket: "my-bucket"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("missing region", func(t *testing.T) {
+		cfg := &Config{Bucket: "my-bucket"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for missing region")
+		}
+	})
+
+	t.Run("missing bucket", func(t *testing.T) {
+		cfg := &Config{Region: "us-east-1"}
+		if err := cfg.Validate(); err == nil {
+			t.Error("expected error for missing bucket")
+		}
+	})
 }

--- a/internal/util/com/common.go
+++ b/internal/util/com/common.go
@@ -71,20 +71,18 @@ func FileStorageName(fileID, origFilename string) string {
 	return fileID + ext
 }
 
-// GetFolderNameByTenantID converts a tenant ID into a filesystem and S3-safe folder name.
-// It generates a deterministic SHA256-based name that is guaranteed to be valid for both
-// filesystem paths and S3 bucket naming requirements (63 characters max).
+// GetFolderNameByTenantID converts a tenant ID into a storage-safe folder name.
+// It generates a deterministic SHA256-based name that is used as a filesystem
+// subdirectory or S3 key prefix for tenant isolation.
 func GetFolderNameByTenantID(tenantID string) (string, error) {
 	if tenantID == "" {
 		return "", fmt.Errorf("tenantID cannot be empty")
 	}
 
-	// Generate SHA256 hash of the tenant ID for a deterministic, filesystem-safe name
 	hash := sha256.Sum256([]byte(tenantID))
 	hashStr := hex.EncodeToString(hash[:])
 
-	// Use "t-" prefix + 61 hex chars = 63 chars total (S3 maximum)
-	// This provides virtually collision-free tenant ID mapping while staying under S3's 63-char limit
+	// "t-" prefix + 61 hex chars = 63 chars total
 	return "t-" + hashStr[:61], nil
 }
 

--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -21,6 +21,7 @@ MINIO_IMAGE="${MINIO_IMAGE:-${IMAGE_REGISTRY}/minio/minio:latest}"
 MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minioadmin}"
 MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minioadmin}"
 MINIO_REGION="${MINIO_REGION:-us-east-1}"
+MINIO_BUCKET="${MINIO_BUCKET:-llm-d-batch-gateway}"
 VLLM_SIM_MODEL="${VLLM_SIM_MODEL:-sim-model}"
 VLLM_SIM_B_MODEL="${VLLM_SIM_B_MODEL:-sim-model-b}"
 VLLM_SIM_429_MODEL="${VLLM_SIM_429_MODEL:-sim-model-429}"
@@ -815,10 +816,12 @@ install_vllm_sim() {
     step "Installing vLLM simulator '${sim_name}' (model: ${sim_model})..."
 
     local extra_args_yaml=""
-    for arg in "${extra_args[@]}"; do
-        extra_args_yaml="${extra_args_yaml}
+    if [ ${#extra_args[@]} -gt 0 ]; then
+        for arg in "${extra_args[@]}"; do
+            extra_args_yaml="${extra_args_yaml}
         - ${arg}"
-    done
+        done
+    fi
 
     kubectl apply -f - <<EOF
 apiVersion: apps/v1
@@ -1115,6 +1118,7 @@ install_batch_gateway() {
         local minio_endpoint="http://${MINIO_NAME}.${NAMESPACE}.svc.cluster.local:9000"
         helm_args+=(
             --set "global.fileClient.s3.region=${MINIO_REGION}"
+            --set "global.fileClient.s3.bucket=${MINIO_BUCKET}"
             --set "global.fileClient.s3.endpoint=${minio_endpoint}"
             --set "global.fileClient.s3.accessKeyId=${MINIO_ACCESS_KEY}"
             --set "global.fileClient.s3.usePathStyle=true"

--- a/test/integration/s3_client_test.go
+++ b/test/integration/s3_client_test.go
@@ -50,7 +50,8 @@ import (
 )
 
 const (
-	integrationBucket = "integration-test"
+	integrationBucket     = "integration-test"
+	integrationFolderName = "test-tenant-folder"
 )
 
 func s3Config() s3client.Config {
@@ -65,6 +66,7 @@ func s3Config() s3client.Config {
 
 	return s3client.Config{
 		Region:           "us-east-1",
+		Bucket:           integrationBucket,
 		Endpoint:         os.Getenv("S3_TEST_ENDPOINT"),
 		AccessKeyID:      accessKey,
 		SecretAccessKey:  secretKey,
@@ -95,11 +97,11 @@ func TestS3StoreAndRetrieve(t *testing.T) {
 	content := []byte("hello integration test\nline2\nline3\n")
 	fileName := fmt.Sprintf("test-store-retrieve-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	md, err := client.Store(ctx, fileName, integrationBucket, 1024, 0, bytes.NewReader(content))
+	md, err := client.Store(ctx, fileName, integrationFolderName, 1024, 0, bytes.NewReader(content))
 	if err != nil {
 		t.Fatalf("Store failed: %v", err)
 	}
-	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationBucket) })
+	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationFolderName) })
 
 	if md.Size != int64(len(content)) {
 		t.Errorf("expected size %d, got %d", len(content), md.Size)
@@ -108,7 +110,7 @@ func TestS3StoreAndRetrieve(t *testing.T) {
 		t.Errorf("expected 3 lines, got %d", md.LinesNumber)
 	}
 
-	reader, md2, err := client.Retrieve(ctx, fileName, integrationBucket)
+	reader, md2, err := client.Retrieve(ctx, fileName, integrationFolderName)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
 	}
@@ -131,13 +133,13 @@ func TestS3StoreExistingFile(t *testing.T) {
 	ctx := context.Background()
 	fileName := fmt.Sprintf("test-existing-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	_, err := client.Store(ctx, fileName, integrationBucket, 1024, 0, bytes.NewReader([]byte("first")))
+	_, err := client.Store(ctx, fileName, integrationFolderName, 1024, 0, bytes.NewReader([]byte("first")))
 	if err != nil {
 		t.Fatalf("first Store failed: %v", err)
 	}
-	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationBucket) })
+	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationFolderName) })
 
-	_, err = client.Store(ctx, fileName, integrationBucket, 1024, 0, bytes.NewReader([]byte("second")))
+	_, err = client.Store(ctx, fileName, integrationFolderName, 1024, 0, bytes.NewReader([]byte("second")))
 	if !errors.Is(err, api.ErrFileExists) {
 		t.Errorf("expected ErrFileExists, got %v", err)
 	}
@@ -148,12 +150,12 @@ func TestS3StoreFileTooLarge(t *testing.T) {
 	ctx := context.Background()
 	fileName := fmt.Sprintf("test-toolarge-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	_, err := client.Store(ctx, fileName, integrationBucket, 5, 0, bytes.NewReader([]byte("this is too large")))
+	_, err := client.Store(ctx, fileName, integrationFolderName, 5, 0, bytes.NewReader([]byte("this is too large")))
 	if !errors.Is(err, api.ErrFileTooLarge) {
 		t.Errorf("expected ErrFileTooLarge, got %v", err)
 	}
 
-	_, _, err = client.Retrieve(ctx, fileName, integrationBucket)
+	_, _, err = client.Retrieve(ctx, fileName, integrationFolderName)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected rejected file to not exist in storage, got: %v", err)
 	}
@@ -164,12 +166,12 @@ func TestS3StoreTooManyLines(t *testing.T) {
 	ctx := context.Background()
 	fileName := fmt.Sprintf("test-toomanylines-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	_, err := client.Store(ctx, fileName, integrationBucket, 1024, 2, bytes.NewReader([]byte("l1\nl2\nl3\n")))
+	_, err := client.Store(ctx, fileName, integrationFolderName, 1024, 2, bytes.NewReader([]byte("l1\nl2\nl3\n")))
 	if !errors.Is(err, api.ErrTooManyLines) {
 		t.Errorf("expected ErrTooManyLines, got %v", err)
 	}
 
-	_, _, err = client.Retrieve(ctx, fileName, integrationBucket)
+	_, _, err = client.Retrieve(ctx, fileName, integrationFolderName)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected rejected file to not exist in storage, got: %v", err)
 	}
@@ -180,17 +182,17 @@ func TestS3Delete(t *testing.T) {
 	ctx := context.Background()
 	fileName := fmt.Sprintf("test-delete-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	_, err := client.Store(ctx, fileName, integrationBucket, 1024, 0, bytes.NewReader([]byte("delete me")))
+	_, err := client.Store(ctx, fileName, integrationFolderName, 1024, 0, bytes.NewReader([]byte("delete me")))
 	if err != nil {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	err = client.Delete(ctx, fileName, integrationBucket)
+	err = client.Delete(ctx, fileName, integrationFolderName)
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
 
-	_, _, err = client.Retrieve(ctx, fileName, integrationBucket)
+	_, _, err = client.Retrieve(ctx, fileName, integrationFolderName)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected os.ErrNotExist after delete, got %v", err)
 	}
@@ -202,7 +204,7 @@ func TestS3DeleteNonExistent(t *testing.T) {
 
 	// Deleting a file that was never created should succeed (S3 DeleteObject is idempotent).
 	fileName := fmt.Sprintf("test-delete-nonexistent-%s-%s", t.Name(), uuid.NewString()[:8])
-	err := client.Delete(ctx, fileName, integrationBucket)
+	err := client.Delete(ctx, fileName, integrationFolderName)
 	if err != nil {
 		t.Fatalf("Delete of non-existent file should succeed (S3 idempotent delete), got: %v", err)
 	}
@@ -212,7 +214,7 @@ func TestS3RetrieveNonExistent(t *testing.T) {
 	client := newS3IntegrationClient(t, s3Config())
 	ctx := context.Background()
 
-	_, _, err := client.Retrieve(ctx, "nonexistent-file-xyz", integrationBucket)
+	_, _, err := client.Retrieve(ctx, "nonexistent-file-xyz", integrationFolderName)
 	if !errors.Is(err, os.ErrNotExist) {
 		t.Errorf("expected os.ErrNotExist, got %v", err)
 	}
@@ -225,18 +227,18 @@ func TestS3Prefix(t *testing.T) {
 	ctx := context.Background()
 	fileName := fmt.Sprintf("test-prefix-%s-%s", t.Name(), uuid.NewString()[:8])
 
-	md, err := client.Store(ctx, fileName, integrationBucket, 1024, 0, bytes.NewReader([]byte("prefixed")))
+	md, err := client.Store(ctx, fileName, integrationFolderName, 1024, 0, bytes.NewReader([]byte("prefixed")))
 	if err != nil {
 		t.Fatalf("Store failed: %v", err)
 	}
-	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationBucket) })
+	t.Cleanup(func() { _ = client.Delete(ctx, fileName, integrationFolderName) })
 
-	expectedLocation := "testprefix/" + fileName
+	expectedLocation := "testprefix/" + integrationFolderName + "/" + fileName
 	if md.Location != expectedLocation {
 		t.Errorf("expected location %s, got %s", expectedLocation, md.Location)
 	}
 
-	reader, _, err := client.Retrieve(ctx, fileName, integrationBucket)
+	reader, _, err := client.Retrieve(ctx, fileName, integrationFolderName)
 	if err != nil {
 		t.Fatalf("Retrieve failed: %v", err)
 	}


### PR DESCRIPTION
## Why is this PR needed?

The S3 backend uses `folderName` (tenant ID hash) as the S3 **bucket name**, creating one bucket per tenant. AWS S3 limits accounts to 100 buckets by default (1000 max after support request), so the system breaks once tenant count exceeds this hard limit.

Fixes #565

## What does this PR do?

Switches the S3 backend from per-tenant buckets to a **single configured bucket** with tenant isolation via S3 key prefixes.
- before: bucket=`t-<hash>`, key=`prefix/fileName`
- after: bucket=`config.bucket`, key=`prefix/t-<hash>/fileName`


The PR include:
- Adds required `bucket` field to S3 Config
- Simplifies `ensureBucket` — called once at startup instead of per-operation
- Updates Helm values/templates and local dev configs with new `bucket` field
- No changes to FS backend

## How was this tested?

- [x] Unit tests added/updated/verified (1057 pass, 0 fail)
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Fixes #565