### PR TITLE
fix(demo): add s3 bucket field to deploy scripts for single-bucket mode

### DIFF
--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -856,7 +856,8 @@ kubectl rollout status statefulset/postgresql -n ${BATCH_NS} --timeout=120s
 # Install MinIO (S3-compatible object storage for batch files)
 MINIO_USER=<your-minio-user>
 MINIO_PASSWORD=<your-minio-password>
-MINIO_BUCKET=batch-gateway
+MINIO_BUCKET=llm-d-batch-gateway
+MINIO_REGION=us-east-1
 
 kubectl apply -f - <<EOF
 apiVersion: apps/v1
@@ -964,7 +965,8 @@ helm upgrade --install batch-gateway ./charts/batch-gateway \
     --set "global.dbClient.type=postgresql" \
     --set "global.fileClient.type=s3" \
     --set "global.fileClient.s3.endpoint=http://minio.${BATCH_NS}.svc.cluster.local:9000" \
-    --set "global.fileClient.s3.region=us-east-1" \
+    --set "global.fileClient.s3.region=${MINIO_REGION}" \
+    --set "global.fileClient.s3.bucket=${MINIO_BUCKET}" \
     --set "global.fileClient.s3.accessKeyId=${MINIO_USER}" \
     --set "global.fileClient.s3.prefix=${MINIO_BUCKET}" \
     --set "global.fileClient.s3.usePathStyle=true" \

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -81,7 +81,8 @@ DEMO_TLS_INSECURE_SKIP_VERIFY="${DEMO_TLS_INSECURE_SKIP_VERIFY:-1}"
 BATCH_MINIO_RELEASE="${BATCH_MINIO_RELEASE:-minio}"
 MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
 MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
-MINIO_BUCKET="${MINIO_BUCKET:-batch-gateway}"
+MINIO_BUCKET="${MINIO_BUCKET:-llm-d-batch-gateway}"
+MINIO_REGION="${MINIO_REGION:-us-east-1}"
 # Image overrides. When set, these take precedence over defaults derived from
 # BATCH_RELEASE_VERSION / BATCH_DEV_VERSION. Leave unset to use chart defaults.
 # Example (upstream):
@@ -619,7 +620,8 @@ do_deploy_batch_gateway_helm() {
         local minio_endpoint="http://${BATCH_MINIO_RELEASE}.${BATCH_NAMESPACE}.svc.cluster.local:9000"
         helm_args+=(
             --set "global.fileClient.s3.endpoint=${minio_endpoint}"
-            --set "global.fileClient.s3.region=us-east-1"
+            --set "global.fileClient.s3.region=${MINIO_REGION}"
+            --set "global.fileClient.s3.bucket=${MINIO_BUCKET}"
             --set "global.fileClient.s3.accessKeyId=${MINIO_ROOT_USER}"
             --set "global.fileClient.s3.prefix=${MINIO_BUCKET}"
             --set "global.fileClient.s3.usePathStyle=true"
@@ -776,7 +778,8 @@ do_deploy_batch_gateway_dsc() {
     if [ "${BATCH_STORAGE_TYPE}" = "s3" ]; then
         local minio_endpoint="http://${BATCH_MINIO_RELEASE}.${BATCH_NAMESPACE}.svc.cluster.local:9000"
         file_storage_yaml="    s3:
-      region: us-east-1
+      region: ${MINIO_REGION}
+      bucket: ${MINIO_BUCKET}
       endpoint: ${minio_endpoint}
       accessKeyId: ${MINIO_ROOT_USER}
       prefix: ${MINIO_BUCKET}

--- a/examples/deploy-demo/deploy-k8s.md
+++ b/examples/deploy-demo/deploy-k8s.md
@@ -124,6 +124,8 @@ Use that only on **ephemeral or dedicated** demo clusters. See [issue #309](http
 | `BATCH_GC_REPO` | — | Override gc image repository |
 | `BATCH_DB_TYPE` | `postgresql` | Database backend: `postgresql` or `redis` |
 | `BATCH_STORAGE_TYPE` | `s3` | File storage: `fs` or `s3` |
+| `MINIO_BUCKET` | `llm-d-batch-gateway` | MinIO bucket name (also used as the S3 `bucket` and `prefix` config values) |
+| `MINIO_REGION` | `us-east-1` | S3 region for MinIO |
 | `DEMO_TLS_INSECURE_SKIP_VERIFY` | `1` | Disables TLS certificate verification for processor → model gateway and Istio Gateway → batch apiserver (**demo/lab only**, [CWE-295](https://cwe.mitre.org/data/definitions/295.html)). Default `1` since demo scripts use self-signed certs. Set to `0` if you have trusted CA certs. |
 | `BATCH_NAMESPACE` | `batch-api` | Namespace for batch-gateway |
 | `LLM_NAMESPACE` | `llm` | Namespace for model serving |


### PR DESCRIPTION
## Why is this PR needed?

PR #566 added a required `bucket` field to S3 config. The deploy-demo scripts were not updated.

## What does this PR do?

- Pass `global.fileClient.s3.bucket` in Helm and DSC deploy paths
- Align default `MINIO_BUCKET` to `llm-d-batch-gateway` (matches dev-deploy.sh)

## How was this tested?

- [x] Full deploy + 13/13 e2e tests passed on OpenShift (CI ephemeral cluster)
- [x] Flow control runtime verification passed

## Related Issues

Follows up on #566