### PR TITLE
fix: size async result channel to plan length

### DIFF
--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -566,7 +566,10 @@ func (p *Processor) processModelAsync(
 
 	logger.V(logging.INFO).Info("Processing requests for model (async)", "numEntries", len(entries))
 
-	asyncClient := p.asyncInference.ClientFor(modelID)
+	// Size the per-job results buffer to the plan length so results that
+	// arrive during submit-before-collect cannot fill a fixed buffer of 100
+	// and be silently dropped by the shared resultDispatcher.
+	asyncClient := p.asyncInference.ClientForWithCapacity(modelID, len(entries))
 	if asyncClient == nil {
 		logger.V(logging.INFO).Info("No async client for model, draining as model_not_found")
 		p.drainUnprocessedRequests(

--- a/pkg/clients/inference/async_inference_client_impl.go
+++ b/pkg/clients/inference/async_inference_client_impl.go
@@ -106,6 +106,10 @@ func (d *resultDispatcher) processNext(ctx context.Context) {
 		RequestID: result.ID,
 		Response:  []byte(result.Payload),
 	}
+	// Non-blocking send keeps the shared dispatcher from stalling when one
+	// job's channel is full. Callers must size the per-job buffer to cover
+	// submit-before-collect (see ClientForWithCapacity); this default branch
+	// is a defensive fallback only.
 	select {
 	case ch <- resp:
 	default:
@@ -162,12 +166,20 @@ type asyncProducerClient struct {
 	logger     logr.Logger
 }
 
-func newAsyncProducerClient(pool *asyncPool) *asyncProducerClient {
+func newAsyncProducerClient(pool *asyncPool, capacity int) *asyncProducerClient {
+	if capacity <= 0 {
+		capacity = defaultResultBufferSize
+	}
 	return &asyncProducerClient{
 		pool:    pool,
-		results: make(chan *GenerateResponse, defaultResultBufferSize),
+		results: make(chan *GenerateResponse, capacity),
 		logger:  pool.logger,
 	}
+}
+
+// resultBufferCap returns the per-job results channel capacity (test helper).
+func (c *asyncProducerClient) resultBufferCap() int {
+	return cap(c.results)
 }
 
 // Submit enqueues a request for async processing. The result will be routed

--- a/pkg/clients/inference/async_inference_client_integration_test.go
+++ b/pkg/clients/inference/async_inference_client_integration_test.go
@@ -35,7 +35,7 @@ func TestAsyncProducerClient_Submit_roundtrip(t *testing.T) {
 		resultQueue := asyncQueuePrefix + "results:" + poolName
 
 		pool := newTestPool(t, mr, poolName)
-		client := newAsyncProducerClient(pool)
+		client := newAsyncProducerClient(pool, 0)
 		defer func() { _ = client.Close() }()
 
 		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})

--- a/pkg/clients/inference/async_inference_client_resolver.go
+++ b/pkg/clients/inference/async_inference_client_resolver.go
@@ -46,9 +46,19 @@ type AsyncGatewayResolver struct {
 	clientFactories map[string]func() AsyncInferenceClient // test-only override
 }
 
-// ClientFor creates a fresh per-job async client for the given model.
+// ClientFor creates a fresh per-job async client for the given model using
+// the default result buffer size. Prefer ClientForWithCapacity when the
+// caller knows how many results may arrive before collect starts.
 // Returns nil if no matching pool exists.
 func (r *AsyncGatewayResolver) ClientFor(modelID string) AsyncInferenceClient {
+	return r.ClientForWithCapacity(modelID, defaultResultBufferSize)
+}
+
+// ClientForWithCapacity creates a fresh per-job async client whose results
+// channel can hold capacity responses. Under submit-then-collect, pass
+// len(planEntries) so results that arrive during submit are not dropped.
+// Returns nil if no matching pool exists. capacity <= 0 uses the default.
+func (r *AsyncGatewayResolver) ClientForWithCapacity(modelID string, capacity int) AsyncInferenceClient {
 	if r.clientFactories != nil {
 		if factory, ok := r.clientFactories[modelID]; ok {
 			return factory()
@@ -59,7 +69,7 @@ func (r *AsyncGatewayResolver) ClientFor(modelID string) AsyncInferenceClient {
 	if !ok {
 		return nil
 	}
-	return newAsyncProducerClient(pool)
+	return newAsyncProducerClient(pool, capacity)
 }
 
 // NewTestAsyncResolver creates a resolver backed by factory functions instead of

--- a/pkg/clients/inference/async_inference_client_resolver_test.go
+++ b/pkg/clients/inference/async_inference_client_resolver_test.go
@@ -125,4 +125,27 @@ func TestNewAsyncResolver(t *testing.T) {
 			t.Fatal("expected fresh client per ClientFor call")
 		}
 	})
+
+	t.Run("ClientForWithCapacity sizes the results buffer", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+
+		r, err := NewAsyncResolver(AsyncClientConfig{
+			RedisURL:          "redis://" + mr.Addr(),
+			Models:            map[string]string{"model-a": "pool-a"},
+			ResultPollTimeout: time.Second,
+		}, testLogger(t))
+		if err != nil {
+			t.Fatalf("NewAsyncResolver: %v", err)
+		}
+		t.Cleanup(func() { _ = r.Close() })
+
+		client := r.ClientForWithCapacity("model-a", 175)
+		got, ok := client.(*asyncProducerClient)
+		if !ok {
+			t.Fatalf("ClientForWithCapacity type = %T, want *asyncProducerClient", client)
+		}
+		if cap := got.resultBufferCap(); cap != 175 {
+			t.Fatalf("resultBufferCap() = %d, want 175", cap)
+		}
+	})
 }

--- a/pkg/clients/inference/async_inference_client_test.go
+++ b/pkg/clients/inference/async_inference_client_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +34,32 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+// stubProducer is an in-memory producer.Producer for unit-testing the
+// resultDispatcher without Redis.
+type stubProducer struct {
+	mu      sync.Mutex
+	results []*api.ResultMessage
+}
+
+func (s *stubProducer) SubmitRequest(context.Context, api.Request) error { return nil }
+
+func (s *stubProducer) GetResult(ctx context.Context) (*api.ResultMessage, error) {
+	s.mu.Lock()
+	if len(s.results) > 0 {
+		r := s.results[0]
+		s.results = s.results[1:]
+		s.mu.Unlock()
+		return r, nil
+	}
+	s.mu.Unlock()
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *stubProducer) Close() error { return nil }
+
+var _ producer.Producer = (*stubProducer)(nil)
 
 func newTestPool(t *testing.T, mr *miniredis.Miniredis, poolName string) *asyncPool {
 	t.Helper()
@@ -79,7 +106,7 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 		resultQueue := asyncQueuePrefix + "results:" + poolName
 
 		pool := newTestPool(t, mr, poolName)
-		client := newAsyncProducerClient(pool)
+		client := newAsyncProducerClient(pool, 0)
 		defer func() { _ = client.Close() }()
 
 		go func() {
@@ -113,7 +140,7 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 		resultQueue := asyncQueuePrefix + "results:" + poolName
 
 		pool := newTestPool(t, mr, poolName)
-		client := newAsyncProducerClient(pool)
+		client := newAsyncProducerClient(pool, 0)
 		defer func() { _ = client.Close() }()
 
 		for _, id := range []string{"s-1", "s-2", "s-3"} {
@@ -156,7 +183,7 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 		resultQueue := asyncQueuePrefix + "results:" + poolName
 
 		pool := newTestPool(t, mr, poolName)
-		client := newAsyncProducerClient(pool)
+		client := newAsyncProducerClient(pool, 0)
 
 		if err := client.Submit(context.Background(), &GenerateRequest{
 			RequestID: "c-1",
@@ -186,8 +213,8 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 		resultQueue := asyncQueuePrefix + "results:" + poolName
 
 		pool := newTestPool(t, mr, poolName)
-		clientA := newAsyncProducerClient(pool)
-		clientB := newAsyncProducerClient(pool)
+		clientA := newAsyncProducerClient(pool, 0)
+		clientB := newAsyncProducerClient(pool, 0)
 		defer func() { _ = clientA.Close() }()
 		defer func() { _ = clientB.Close() }()
 
@@ -233,7 +260,7 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 	t.Run("close handles non-string key without panic", func(t *testing.T) {
 		mr := miniredis.RunT(t)
 		pool := newTestPool(t, mr, "close-nonstring-pool")
-		client := newAsyncProducerClient(pool)
+		client := newAsyncProducerClient(pool, 0)
 
 		// Manually store a non-string key in pendingIDs
 		client.pendingIDs.Store(42, struct{}{})
@@ -246,13 +273,80 @@ func TestAsyncProducerClient_Submit(t *testing.T) {
 	})
 }
 
+func TestAsyncProducerClient_ResultBufferCapacity(t *testing.T) {
+	mr := miniredis.RunT(t)
+	pool := newTestPool(t, mr, "capacity-pool")
+
+	t.Run("explicit capacity is honored", func(t *testing.T) {
+		client := newAsyncProducerClient(pool, 250)
+		defer func() { _ = client.Close() }()
+		if got := client.resultBufferCap(); got != 250 {
+			t.Fatalf("resultBufferCap() = %d, want 250", got)
+		}
+	})
+
+	t.Run("non-positive capacity falls back to default", func(t *testing.T) {
+		client := newAsyncProducerClient(pool, 0)
+		defer func() { _ = client.Close() }()
+		if got := client.resultBufferCap(); got != defaultResultBufferSize {
+			t.Fatalf("resultBufferCap() = %d, want %d", got, defaultResultBufferSize)
+		}
+	})
+}
+
+func TestResultDispatcher_SubmitBeforeCollectBuffer(t *testing.T) {
+	// Reproduces submit-before-collect: many results arrive before any drain.
+	// Undersized buffer (default 100) drops; sizing to the batch does not.
+	const n = 150
+
+	dispatchAll := func(t *testing.T, bufSize int) int {
+		t.Helper()
+		results := make([]*api.ResultMessage, n)
+		for i := range results {
+			id := fmt.Sprintf("req-%d", i)
+			results[i] = &api.ResultMessage{ID: id, Payload: `{"ok":true}`}
+		}
+		stub := &stubProducer{results: results}
+		d := newResultDispatcher(stub, testLogger(t), time.Second)
+		ch := make(chan *GenerateResponse, bufSize)
+		// Store waiters directly — register() would start the background
+		// run loop and race with the processNext calls below.
+		for i := range n {
+			d.waiters.Store(fmt.Sprintf("req-%d", i), (chan<- *GenerateResponse)(ch))
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		for range n {
+			d.processNext(ctx)
+		}
+		return len(ch)
+	}
+
+	t.Run("undersized buffer drops results", func(t *testing.T) {
+		got := dispatchAll(t, defaultResultBufferSize) // 100 < 150
+		if got >= n {
+			t.Fatalf("delivered %d/%d — expected drops with buffer %d", got, n, defaultResultBufferSize)
+		}
+		if got != defaultResultBufferSize {
+			t.Fatalf("delivered %d, want %d (channel filled then dropped the rest)", got, defaultResultBufferSize)
+		}
+	})
+
+	t.Run("buffer sized to batch delivers all", func(t *testing.T) {
+		got := dispatchAll(t, n)
+		if got != n {
+			t.Fatalf("delivered %d results, want %d", got, n)
+		}
+	})
+}
+
 func TestResultDispatcher_PanicRecovery(t *testing.T) {
 	mr := miniredis.RunT(t)
 	poolName := "panic-pool"
 	resultQueue := asyncQueuePrefix + "results:" + poolName
 
 	pool := newTestPool(t, mr, poolName)
-	client := newAsyncProducerClient(pool)
+	client := newAsyncProducerClient(pool, 0)
 	defer func() { _ = client.Close() }()
 
 	// Submit two requests
@@ -298,7 +392,7 @@ func TestAsyncProducerClient_SubmitPropagatesTraceContext(t *testing.T) {
 	requestQueue := asyncQueuePrefix + "requests:" + poolName
 
 	pool := newTestPool(t, mr, poolName)
-	client := newAsyncProducerClient(pool)
+	client := newAsyncProducerClient(pool, 0)
 	defer func() { _ = client.Close() }()
 
 	// Create a parent span to simulate the job runner's trace context


### PR DESCRIPTION
## Why is this PR needed?

Under the async submit-then-collect path, results can arrive before collect starts reading. The per-job results channel used a fixed buffer of 100. When more than 100 results arrived first, `resultDispatcher` dropped them (`default:` + "Dropping result"). Those results were already removed from Redis and from the waiter map, so collect waited until abort and the job looked like it expired. 

## What does this PR do?

Sizes the per-job results channel to the plan length (`len(entries)`) via `ClientForWithCapacity`, so submit-before-collect cannot fill a fixed buffer of 100. Keeps the non-blocking send and drop only as a defensive fallback, so one full channel does not stall the shared dispatcher for other jobs on the same pool.

## How was this tested?

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

Unit and integration: `go test ./pkg/clients/inference/ ./internal/processor/worker/ -count=1`, `go test ./... -count=1`, `go test ./test/regression/... -count=1`, `go test -tags=integration ./... -count=1`.

Regression coverage: `TestResultDispatcher_SubmitBeforeCollectBuffer` shows undersized buffer drops results, and buffer sized to the batch delivers all.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

None. Standalone correctness fix.