### PR TITLE
fix(e2e): make tests portable for non-standard clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ benchmarks/results/*
 !benchmarks/results/.gitkeep
 .dispatcher-port-forward.pid
 .dispatcher-sim-port-forward.pid
+*.DS_Store

--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -74,11 +74,11 @@ func doTestBatchCancel(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 5; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"sim-model","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, i))
+			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, testModel, i))
 	}
 	for i := 1; i <= 20; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"sim-model","max_tokens":200,"messages":[{"role":"user","content":"Tell me a long story %d"}]}}`, i, i))
+			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Tell me a long story %d"}]}}`, i, testModel, i))
 	}
 	slowJSONL := strings.Join(lines, "\n")
 	fileID := mustCreateFile(t, fmt.Sprintf("test-batch-cancel-%s.jsonl", testRunID), slowJSONL)
@@ -371,11 +371,6 @@ func doTestBatchMixedSuccessFailure(t *testing.T) {
 func doTestPassThroughHeaders(t *testing.T) {
 	t.Helper()
 
-	// Verify processor logs contain the pass-through header names
-	if !testKubectlAvailable {
-		t.Skip("kubectl not available, skipping processor log verification")
-	}
-
 	// Create batch with pass-through headers
 	fileID := mustCreateFile(t, fmt.Sprintf("test-pass-through-headers-%s.jsonl", testRunID), testJSONL)
 
@@ -403,6 +398,13 @@ func doTestPassThroughHeaders(t *testing.T) {
 	}
 	if finalBatch.ErrorFileID != "" {
 		t.Errorf("expected empty error_file_id, got %q", finalBatch.ErrorFileID)
+	}
+
+	// Verify processor logs contain the pass-through header names.
+	// Skip when kubectl is unavailable — the batch completion above already
+	// validates the core pass-through functionality.
+	if !testKubectlAvailable {
+		t.Skip("kubectl not available, skipping processor log verification")
 	}
 
 	out, err := exec.Command("kubectl", "logs",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,6 +37,7 @@ var (
 	testHelmRelease       = getEnvOrDefault("TEST_HELM_RELEASE", "batch-gateway")
 	testPostgresqlRelease = getEnvOrDefault("TEST_POSTGRESQL_RELEASE", "postgresql")
 	testRedisRelease      = getEnvOrDefault("TEST_REDIS_RELEASE", "redis")
+	testDBPod             = getEnvOrDefault("TEST_DB_POD", "")
 
 	// testDBClientType and testExchangeClientType are detected from Helm
 	// releases at startup; see detectDBClientType / detectExchangeClientType.

--- a/test/e2e/gc_test.go
+++ b/test/e2e/gc_test.go
@@ -47,10 +47,15 @@ func expireInDB(t *testing.T, table, id string) {
 func expireInPostgresql(t *testing.T, table, id string) {
 	t.Helper()
 
+	podName := testDBPod
+	if podName == "" {
+		podName = fmt.Sprintf("%s-0", testPostgresqlRelease)
+	}
+
 	sql := fmt.Sprintf("UPDATE %s SET expiry = 1 WHERE id = '%s'", table, id)
 	cmd := fmt.Sprintf(`PGPASSWORD="$(cat "$POSTGRES_PASSWORD_FILE")" psql -U postgres -d postgres -c %q`, sql)
 	out, err := exec.Command("kubectl", "exec",
-		fmt.Sprintf("%s-0", testPostgresqlRelease),
+		podName,
 		"-n", testNamespace,
 		"--", "bash", "-c", cmd,
 	).CombinedOutput()


### PR DESCRIPTION
## Why is this PR needed?

The e2e test suite has several hardcoded assumptions (model names, pod names, kubectl availability) that prevent tests from passing on non-standard cluster configurations such as RHOAI, where  pod names differ from conventions, and pass-through headers may not be configured.

## What does this PR do?

- **Replace hardcoded `"sim-model"` with `testModel` in `Cancel/InProgress` test** — `doTestBatchCancel` was the only test that ignored the `TEST_MODEL` env var, causing failures when the model name is overridden.
- **Add `TEST_DB_POD` env var for GC tests** — `expireInPostgresql` now accepts an optional pod name override, so clusters with non-standard pod naming (e.g. CockroachDB on RHOAI) can set `TEST_DB_POD` instead of being forced to match the `<release>-0` convention.
- **Decouple `PassThroughHeaders` batch assertions from kubectl log verification** — The test previously skipped entirely when kubectl was unavailable. Now the batch creation and completion assertions always run (validating core functionality), and only the processor log-grep is skipped when kubectl is not present.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

