### PR TITLE
test(e2e): add TEST_SIM_MODEL for timing-dependent tests to use simulator with controlled latency

### DIFF
--- a/test/e2e/batches_test.go
+++ b/test/e2e/batches_test.go
@@ -74,11 +74,11 @@ func doTestBatchCancel(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 5; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, testModel, i))
+			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, testSimModel, i))
 	}
 	for i := 1; i <= 20; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Tell me a long story %d"}]}}`, i, testModel, i))
+			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Tell me a long story %d"}]}}`, i, testSimModel, i))
 	}
 	slowJSONL := strings.Join(lines, "\n")
 	fileID := mustCreateFile(t, fmt.Sprintf("test-batch-cancel-%s.jsonl", testRunID), slowJSONL)
@@ -521,7 +521,7 @@ func doTestBatchExpiration(t *testing.T) {
 	var blockerLines []string
 	for i := 1; i <= 50; i++ {
 		blockerLines = append(blockerLines, fmt.Sprintf(
-			`{"custom_id":"blocker-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Block %d"}]}}`, i, testModel, i))
+			`{"custom_id":"blocker-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Block %d"}]}}`, i, testSimModel, i))
 	}
 	blockerFileID := mustCreateFile(t, fmt.Sprintf("test-expiration-blocker-%s.jsonl", testRunID), strings.Join(blockerLines, "\n"))
 	blockerBatchID := mustCreateBatch(t, blockerFileID)
@@ -547,7 +547,7 @@ func doTestBatchExpiration(t *testing.T) {
 	var lines []string
 	for i := 1; i <= numRequests; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"expire-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Expire %d"}]}}`, i, testModel, i))
+			`{"custom_id":"expire-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"Expire %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-batch-expiration-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 
@@ -606,7 +606,7 @@ func doTestCancelIdempotentRetry(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 20; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"retry-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"retry-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-cancel-retry-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)
@@ -742,11 +742,11 @@ func doTestProgressPolling(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 5; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"fast %d"}]}}`, i, testModel, i))
+			`{"custom_id":"fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"fast %d"}]}}`, i, testSimModel, i))
 	}
 	for i := 1; i <= 15; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-progress-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -47,8 +47,14 @@ var (
 	testRunID = fmt.Sprintf("%d", time.Now().UnixNano())
 
 	// testModel is the model name used in batch input; configurable via TEST_MODEL env var.
-	testModel           = getEnvOrDefault("TEST_MODEL", "sim-model")
-	testModelB          = getEnvOrDefault("TEST_MODEL_B", "sim-model-b")
+	testModel  = getEnvOrDefault("TEST_MODEL", "sim-model")
+	testModelB = getEnvOrDefault("TEST_MODEL_B", "sim-model-b")
+	// testSimModel is the model name used in timing-dependent tests that require
+	// controlled latency (cancel, expiration, progress polling, orphan recovery,
+	// graceful shutdown). It should always point to a simulator with predictable
+	// inter-token latency. Defaults to testModel for dev-deploy where all models
+	// are simulated.
+	testSimModel        = getEnvOrDefault("TEST_SIM_MODEL", testModel)
 	testModel429        = getEnvOrDefault("TEST_MODEL_429", "sim-model-429")
 	testModelAlwaysFail = getEnvOrDefault("TEST_MODEL_ALWAYS_FAIL", "sim-model-always-fail")
 	testModelAIMD       = getEnvOrDefault("TEST_MODEL_AIMD", "sim-model-aimd")

--- a/test/e2e/orphan_recovery_test.go
+++ b/test/e2e/orphan_recovery_test.go
@@ -68,7 +68,7 @@ func doTestHardCrashOrphanRecovery(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 50; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"orphan-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"orphan-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-orphan-recovery-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)
@@ -115,11 +115,11 @@ func doTestCancellingOrphanRecovery(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 5; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"cancel-orphan-fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, testModel, i))
+			`{"custom_id":"cancel-orphan-fast-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":1,"messages":[{"role":"user","content":"Hi %d"}]}}`, i, testSimModel, i))
 	}
 	for i := 1; i <= 20; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"cancel-orphan-slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"cancel-orphan-slow-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-cancelling-orphan-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)

--- a/test/e2e/processor_graceful_shutdown_test.go
+++ b/test/e2e/processor_graceful_shutdown_test.go
@@ -62,7 +62,7 @@ func doTestPodDeleteMidJob(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 10; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"pod-del-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"pod-del-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-pod-delete-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)
@@ -124,7 +124,7 @@ func doTestRollingRestartReEnqueue(t *testing.T) {
 	var lines []string
 	for i := 1; i <= 10; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"custom_id":"restart-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testModel, i))
+			`{"custom_id":"restart-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":200,"messages":[{"role":"user","content":"slow %d"}]}}`, i, testSimModel, i))
 	}
 	fileID := mustCreateFile(t, fmt.Sprintf("test-rolling-restart-%s.jsonl", testRunID), strings.Join(lines, "\n"))
 	batchID := mustCreateBatch(t, fileID)


### PR DESCRIPTION
## Why is this PR needed?

Seven timing-dependent e2e tests (cancel, expiration, progress polling, orphan recovery, graceful shutdown) rely on the simulator's controlled inter-token latency to keep requests in-flight long enough to observe race conditions. When `TEST_MODEL` is overridden to a real model (e.g. on RHOAI), these requests complete too quickly and the tests fail because intermediate states like `in_progress` or `cancelling` are never observed.

## What does this PR do?

Introduces a `TEST_SIM_MODEL` env var (`testSimModel`) that always points to a simulator model with predictable latency. It defaults to `TEST_MODEL` so existing dev-deploy setups are unaffected. The following 8 tests now use `testSimModel` instead of `testModel` for their slow requests:

- `Cancel/InProgress`
- `Cancel/IdempotentRetry`
- `Expiration` (both blocker and expiration batches)
- `ProgressPolling`
- `OrphanRecovery/HardCrashInProgress`
- `OrphanRecovery/CancellingOrphan`
- `ProcessorGracefulShutdown/PodDeleteMidJob`
- `ProcessorGracefulShutdown/RollingRestartOrphan`

For example: On RHOAI, set `TEST_MODEL=facebook/opt-125m` and `TEST_SIM_MODEL=sim-model` to run functional tests against the real model while timing-dependent tests use the simulator.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

