### PR TITLE
fix(processor): propagate async ResultMessage HTTP status to batch

### DIFF
--- a/internal/processor/pipeline/async_test.go
+++ b/internal/processor/pipeline/async_test.go
@@ -55,8 +55,9 @@ func (c *fakeAsyncClient) Close() error { return nil }
 func (c *fakeAsyncClient) deliver(requestID string, body map[string]any) {
 	resp, _ := json.Marshal(body)
 	c.results <- &inference.GenerateResponse{
-		RequestID: requestID,
-		Response:  resp,
+		RequestID:  requestID,
+		Response:   resp,
+		StatusCode: 200,
 	}
 }
 
@@ -127,34 +128,123 @@ func TestAsyncEndToEnd(t *testing.T) {
 	}
 }
 
-func TestAsyncResult_NilResponseBody(t *testing.T) {
-	resp := &inference.GenerateResponse{
-		RequestID: "req-nil-body",
-		Response:  nil,
+func TestAsyncResult(t *testing.T) {
+	tests := []struct {
+		name           string
+		resp           *inference.GenerateResponse
+		wantStatusCode int
+		wantErrCode    string
+		wantResponse   bool
+	}{
+		{
+			name: "nil body treated as empty 2xx",
+			resp: &inference.GenerateResponse{
+				RequestID: "req-nil-body",
+				Response:  nil,
+			},
+			wantErrCode: "server_error",
+		},
+		{
+			name: "bad JSON on 2xx is parse_error",
+			resp: &inference.GenerateResponse{
+				RequestID:  "req-bad-json",
+				Response:   []byte(`{not valid json`),
+				StatusCode: 200,
+			},
+			wantErrCode: "parse_error",
+		},
+		{
+			name: "legacy success without StatusCode defaults to 200",
+			resp: &inference.GenerateResponse{
+				RequestID: "req-ok",
+				Response:  []byte(`{"choices":[]}`),
+			},
+			wantStatusCode: 200,
+			wantResponse:   true,
+		},
+		{
+			name: "success with StatusCode 200",
+			resp: &inference.GenerateResponse{
+				RequestID:  "req-ok-200",
+				Response:   []byte(`{"choices":[]}`),
+				StatusCode: 200,
+			},
+			wantStatusCode: 200,
+			wantResponse:   true,
+		},
+		{
+			name: "HTTP 403 with empty body preserves status",
+			resp: &inference.GenerateResponse{
+				RequestID:  "req-403",
+				Response:   []byte{},
+				StatusCode: 403,
+			},
+			wantStatusCode: 403,
+			wantResponse:   true,
+		},
+		{
+			name: "HTTP 403 with JSON error body preserves status",
+			resp: &inference.GenerateResponse{
+				RequestID:  "req-403-json",
+				Response:   []byte(`{"error":{"message":"unauthorized"}}`),
+				StatusCode: 403,
+			},
+			wantStatusCode: 403,
+			wantResponse:   true,
+		},
+		{
+			name: "HTTP 422 with unparseable body preserves status",
+			resp: &inference.GenerateResponse{
+				RequestID:  "req-422",
+				Response:   []byte(`not-json`),
+				StatusCode: 422,
+			},
+			wantStatusCode: 422,
+			wantResponse:   true,
+		},
+		{
+			name: "non-HTTP failure uses ErrorCode",
+			resp: &inference.GenerateResponse{
+				RequestID:    "req-deadline",
+				StatusCode:   0,
+				ErrorCode:    "DEADLINE_EXCEEDED",
+				ErrorMessage: "deadline exceeded",
+			},
+			wantErrCode: "DEADLINE_EXCEEDED",
+		},
 	}
-	result := asyncResult(resp, logr.Discard())
-	if result.Error == nil {
-		t.Fatal("expected error for nil response body")
-	}
-	if result.Error.Code != "server_error" {
-		t.Fatalf("error code = %q, want %q", result.Error.Code, "server_error")
-	}
-	if result.Response != nil {
-		t.Fatalf("expected nil response, got %+v", result.Response)
-	}
-}
 
-func TestAsyncResult_BadJSONBody(t *testing.T) {
-	resp := &inference.GenerateResponse{
-		RequestID: "req-bad-json",
-		Response:  []byte(`{not valid json`),
-	}
-	result := asyncResult(resp, logr.Discard())
-	if result.Error == nil {
-		t.Fatal("expected error for bad JSON body")
-	}
-	if result.Error.Code != "parse_error" {
-		t.Fatalf("error code = %q, want %q", result.Error.Code, "parse_error")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := asyncResult(tt.resp, logr.Discard())
+			if tt.wantErrCode != "" {
+				if result.Error == nil {
+					t.Fatalf("expected error code %q, got nil error", tt.wantErrCode)
+				}
+				if result.Error.Code != tt.wantErrCode {
+					t.Fatalf("error code = %q, want %q", result.Error.Code, tt.wantErrCode)
+				}
+				if result.Response != nil {
+					t.Fatalf("expected nil response, got %+v", result.Response)
+				}
+				return
+			}
+			if result.Error != nil {
+				t.Fatalf("unexpected error: %+v", result.Error)
+			}
+			if !tt.wantResponse {
+				return
+			}
+			if result.Response == nil {
+				t.Fatal("expected response")
+			}
+			if result.Response.StatusCode != tt.wantStatusCode {
+				t.Fatalf("StatusCode = %d, want %d", result.Response.StatusCode, tt.wantStatusCode)
+			}
+			if result.Response.RequestID != tt.resp.RequestID {
+				t.Fatalf("RequestID = %q, want %q", result.Response.RequestID, tt.resp.RequestID)
+			}
+		})
 	}
 }
 
@@ -176,26 +266,6 @@ func TestSafeChannelSend(t *testing.T) {
 		close(ch)
 		b.safeChannelSend(result, ch)
 	})
-}
-
-func TestAsyncResult_Success(t *testing.T) {
-	resp := &inference.GenerateResponse{
-		RequestID: "req-ok",
-		Response:  []byte(`{"choices":[]}`),
-	}
-	result := asyncResult(resp, logr.Discard())
-	if result.Error != nil {
-		t.Fatalf("unexpected error: %+v", result.Error)
-	}
-	if result.Response == nil {
-		t.Fatal("expected response")
-	}
-	if result.Response.StatusCode != 200 {
-		t.Fatalf("StatusCode = %d, want 200", result.Response.StatusCode)
-	}
-	if result.Response.RequestID != "req-ok" {
-		t.Fatalf("RequestID = %q, want %q", result.Response.RequestID, "req-ok")
-	}
 }
 
 func TestBroadcaster_RetriesTransientError(t *testing.T) {

--- a/internal/processor/pipeline/result_router.go
+++ b/internal/processor/pipeline/result_router.go
@@ -136,21 +136,59 @@ func asyncResult(resp *inference.GenerateResponse, logger logr.Logger) ResultIte
 	result := ResultItem{
 		RequestID: resp.RequestID,
 	}
-	if resp.Response == nil {
-		result.Error = &OutputError{Code: "server_error", Message: "async response has no body"}
+
+	if resp.IsNonHTTPFailure() {
+		code := resp.ErrorCode
+		if code == "" {
+			code = "server_error"
+		}
+		msg := resp.ErrorMessage
+		if msg == "" {
+			msg = "async request failed"
+		}
+		result.Error = &OutputError{Code: code, Message: msg}
 		return result
 	}
-	var body map[string]any
-	if err := json.Unmarshal(resp.Response, &body); err != nil {
-		logger.Error(err, "Failed to unmarshal async response", "requestID", resp.RequestID)
-		result.Error = &OutputError{
-			Code:    "parse_error",
-			Message: fmt.Sprintf("response body could not be parsed: %v", err),
+
+	statusCode := resp.StatusCode
+	if statusCode == 0 {
+		// Legacy ResultMessage with only Payload — treat as HTTP 200.
+		statusCode = 200
+	}
+
+	if len(resp.Response) == 0 {
+		if statusCode >= 200 && statusCode < 300 {
+			result.Error = &OutputError{Code: "server_error", Message: "async response has no body"}
+			return result
+		}
+		// Non-2xx with empty body (e.g. 403 from auth): preserve status code.
+		result.Response = &batch_types.ResponseData{
+			StatusCode: statusCode,
+			RequestID:  resp.RequestID,
+			Body:       map[string]any{},
 		}
 		return result
 	}
+
+	var body map[string]any
+	if err := json.Unmarshal(resp.Response, &body); err != nil {
+		if statusCode >= 200 && statusCode < 300 {
+			logger.Error(err, "Failed to unmarshal async response", "requestID", resp.RequestID)
+			result.Error = &OutputError{
+				Code:    "parse_error",
+				Message: fmt.Sprintf("response body could not be parsed: %v", err),
+			}
+			return result
+		}
+		// Non-2xx with unparseable body: still preserve the HTTP status.
+		body = map[string]any{
+			"error": map[string]any{
+				"message": string(resp.Response),
+			},
+		}
+	}
 	result.Response = &batch_types.ResponseData{
-		StatusCode: 200,
+		StatusCode: statusCode,
 		RequestID:  resp.RequestID,
 		Body:       body,
 	}

--- a/pkg/clients/inference/async_inference_client_integration_test.go
+++ b/pkg/clients/inference/async_inference_client_integration_test.go
@@ -54,7 +54,11 @@ func TestAsyncSharedClient_Submit_roundtrip(t *testing.T) {
 
 		go func() {
 			time.Sleep(50 * time.Millisecond)
-			data, _ := json.Marshal(api.ResultMessage{ID: "req-1", Payload: `{"choices":[{"text":"hello"}]}`})
+			data, _ := json.Marshal(api.ResultMessage{
+				ID:         "req-1",
+				StatusCode: 200,
+				Payload:    `{"choices":[{"text":"hello"}]}`,
+			})
 			if _, lpushErr := mr.Lpush(resultQueue, string(data)); lpushErr != nil {
 				t.Errorf("Lpush: %v", lpushErr)
 			}
@@ -79,6 +83,9 @@ func TestAsyncSharedClient_Submit_roundtrip(t *testing.T) {
 		if resp.RequestID != "req-1" {
 			t.Errorf("RequestID = %q, want %q", resp.RequestID, "req-1")
 		}
+		if resp.StatusCode != 200 {
+			t.Errorf("StatusCode = %d, want 200", resp.StatusCode)
+		}
 		if resp.Response == nil {
 			t.Fatal("expected non-nil Response")
 		}
@@ -101,6 +108,55 @@ func TestAsyncSharedClient_Submit_roundtrip(t *testing.T) {
 		}
 		if data.ID != "req-1" {
 			t.Errorf("enqueued request ID = %q, want %q", data.ID, "req-1")
+		}
+	})
+
+	t.Run("propagates HTTP error status code from ResultMessage", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		poolName := "test-pool-403"
+		resultQueue := asyncQueuePrefix + "results:" + poolName
+
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		defer func() { _ = rdb.Close() }()
+
+		p, err := producer.NewRedisSortedSetProducer(
+			producer.RedisSortedSetConfig{
+				RequestQueueName: asyncQueuePrefix + "requests:" + poolName,
+				ResultQueueName:  resultQueue,
+			},
+			producer.WithRedisClient(rdb),
+		)
+		if err != nil {
+			t.Fatalf("NewRedisSortedSetProducer: %v", err)
+		}
+		defer func() { _ = p.Close() }()
+
+		client := newAsyncSharedClient(p, time.Second, testLogger(t))
+
+		data, _ := json.Marshal(api.ResultMessage{
+			ID:         "req-403",
+			StatusCode: 403,
+			Payload:    "",
+		})
+		if _, lpushErr := mr.Lpush(resultQueue, string(data)); lpushErr != nil {
+			t.Fatalf("Lpush: %v", lpushErr)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		resp, getErr := client.GetResult(ctx)
+		if getErr != nil {
+			t.Fatalf("GetResult error: %v", getErr)
+		}
+		if resp.RequestID != "req-403" {
+			t.Errorf("RequestID = %q, want %q", resp.RequestID, "req-403")
+		}
+		if resp.StatusCode != 403 {
+			t.Errorf("StatusCode = %d, want 403", resp.StatusCode)
+		}
+		if len(resp.Response) != 0 {
+			t.Errorf("Response = %q, want empty", resp.Response)
 		}
 	})
 }

--- a/pkg/clients/inference/async_shared_client.go
+++ b/pkg/clients/inference/async_shared_client.go
@@ -78,8 +78,11 @@ func (c *asyncSharedClient) GetResult(ctx context.Context) (*GenerateResponse, e
 	}
 
 	return &GenerateResponse{
-		RequestID: result.ID,
-		Response:  []byte(result.Payload),
+		RequestID:    result.ID,
+		Response:     []byte(result.Payload),
+		StatusCode:   result.StatusCode,
+		ErrorCode:    result.ErrorCode,
+		ErrorMessage: result.ErrorMessage,
 	}, nil
 }
 

--- a/pkg/clients/inference/inference_client_interface.go
+++ b/pkg/clients/inference/inference_client_interface.go
@@ -35,12 +35,27 @@ type GenerateRequest struct {
 	Headers   map[string]string      // extra headers to forward to the endpoint
 }
 
-// GenerateResponse represents an inference generation response
+// GenerateResponse represents an inference generation response.
+//
+// For async results (from llm-d-async ResultMessage):
+//   - StatusCode > 0: an HTTP response was received; Response holds the body.
+//   - StatusCode == 0 with ErrorCode/ErrorMessage: no HTTP response (deadline,
+//     cancel, gate drop, etc.).
+//   - StatusCode == 0 with empty ErrorCode: legacy success payload (treat as 200).
 type GenerateResponse struct {
 	RequestID        string
 	Response         []byte
+	StatusCode       int    // HTTP status from async ResultMessage; 0 = unset/non-HTTP
+	ErrorCode        string // non-HTTP failure code from async ResultMessage
+	ErrorMessage     string // non-HTTP failure message from async ResultMessage
 	RawData          interface{}
 	HadCapacityRetry bool // true if any retry was caused by 429/5xx (not network error)
+}
+
+// IsNonHTTPFailure reports whether the response represents a failure that did
+// not produce an HTTP status (e.g. deadline exceeded, cancel, gate drop).
+func (r *GenerateResponse) IsNonHTTPFailure() bool {
+	return r.StatusCode == 0 && (r.ErrorCode != "" || r.ErrorMessage != "")
 }
 
 // ClientError represents an inference client error

--- a/test/e2e/dispatcher/processor-async-values.yaml
+++ b/test/e2e/dispatcher/processor-async-values.yaml
@@ -6,3 +6,5 @@ processor:
     modelGateways:
       sim-model:
         inferencePoolName: "sim-pool"
+      sim-model-inject:
+        inferencePoolName: "sim-pool-inject"

--- a/test/e2e/dispatcher_test.go
+++ b/test/e2e/dispatcher_test.go
@@ -50,6 +50,11 @@ var (
 	promPool        = "sim-pool-prom"
 	promReqQueue    = "llm-d-async:requests:" + promPool
 	promResultQueue = "llm-d-async:results:" + promPool
+
+	injectPool        = "sim-pool-inject"
+	injectReqQueue    = "llm-d-async:requests:" + injectPool
+	injectResultQueue = "llm-d-async:results:" + injectPool
+	injectModel       = "sim-model-inject"
 )
 
 func newDispatcherRedisClient(t *testing.T) *redis.Client {
@@ -134,6 +139,9 @@ func TestDispatcher(t *testing.T) {
 	t.Run("MultiRequestBatch", func(t *testing.T) {
 		testDispatcherMultiRequestBatch(t, rdb)
 	})
+	t.Run("HTTPErrorStatusPreserved", func(t *testing.T) {
+		testDispatcherHTTPErrorStatusPreserved(t, rdb)
+	})
 	t.Run("BatchCancel", func(t *testing.T) {
 		doTestBatchCancel(t)
 	})
@@ -146,6 +154,133 @@ func TestDispatcher(t *testing.T) {
 	t.Run("PrometheusGate", func(t *testing.T) {
 		testDispatcherPrometheusGate(t, rdb)
 	})
+}
+
+// testDispatcherHTTPErrorStatusPreserved verifies that an HTTP error status
+// from the async ResultMessage (e.g. 403 with an empty body) is preserved in
+// the batch output file instead of being collapsed into parse_error.
+//
+// Uses the consumer-less "sim-pool-inject" pool: no async-processor subscribes
+// to it, so the request stays in the queue deterministically until the test
+// removes it and injects a synthetic ResultMessage.
+func testDispatcherHTTPErrorStatusPreserved(t *testing.T, rdb *redis.Client) {
+	ctx := context.Background()
+
+	rdb.Del(ctx, injectReqQueue, injectResultQueue)
+	defer rdb.Del(ctx, injectReqQueue, injectResultQueue)
+
+	jsonl := fmt.Sprintf(
+		`{"custom_id":"dreq-403","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":5,"messages":[{"role":"user","content":"expect 403"}]}}`,
+		injectModel)
+	fileID := mustCreateFile(t, fmt.Sprintf("dispatcher-http-error-%s.jsonl", testRunID), jsonl)
+	batchID := mustCreateBatch(t, fileID)
+	t.Logf("Created batch %s; waiting for request in %s", batchID, injectReqQueue)
+
+	reqID := waitAndStealQueuedRequestID(t, rdb, injectReqQueue, 30*time.Second)
+	t.Logf("Got request %s; injecting StatusCode=403 result", reqID)
+
+	resultBytes, err := json.Marshal(asyncapi.ResultMessage{
+		ID:         reqID,
+		StatusCode: http.StatusForbidden,
+		Payload:    "",
+	})
+	if err != nil {
+		t.Fatalf("marshal ResultMessage: %v", err)
+	}
+	if err := rdb.LPush(ctx, injectResultQueue, string(resultBytes)).Err(); err != nil {
+		t.Fatalf("LPUSH result: %v", err)
+	}
+
+	finalBatch := waitForRetryExhaustion(t, batchID, 2*time.Minute)
+
+	if finalBatch.Status != openai.BatchStatusCompleted {
+		t.Errorf("expected batch status %q, got %q", openai.BatchStatusCompleted, finalBatch.Status)
+	}
+	if finalBatch.RequestCounts.Completed != 0 {
+		t.Errorf("completed = %d, want 0", finalBatch.RequestCounts.Completed)
+	}
+	if finalBatch.RequestCounts.Failed != 1 {
+		t.Errorf("failed = %d, want 1", finalBatch.RequestCounts.Failed)
+	}
+	if finalBatch.OutputFileID == "" {
+		t.Fatal("expected output_file_id with HTTP 403 response")
+	}
+	if finalBatch.ErrorFileID != "" {
+		t.Errorf("expected empty error_file_id (HTTP errors go to output), got %q", finalBatch.ErrorFileID)
+	}
+
+	output := fetchOutputFile(t, finalBatch)
+	var found403 bool
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var rl batchResultLine
+		if err := json.Unmarshal([]byte(line), &rl); err != nil {
+			t.Fatalf("invalid output line: %v\n%s", err, line)
+		}
+		if rl.Error != nil {
+			t.Fatalf("expected HTTP response in output, got error file entry code=%q message=%q",
+				rl.Error.Code, rl.Error.Message)
+		}
+		if rl.Response == nil {
+			t.Fatal("expected response object in output line")
+		}
+		if rl.Response.StatusCode == http.StatusForbidden {
+			found403 = true
+		} else {
+			t.Errorf("status_code = %d, want 403", rl.Response.StatusCode)
+		}
+	}
+	if !found403 {
+		t.Errorf("expected status_code 403 in output file, got:\n%s", output)
+	}
+	t.Logf("Batch %s preserved HTTP 403 in output (no parse_error)", batchID)
+}
+
+// waitAndStealQueuedRequestID waits until a request appears in the Redis sorted
+// set queue, removes it, and returns the request ID from the InternalRequest envelope.
+func waitAndStealQueuedRequestID(t *testing.T, rdb *redis.Client, queue string, timeout time.Duration) string {
+	t.Helper()
+
+	ctx := context.Background()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		members, err := rdb.ZRange(ctx, queue, 0, 0).Result()
+		if err != nil {
+			t.Fatalf("ZRange %s: %v", queue, err)
+		}
+		if len(members) == 0 {
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
+		member := members[0]
+		removed, err := rdb.ZRem(ctx, queue, member).Result()
+		if err != nil {
+			t.Fatalf("ZRem %s: %v", queue, err)
+		}
+		if removed == 0 {
+			// Another consumer won the race; retry.
+			continue
+		}
+
+		var ir asyncapi.InternalRequest
+		if err := json.Unmarshal([]byte(member), &ir); err != nil {
+			t.Fatalf("unmarshal InternalRequest: %v\n%s", err, member)
+		}
+		if ir.PublicRequest == nil {
+			t.Fatalf("InternalRequest missing PublicRequest: %s", member)
+		}
+		reqID := ir.PublicRequest.ReqID()
+		if reqID == "" {
+			t.Fatalf("empty request ID in queued message: %s", member)
+		}
+		return reqID
+	}
+	t.Fatalf("no request appeared in %s within %v", queue, timeout)
+	return ""
 }
 
 func testDispatcherBatchRoundTrip(t *testing.T, rdb *redis.Client) {


### PR DESCRIPTION
## Why is this PR needed?
When `dispatchMode: async`, HTTP error statuses from the async-processor (e.g. 403 with an empty body) were lost on the batch-gateway consumer side. Batch output then reported `parse_error` instead of preserving `status_code: 403`, which broke sync/async parity for authorization failures.
Upstream llm-d-async already returns `ResultMessage.StatusCode` / error fields (llm-d/llm-d-async#298). This PR consumes those fields.
## What does this PR do?
- Add `StatusCode`, `ErrorCode`, and `ErrorMessage` to `GenerateResponse`
- Propagate those fields from `ResultMessage` in `GetResult()`
- Update `asyncResult()` to:
  - use the real HTTP status instead of hardcoding 200
  - preserve non-2xx status even when the body is empty or non-JSON
  - map non-HTTP failures (`StatusCode == 0` + error metadata) to output errors
  - treat legacy payloads with no status as HTTP 200
- Unit coverage for status/error propagation
- Dispatcher e2e (`HTTPErrorStatusPreserved`) using a consumer-less `sim-pool-inject` pool so a synthetic `ResultMessage{StatusCode: 403, Payload: ""}` can be injected without racing the async-processor (Kind has no AuthPolicy)
## How was this tested?
- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed
## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)
## Related Issues
Fixes #589