### PR TITLE
fix(pipeline): resolve flaky TestBroadcaster_RetriesTransientError synctest deadlock

### DIFF
--- a/internal/processor/pipeline/async_test.go
+++ b/internal/processor/pipeline/async_test.go
@@ -275,6 +275,9 @@ func TestBroadcaster_RetriesTransientError(t *testing.T) {
 
 		client := &fakeAsyncClientWithErrors{
 			getResult: func(ctx context.Context) (*inference.GenerateResponse, error) {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
 				n := callCount.Add(1)
 				if n <= 3 {
 					return nil, transientErr
@@ -292,7 +295,6 @@ func TestBroadcaster_RetriesTransientError(t *testing.T) {
 		broadcaster.Subscribe(resultCh)
 
 		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
 		go broadcaster.Run(ctx)
 
 		// Advance past backoff sleeps: 100ms + 200ms + 400ms = 700ms
@@ -313,6 +315,18 @@ func TestBroadcaster_RetriesTransientError(t *testing.T) {
 
 		if n := callCount.Load(); n < 4 {
 			t.Fatalf("GetResult called %d times, want >= 4 (3 errors + 1 success)", n)
+		}
+
+		// Cancel and drain resultCh so broadcaster goroutines can exit
+		// before the synctest bubble closes.
+		cancel()
+		for {
+			synctest.Wait()
+			select {
+			case <-resultCh:
+			default:
+				return
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes flaky `TestBroadcaster_RetriesTransientError` that panicked with `deadlock: main bubble goroutine has exited but blocked goroutines remain`
- Makes the fake client context-aware so it stops producing results after cancellation
- Adds explicit cancel + drain loop before the synctest bubble exits

## Root Cause

The test used `synctest.Test` but didn't ensure all broadcaster goroutines exited before the bubble closed. After `cancel()`, the fake client could produce results faster than they were drained, filling the subscriber channel buffer and blocking `safeChannelSend` — triggering a synctest deadlock panic.

## Test plan

- [x] `go test -run TestBroadcaster_RetriesTransientError -count=100 -race` — 100/100 passes
- [x] Full pipeline test suite passes with race detector
- [x] `make pre-commit` passes

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)