### PR TITLE
fix(pipeline): correct unparsable spelling in async pipeline

### DIFF
--- a/internal/processor/pipeline/async_test.go
+++ b/internal/processor/pipeline/async_test.go
@@ -193,7 +193,7 @@ func TestAsyncResult(t *testing.T) {
 			wantResponse:   true,
 		},
 		{
-			name: "HTTP 422 with unparseable body preserves status",
+			name: "HTTP 422 with unparsable body preserves status",
 			resp: &inference.GenerateResponse{
 				RequestID:  "req-422",
 				Response:   []byte(`not-json`),

--- a/internal/processor/pipeline/result_router.go
+++ b/internal/processor/pipeline/result_router.go
@@ -180,7 +180,7 @@ func asyncResult(resp *inference.GenerateResponse, logger logr.Logger) ResultIte
 			}
 			return result
 		}
-		// Non-2xx with unparseable body: still preserve the HTTP status.
+		// Non-2xx with unparsable body: still preserve the HTTP status.
 		body = map[string]any{
 			"error": map[string]any{
 				"message": string(resp.Response),


### PR DESCRIPTION
## Why is this PR needed?

Fix two typo-only strings reported in `#594`.

## What does this PR do?

Updates `unparseable` to `unparsable` in one test name and one comment.

## How was this tested?

- [x] Pre-commit checks pass (`pre-commit run -a`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Closes #594