### PR TITLE
chore(scripts): fix false-positive exchange chart mismatch warning

### DIFF
--- a/scripts/dev-deploy.sh
+++ b/scripts/dev-deploy.sh
@@ -183,7 +183,7 @@ install_exchange() {
     if helm status "${REDIS_RELEASE}" -n "${NAMESPACE}" &>/dev/null; then
         local installed_chart
         installed_chart=$(helm get metadata "${REDIS_RELEASE}" -n "${NAMESPACE}" -o json 2>/dev/null | jq -r '.chart')
-        if [[ "${installed_chart}" == "${EXCHANGE_CLIENT_TYPE}-"* ]]; then
+        if [[ "${installed_chart}" == "${EXCHANGE_CLIENT_TYPE}" || "${installed_chart}" == "${EXCHANGE_CLIENT_TYPE}-"* ]]; then
             log "Exchange backend (${chart}) release '${REDIS_RELEASE}' is already installed. Skipping."
             return
         fi


### PR DESCRIPTION
## Why is this PR needed?

When re-running `make dev-deploy` with Redis already installed, the script incorrectly warns "Installed exchange chart 'redis' does not match requested 'redis'. Reinstalling..." and performs an unnecessary uninstall/reinstall cycle.

This happens because `helm get metadata` may return the chart name without a version suffix (e.g. `redis` instead of `redis-27.0.15`), and the comparison only matched the `${type}-*` pattern (requiring a trailing hyphen).

## What does this PR do?

Adds an exact-match check alongside the existing prefix match in `dev-deploy.sh`, so both `redis` and `redis-27.0.15` are recognized as valid installed charts for the `redis` exchange type.

## How was this tested?

- [x] Fresh `make dev-deploy` from a clean cluster — Redis installs normally
- [x] Second `make dev-deploy` on existing cluster — Redis correctly skipped with no warning
- [x] Pre-commit checks pass (`make pre-commit`)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)