### PR TITLE
feat(demo): add llm-d-async dispatcher support to deploy-k8s.sh

### DIFF
--- a/docs/guides/deploy-k8s.md
+++ b/docs/guides/deploy-k8s.md
@@ -48,6 +48,14 @@ The sections below walk through each step manually for understanding and customi
 5. Request is routed to **InferencePool** → **EPP** (endpoint picker) → **vLLM** model server, and the response is returned to the Processor, which adds the response to the batch job's output file
     - The Processor sets the `x-gateway-inference-objective: batch-sheddable` header, which assigns the request to the **batch priority band (priority -1)** in EPP's flow control. This band is **sheddable** — when the backend is saturated, batch requests are rejected immediately instead of queued, and the Processor retries with backoff
 
+**Async dispatch flow** (when `ENABLE_DISPATCHER=true`):
+
+Steps 1–2 are the same as above. Steps 3–5 change:
+
+3. **Processor** dequeues the batch job and sends inference requests to a **Redis queue** (keyed by `inferencePoolName`) instead of making HTTP calls directly. The user's Authorization header is included in the queue message (via `passThroughHeaders`)
+4. **async-processor** ([llm-d-async](https://github.com/llm-d/llm-d-async)) reads from the Redis queue and sends the request to the **Internal Gateway** with the user's original token (pass-through headers)
+5. The Internal Gateway routes through **batch-llm-route** → **InferencePool** → **EPP** → **vLLM** as before. The async-processor writes the result back to a Redis result queue, which the Processor reads to complete the batch job
+
 **Online inference flow**:
 1. Client sends an inference request (e.g. `POST /{ns}/{model}/v1/chat/completions`) to the External Gateway with a Kubernetes token
 2. Gateway matches `/{ns}/{model}/v1/*` → **llm-route** (HTTPRoute, manually created with URL rewrite rules)
@@ -170,6 +178,10 @@ export MODEL_NAME=random
 # Flow control
 export INTERACTIVE_FLOW_CONTROL_OBJECTIVE=interactive-default
 export BATCH_FLOW_CONTROL_OBJECTIVE=batch-sheddable
+
+# Async dispatcher (optional — set ENABLE_DISPATCHER=true to use)
+export ENABLE_DISPATCHER=false
+export DISPATCHER_VERSION=v0.7.3
 ```
 
 > **Note**: `GAIE_VERSION`, `ROUTER_CHART_VERSION`, and `ROUTER_GATEWAY_CHART` are automatically sourced from the llm-d repo's `guides/env.sh` after cloning (see step 3.2). You do not need to set them manually.
@@ -601,7 +613,7 @@ kubectl wait tokenratelimitpolicy/inference-token-limit \
 
 </details>
 
-### 3.8 Install Batch Gateway
+### 3.8 Batch Gateway Dependencies
 
 The batch processor routes inference requests through a separate, ClusterIP-only Internal Gateway to bypass the TokenRateLimitPolicy on the External Gateway while still enforcing model-level authorization (AuthPolicy).
 
@@ -848,8 +860,14 @@ kubectl create secret generic batch-gateway-secrets \
 
 </details>
 
+### 3.9 Install Batch Gateway
+
+Choose **one** of the two dispatch modes below (sync or async).
+
+#### 3.9.1 Option 1: Sync dispatch (default)
+
 <details>
-<summary>Install batch-gateway</summary>
+<summary>Sync dispatch: processor sends inference requests directly to the Internal Gateway</summary>
 
 ```bash
 # Discover the Internal Gateway's Service (ClusterIP, HTTP :80)
@@ -901,7 +919,226 @@ helm upgrade --install batch-gateway ./charts/batch-gateway \
 
 </details>
 
-### 3.9 Configure HTTPRoute and Policies for Batch Gateway
+#### 3.9.2 Option 2: Async dispatch
+
+Uses [llm-d-async](https://github.com/llm-d/llm-d-async). The async-processor uses a dispatch gate to control when requests are sent to the model server. This example uses the `prometheus-budget` gate. See [llm-d-async dispatch gates](https://github.com/llm-d/llm-d-async#per-queue-dispatch-gates) for other gate types (`redis`, `endpoint-scrape`, `prometheus-query`, etc.).
+
+The `prometheus-budget` gate requires **Prometheus** scraping EPP and vLLM metrics.
+
+> - **`dispatchMode: async`** + **`inferencePoolName`**: The processor sends requests to Redis queues (`llm-d-async:requests:<pool>`) instead of making HTTP calls. This replaces `modelGateways.<model>.url`/`requestTimeout`/`maxRetries`/etc.
+> - **`igw_base_url`**: The async-processor sends inference requests through the Internal Gateway (same path as sync). Pass-through headers (including Authorization) are forwarded, so AuthPolicy works.
+> - **`gate_type: prometheus-budget`**: Computes a dispatch budget from EPP flow control metrics (primary) with vLLM metrics fallback. Requires `prometheusURL` and `gate_params.pool`.
+
+<details>
+<summary>Deploy Prometheus (required for prometheus-budget gate)</summary>
+
+Deploy a minimal Prometheus instance scraping EPP and vLLM metrics. The `relabel_configs` add the `inference_pool` label from pod labels, which vLLM doesn't emit natively.
+
+```bash
+PROMETHEUS_NAME=prometheus
+
+kubectl apply -n "${LLM_NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${PROMETHEUS_NAME}-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+    - job_name: 'epp'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['${LLMD_POOL_NAME}-epp.${LLM_NAMESPACE}.svc.cluster.local:9090']
+    - job_name: 'vllm'
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ['${LLM_NAMESPACE}']
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_llm_d_ai_model]
+        action: keep
+        regex: '.+'
+      - source_labels: [__meta_kubernetes_pod_ip]
+        target_label: __address__
+        replacement: '\${1}:8000'
+      metric_relabel_configs:
+      - target_label: inference_pool
+        replacement: '${LLMD_POOL_NAME}'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${PROMETHEUS_NAME}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${PROMETHEUS_NAME}
+  template:
+    metadata:
+      labels:
+        app: ${PROMETHEUS_NAME}
+    spec:
+      serviceAccountName: ${PROMETHEUS_NAME}
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v3.5.0
+        args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.path=/tmp/prometheus
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: ${PROMETHEUS_NAME}-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${PROMETHEUS_NAME}
+spec:
+  selector:
+    app: ${PROMETHEUS_NAME}
+  ports:
+  - port: 9090
+    targetPort: 9090
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${PROMETHEUS_NAME}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${PROMETHEUS_NAME}
+rules:
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${PROMETHEUS_NAME}
+subjects:
+- kind: ServiceAccount
+  name: ${PROMETHEUS_NAME}
+  namespace: ${LLM_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: ${PROMETHEUS_NAME}
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+kubectl rollout status deployment/${PROMETHEUS_NAME} -n ${LLM_NAMESPACE} --timeout=120s
+```
+
+</details>
+
+<details>
+<summary>Deploy async-processor</summary>
+
+```bash
+DISPATCHER_RELEASE=dispatcher
+DISPATCHER_VERSION=${DISPATCHER_VERSION:-v0.7.3}
+DISPATCHER_IMAGE="ghcr.io/llm-d-incubation/llm-d-async:${DISPATCHER_VERSION}"
+DISPATCHER_CHART="oci://ghcr.io/llm-d-incubation/charts/async-processor"
+
+REDIS_SVC=redis-master   # or redis-valkey-primary for Valkey
+REDIS_HOST="${REDIS_SVC}.${BATCH_NAMESPACE}.svc.cluster.local"
+
+INTERNAL_GW_SVC=$(kubectl get svc -n ${BATCH_INTERNAL_GATEWAY_NAMESPACE} \
+    -l "gateway.networking.k8s.io/gateway-name=${BATCH_INTERNAL_GATEWAY_NAME}" \
+    -o jsonpath='{.items[0].metadata.name}')
+
+PROMETHEUS_URL="http://prometheus.${LLM_NAMESPACE}.svc.cluster.local:9090"
+
+cat > /tmp/dispatcher-values.yaml <<YAML
+ap:
+  imagePullPolicy: IfNotPresent
+  messageQueueImpl: "redis-sortedset"
+  concurrency: 1
+  prometheusURL: "${PROMETHEUS_URL}"
+  prometheusCacheTTL: "0s"
+  redis:
+    enabled: true
+    url: "redis://${REDIS_HOST}:6379"
+    pollIntervalMs: 500
+    batchSize: 10
+    queuesConfig:
+      - queue_name: "llm-d-async:requests:${LLMD_POOL_NAME}"
+        result_queue_name: "llm-d-async:results:${LLMD_POOL_NAME}"
+        request_path_url: "/v1/chat/completions"
+        igw_base_url: "http://${INTERNAL_GW_SVC}.${BATCH_INTERNAL_GATEWAY_NAMESPACE}.svc.cluster.local/${LLM_NAMESPACE}/${MODEL_NAME}"
+        gate_type: "prometheus-budget"
+        gate_params:
+          pool: "${LLMD_POOL_NAME}"
+          namespace: "${LLM_NAMESPACE}"
+          max_concurrency: "100"
+          baseline: "0.05"
+          fallback: "1.0"
+  modelServerMonitor:
+    enabled: false
+YAML
+
+IMAGE_REPO="${DISPATCHER_IMAGE%%:*}"
+IMAGE_TAG="${DISPATCHER_IMAGE##*:}"
+
+helm upgrade --install "${DISPATCHER_RELEASE}" "${DISPATCHER_CHART}" \
+    --version "${DISPATCHER_VERSION#v}" \
+    --namespace "${BATCH_NAMESPACE}" \
+    --values /tmp/dispatcher-values.yaml \
+    --set "ap.image.repository=${IMAGE_REPO}" \
+    --set "ap.image.tag=${IMAGE_TAG}"
+
+kubectl rollout status deployment/${DISPATCHER_RELEASE}-async-processor \
+    -n ${BATCH_NAMESPACE} --timeout=120s
+```
+
+</details>
+
+<details>
+<summary>Install batch-gateway with async dispatch</summary>
+
+The helm install uses the same `global.*`, `apiserver.tls.*`, and storage args as sync, but replaces the `modelGateways` section:
+
+```bash
+helm upgrade --install batch-gateway ./charts/batch-gateway \
+    --namespace ${BATCH_NAMESPACE} \
+    --set "global.secretName=batch-gateway-secrets" \
+    --set "global.dbClient.type=postgresql" \
+    --set "global.fileClient.type=s3" \
+    --set "global.fileClient.s3.endpoint=http://minio.${BATCH_NAMESPACE}.svc.cluster.local:9000" \
+    --set "global.fileClient.s3.region=${MINIO_REGION}" \
+    --set "global.fileClient.s3.bucket=${MINIO_BUCKET}" \
+    --set "global.fileClient.s3.accessKeyId=${MINIO_USER}" \
+    --set "global.fileClient.s3.prefix=${MINIO_BUCKET}" \
+    --set "global.fileClient.s3.usePathStyle=true" \
+    --set "global.fileClient.s3.autoCreateBucket=true" \
+    --set "processor.config.dispatchMode=async" \
+    --set "processor.config.asyncDispatch.resultPollTimeout=30s" \
+    --set "processor.config.modelGateways.${MODEL_NAME}.inferencePoolName=${LLMD_POOL_NAME}" \
+    --set "processor.config.modelGateways.${MODEL_NAME}.inferenceObjective=${BATCH_FLOW_CONTROL_OBJECTIVE}" \
+    --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}" \
+    --set apiserver.tls.enabled=true \
+    --set apiserver.tls.certManager.enabled=true \
+    --set apiserver.tls.certManager.issuerName=selfsigned-issuer \
+    --set apiserver.tls.certManager.issuerKind=ClusterIssuer \
+    --set "apiserver.tls.certManager.dnsNames={batch-gateway-apiserver,batch-gateway-apiserver.${BATCH_NAMESPACE}.svc.cluster.local,localhost}"
+```
+
+</details>
+
+### 3.10 Configure HTTPRoute and Policies for Batch Gateway
 
 <details>
 <summary>Create HTTPRoute and DestinationRule for Batch API Server</summary>
@@ -1007,7 +1244,7 @@ EOF
 
 </details>
 
-### 3.10 Verify Installation
+### 3.11 Verify Installation
 
 After completing all installation steps, verify that all components are running:
 
@@ -1032,6 +1269,14 @@ kubectl get httproute -A
 echo "=== Flow Control ==="
 kubectl get inferenceobjective -n ${LLM_NAMESPACE}
 # Expected: interactive-default (priority 100), batch-sheddable (priority -1)
+
+# If ENABLE_DISPATCHER=true:
+echo "=== Async Dispatcher ==="
+kubectl get pods -n ${BATCH_NAMESPACE} -l app.kubernetes.io/name=async-processor
+# Expected: dispatcher-async-processor (1/1 Running)
+kubectl get configmap batch-gateway-processor-config -n ${BATCH_NAMESPACE} \
+    -o jsonpath='{.data}' | grep dispatch_mode
+# Expected: dispatch_mode: "async"
 ```
 
 ## 4. Test

--- a/examples/deploy-demo/common.sh
+++ b/examples/deploy-demo/common.sh
@@ -94,6 +94,8 @@ BATCH_APISERVER_REPO="${BATCH_APISERVER_REPO:-}"
 BATCH_PROCESSOR_REPO="${BATCH_PROCESSOR_REPO:-}"
 BATCH_GC_REPO="${BATCH_GC_REPO:-}"
 
+ENABLE_DISPATCHER="${ENABLE_DISPATCHER:-false}"
+
 # Temp directory cleanup (used by do_deploy_batch_gateway_helm)
 _BATCH_TMP_DIR=""
 _cleanup() {

--- a/examples/deploy-demo/deploy-k8s.md
+++ b/examples/deploy-demo/deploy-k8s.md
@@ -31,6 +31,7 @@ bash examples/deploy-demo/deploy-k8s.sh install
 | Internal Gateway | ClusterIP gateway for batch processor → LLM inference (bypasses rate limits, preserves AuthPolicy) |
 | InferenceObjective | GIE flow control CRDs — priority-based dispatch (interactive=100, batch=-1). Enabled by default (`ENABLE_FLOW_CONTROL=true`) |
 | batch-gateway | apiserver + processor + gc (Helm chart) |
+| async-processor | llm-d-async dispatcher for async dispatch mode (when `ENABLE_DISPATCHER=true`). Routes requests through Redis queues → Internal Gateway → EPP |
 
 #### Routing & Policies
 
@@ -57,6 +58,7 @@ Batch-route has no authorization — model-level authz is enforced downstream wh
 | Chart from a specific commit | `BATCH_DEV_VERSION=1f925ff bash examples/deploy-demo/deploy-k8s.sh install` |
 | Released OCI chart | `BATCH_RELEASE_VERSION=v0.1.0 bash examples/deploy-demo/deploy-k8s.sh install` |
 | Custom images | `BATCH_IMAGE_TAG=v0.2.0` <br> `BATCH_APISERVER_REPO=ghcr.io/llm-d/batch-gateway-apiserver` <br> `BATCH_PROCESSOR_REPO=ghcr.io/llm-d/batch-gateway-processor` <br> `BATCH_GC_REPO=ghcr.io/llm-d/batch-gateway-gc` <br> `bash examples/deploy-demo/deploy-k8s.sh install` |
+| With async dispatcher | `ENABLE_DISPATCHER=true bash examples/deploy-demo/deploy-k8s.sh install` |
 
 > `BATCH_RELEASE_VERSION` and `BATCH_DEV_VERSION` cannot be used together. See [Environment Variables](#environment-variables) for common parameters.
 
@@ -89,6 +91,7 @@ bash examples/deploy-demo/deploy-k8s.sh uninstall
 
 Default `uninstall` removes the batch-gateway footprint and associated gateway/policy resources:
 
+- Dispatcher Helm release (if deployed)
 - Helm releases and CRs in `BATCH_NAMESPACE` (`batch-route` HTTPRoute, Redis, PostgreSQL, MinIO)
 - Both Gateways: `GATEWAY_NAME` and `BATCH_INTERNAL_GATEWAY_NAME`
 - DestinationRule `${BATCH_INSTANCE_NAME}-backend-tls`
@@ -149,4 +152,6 @@ Use that only on **ephemeral or dedicated** demo clusters. See [issue #309](http
 | `ISTIO_VERSION` | `1.29.2` | Istio Helm chart version |
 | `ENABLE_FLOW_CONTROL` | `true` | Enable GIE priority-based flow control |
 | `BATCH_FLOW_CONTROL_OBJECTIVE` | `batch-sheddable` | InferenceObjective name for batch requests (priority -1) |
+| `ENABLE_DISPATCHER` | `false` | Deploy llm-d-async dispatcher for async dispatch mode |
+| `DISPATCHER_VERSION` | `v0.7.3` | llm-d-async version (image tag and chart version) |
 | `UNINSTALL_ALL` | `0` | Set to `1` to remove Kuadrant, Istio, cert-manager, CRDs (ephemeral clusters only) |

--- a/examples/deploy-demo/deploy-k8s.sh
+++ b/examples/deploy-demo/deploy-k8s.sh
@@ -60,6 +60,13 @@ ENABLE_FLOW_CONTROL="${ENABLE_FLOW_CONTROL:-true}"
 INTERACTIVE_FLOW_CONTROL_OBJECTIVE="${INTERACTIVE_FLOW_CONTROL_OBJECTIVE:-interactive-default}"
 BATCH_FLOW_CONTROL_OBJECTIVE="${BATCH_FLOW_CONTROL_OBJECTIVE:-batch-sheddable}"
 
+# Async dispatcher (llm-d-async) — ENABLE_DISPATCHER is set in common.sh
+DISPATCHER_RELEASE="${DISPATCHER_RELEASE:-dispatcher}"
+DISPATCHER_VERSION="${DISPATCHER_VERSION:-v0.7.3}"
+DISPATCHER_IMAGE="${DISPATCHER_IMAGE:-ghcr.io/llm-d-incubation/llm-d-async:${DISPATCHER_VERSION}}"
+DISPATCHER_CHART="${DISPATCHER_CHART:-oci://ghcr.io/llm-d-incubation/charts/async-processor}"
+DISPATCHER_CHART_VERSION="${DISPATCHER_CHART_VERSION:-0.7.3}"
+
 # ── Infrastructure ────────────────────────────────────────────────────────────
 
 install_cert_manager() {
@@ -373,16 +380,16 @@ init_test() {
     set_gateway_url
 
     step "Waiting for gateway to be accessible..."
-    local retries=30
+    local retries=60
     for i in $(seq 1 "${retries}"); do
-        if curl -sk -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/" &>/dev/null; then
+        if curl -sk --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/" &>/dev/null; then
             log "Gateway is accessible."
             break
         fi
         if [ "$i" -eq "${retries}" ]; then
             die "Gateway not accessible after ${retries} attempts."
         fi
-        sleep 2
+        sleep 3
     done
 }
 
@@ -644,32 +651,390 @@ uninstall_llmd() {
     timeout_delete 30s inferencepool --all -n "${LLM_NAMESPACE}" || true
 }
 
-# ── Batch Gateway ─────────────────────────────────────────────────────────────
+# ── Async Dispatcher (llm-d-async) ───────────────────────────────────────────
 
-deploy_batch_gateway_k8s() {
-    banner "Installing Batch Gateway"
+install_prometheus() {
+    local prom_name="prometheus"
 
-    # Route batch processor through the Internal Gateway (ClusterIP, no rate limit)
-    # instead of the external Gateway. The Internal Gateway still uses EPP and
-    # enforces AuthPolicy (model access check with user's original token).
+    if kubectl get deployment "${prom_name}" -n "${LLM_NAMESPACE}" &>/dev/null; then
+        log "Prometheus already exists in ${LLM_NAMESPACE}. Skipping."
+        return
+    fi
+
+    step "Installing Prometheus"
+    kubectl apply -n "${LLM_NAMESPACE}" -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${prom_name}-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+    - job_name: 'epp'
+      metrics_path: /metrics
+      static_configs:
+      - targets: ['${LLMD_POOL_NAME}-epp.${LLM_NAMESPACE}.svc.cluster.local:9090']
+    - job_name: 'vllm'
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: ['${LLM_NAMESPACE}']
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_llm_d_ai_model]
+        action: keep
+        regex: '.+'
+      - source_labels: [__meta_kubernetes_pod_ip]
+        target_label: __address__
+        replacement: '\${1}:8000'
+      metric_relabel_configs:
+      - target_label: inference_pool
+        replacement: '${LLMD_POOL_NAME}'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${prom_name}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${prom_name}
+  template:
+    metadata:
+      labels:
+        app: ${prom_name}
+    spec:
+      serviceAccountName: ${prom_name}
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v3.5.0
+        args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.retention.time=1h
+        - --storage.tsdb.path=/tmp/prometheus
+        ports:
+        - containerPort: 9090
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus
+      volumes:
+      - name: config
+        configMap:
+          name: ${prom_name}-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${prom_name}
+spec:
+  selector:
+    app: ${prom_name}
+  ports:
+  - port: 9090
+    targetPort: 9090
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${prom_name}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${prom_name}
+rules:
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${prom_name}
+subjects:
+- kind: ServiceAccount
+  name: ${prom_name}
+  namespace: ${LLM_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: ${prom_name}
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+    wait_for_deployment "${prom_name}" "${LLM_NAMESPACE}" 120s
+    log "Prometheus installed (scraping EPP + vLLM metrics)."
+}
+
+deploy_dispatcher() {
+    banner "Installing Async Dispatcher (llm-d-async)"
+
+    install_prometheus
+
+    # Reuse batch-internal-gateway: async-processor passes through the user's
+    # Authorization header (captured at batch creation), so AuthPolicy works.
     local internal_gw_svc
     internal_gw_svc=$(kubectl get svc -n "${BATCH_INTERNAL_GATEWAY_NAMESPACE}" \
         -l "gateway.networking.k8s.io/gateway-name=${BATCH_INTERNAL_GATEWAY_NAME}" \
         -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
     [ -z "${internal_gw_svc}" ] && die "No service found for Internal Gateway '${BATCH_INTERNAL_GATEWAY_NAME}'."
-    local model_url="http://${internal_gw_svc}.${BATCH_INTERNAL_GATEWAY_NAMESPACE}.svc.cluster.local/${LLM_NAMESPACE}/${MODEL_NAME}"
-    log "Model URL (via Internal Gateway): ${model_url}"
+
+    local redis_svc="${BATCH_REDIS_RELEASE}-master"
+    if [[ "${BATCH_EXCHANGE_CLIENT_TYPE}" == "valkey" ]]; then
+        redis_svc="${BATCH_REDIS_RELEASE}-valkey-primary"
+    fi
+    local redis_host="${redis_svc}.${BATCH_NAMESPACE}.svc.cluster.local"
+    local redis_url="redis://${redis_host}:6379"
+    local prometheus_url="http://prometheus.${LLM_NAMESPACE}.svc.cluster.local:9090"
+
+    local igw_base_url="http://${internal_gw_svc}.${BATCH_INTERNAL_GATEWAY_NAMESPACE}.svc.cluster.local/${LLM_NAMESPACE}/${MODEL_NAME}"
+    log "Dispatcher igw_base_url (via Internal Gateway): ${igw_base_url}"
+    log "Dispatcher Redis: ${redis_url}"
+    log "Dispatcher Prometheus: ${prometheus_url}"
+
+    local image_repo="${DISPATCHER_IMAGE%%:*}"
+    local image_tag="${DISPATCHER_IMAGE##*:}"
+
+    local values_file
+    values_file=$(mktemp)
+    cat > "${values_file}" <<YAML
+ap:
+  imagePullPolicy: IfNotPresent
+  messageQueueImpl: "redis-sortedset"
+  concurrency: 1
+  prometheusURL: "${prometheus_url}"
+  prometheusCacheTTL: "0s"
+  redis:
+    enabled: true
+    url: "${redis_url}"
+    pollIntervalMs: 500
+    batchSize: 10
+    queuesConfig:
+      - queue_name: "llm-d-async:requests:${LLMD_POOL_NAME}"
+        result_queue_name: "llm-d-async:results:${LLMD_POOL_NAME}"
+        request_path_url: "/v1/chat/completions"
+        igw_base_url: "${igw_base_url}"
+        gate_type: "prometheus-budget"
+        gate_params:
+          pool: "${LLMD_POOL_NAME}"
+          namespace: "${LLM_NAMESPACE}"
+          max_concurrency: "100"
+          baseline: "0.05"
+          fallback: "1.0"
+  modelServerMonitor:
+    enabled: false
+YAML
+
+    step "Deploying async-processor (release: ${DISPATCHER_RELEASE})..."
+    local helm_cmd=(helm)
+    if helm status "${DISPATCHER_RELEASE}" -n "${BATCH_NAMESPACE}" &>/dev/null; then
+        log "Release '${DISPATCHER_RELEASE}' already exists. Upgrading..."
+        helm_cmd+=(upgrade --reset-values)
+    else
+        helm_cmd+=(install)
+    fi
+    "${helm_cmd[@]}" "${DISPATCHER_RELEASE}" "${DISPATCHER_CHART}" \
+        --version "${DISPATCHER_CHART_VERSION}" \
+        --namespace "${BATCH_NAMESPACE}" \
+        --values "${values_file}" \
+        --set "ap.image.repository=${image_repo}" \
+        --set "ap.image.tag=${image_tag}" \
+        --wait --timeout=120s
+
+    rm -f "${values_file}"
+
+    wait_for_deployment "${DISPATCHER_RELEASE}-async-processor" "${BATCH_NAMESPACE}" 120s
+
+    log "Async dispatcher deployed."
+}
+
+verify_dispatcher_config() {
+    banner "Verifying Async Dispatcher configuration"
+
+    local errors=0
+
+    local config_yaml
+    config_yaml=$(kubectl get configmap "${BATCH_INSTANCE_NAME}-processor-config" -n "${BATCH_NAMESPACE}" \
+        -o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "")
+
+    # 1. Processor dispatch mode
+    step "Checking batch processor dispatch mode..."
+    local dispatch_mode
+    dispatch_mode=$(echo "${config_yaml}" | yq '.dispatch_mode // "sync"')
+    if [ "${dispatch_mode}" = "async" ]; then
+        log "Processor configured with dispatch_mode: async"
+    else
+        warn "Processor dispatch_mode is '${dispatch_mode}', expected 'async'"
+        errors=$((errors + 1))
+    fi
+
+    # 2. Processor inferencePoolName
+    step "Checking batch processor inferencePoolName..."
+    local pool_name
+    pool_name=$(echo "${config_yaml}" | yq ".model_gateways.${MODEL_NAME}.inference_pool_name // \"\"")
+    if [ -n "${pool_name}" ]; then
+        log "Processor inference_pool_name: ${pool_name}"
+    else
+        warn "Processor missing inference_pool_name for model '${MODEL_NAME}'"
+        errors=$((errors + 1))
+    fi
+
+    # 3. Async-processor started successfully
+    local ap_deploy="${DISPATCHER_RELEASE}-async-processor"
+    step "Checking async-processor startup logs..."
+    local ap_logs
+    ap_logs=$(kubectl logs "deployment/${ap_deploy}" -n "${BATCH_NAMESPACE}" 2>/dev/null || echo "")
+    if echo "${ap_logs}" | grep -q "Async Processor starting"; then
+        log "Async-processor started successfully"
+    else
+        warn "Async-processor startup log not found"
+        errors=$((errors + 1))
+    fi
+
+    # 4. Prometheus has the metrics that prometheus-budget gate needs
+    step "Checking Prometheus metrics for prometheus-budget gate..."
+    local prom_url="http://prometheus.${LLM_NAMESPACE}.svc.cluster.local:9090"
+
+    local prom_query_pod="prom-verify-$(date +%s)"
+    local prom_queries=(
+        "inference_pool_ready_pods{name=\"${LLMD_POOL_NAME}\"}"
+        "vllm:num_requests_running{inference_pool=\"${LLMD_POOL_NAME}\"}"
+    )
+    local prom_labels=(
+        "inference_pool_ready_pods (shared: ready pods count)"
+        "vllm:num_requests_running with inference_pool label (fallback source)"
+    )
+
+    for i in "${!prom_queries[@]}"; do
+        local query="${prom_queries[$i]}"
+        local label="${prom_labels[$i]}"
+        local result
+        prom_query_pod="prom-verify-${i}-$(date +%s)"
+        result=$(kubectl run "${prom_query_pod}" --rm -i --restart=Never --quiet \
+            --image=curlimages/curl -n "${LLM_NAMESPACE}" -- \
+            curl -sf -G "${prom_url}/api/v1/query" --data-urlencode "query=${query}" 2>/dev/null) || true
+        local data_count
+        data_count=$(echo "${result}" | jq '.data.result | length' 2>/dev/null || echo "0")
+        if [ "${data_count}" -gt 0 ]; then
+            log "${label}: ${data_count} series found"
+        else
+            warn "${label}: no data in Prometheus"
+            errors=$((errors + 1))
+        fi
+    done
+
+    if [ "${errors}" -gt 0 ]; then
+        die "Dispatcher config verification failed with ${errors} error(s)."
+    fi
+    log "Dispatcher configuration verified."
+}
+
+verify_dispatcher_runtime() {
+    banner "Verifying Async Dispatcher"
+
+    step "Setting up port-forward to async-processor metrics..."
+    local ap_deploy="${DISPATCHER_RELEASE}-async-processor"
+    local ap_metrics_port=19090
+    kubectl port-forward -n "${BATCH_NAMESPACE}" \
+        "deployment/${ap_deploy}" "${ap_metrics_port}:9090" &>/dev/null &
+    local pf_pid=$!
+
+    local attempt
+    for attempt in $(seq 1 15); do
+        if curl -sf "http://localhost:${ap_metrics_port}/metrics" &>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    if ! curl -sf "http://localhost:${ap_metrics_port}/metrics" &>/dev/null; then
+        kill "${pf_pid}" 2>/dev/null || true
+        die "Cannot reach async-processor metrics on port ${ap_metrics_port}."
+    fi
+
+    local metrics_body
+    metrics_body=$(curl -sf "http://localhost:${ap_metrics_port}/metrics")
+    local errors=0
+
+    step "Checking async-processor successful requests..."
+    local success_count
+    success_count=$(echo "${metrics_body}" | { grep "^llm_d_async_async_successful_requests_total" || true; } \
+        | awk '{sum+=$2} END {printf "%d", sum}')
+    if [ "${success_count}" -gt 0 ]; then
+        log "Async-processor completed ${success_count} successful request(s)."
+    else
+        warn "No successful requests via async-processor."
+        errors=$((errors + 1))
+    fi
+
+    step "Checking async-processor worker pool..."
+    local pool_limit
+    pool_limit=$(echo "${metrics_body}" | { grep "^llm_d_async_async_pool_worker_limit" || true; } \
+        | awk '{sum+=$2} END {printf "%d", sum}')
+    if [ "${pool_limit}" -gt 0 ]; then
+        log "Worker pool active: pool_worker_limit=${pool_limit}"
+    else
+        warn "Worker pool not active (pool_worker_limit=0)."
+        errors=$((errors + 1))
+    fi
+
+    step "Checking dispatch gate budget..."
+    local budget_line
+    budget_line=$(echo "${metrics_body}" | { grep "^llm_d_async_async_dispatch_budget" || true; } | head -1)
+    if [ -n "${budget_line}" ]; then
+        local budget_val
+        budget_val=$(echo "${budget_line}" | awk '{print $2}')
+        log "Gate budget: ${budget_val} (${budget_line})"
+    else
+        warn "Gate budget metric not found — dispatch gate is not active."
+        errors=$((errors + 1))
+    fi
+
+    kill "${pf_pid}" 2>/dev/null || true
+
+    if [ "${errors}" -gt 0 ]; then
+        die "Async dispatcher runtime verification failed with ${errors} error(s). Review output above."
+    fi
+    log "Async dispatcher verification passed."
+}
+
+# ── Batch Gateway ─────────────────────────────────────────────────────────────
+
+deploy_batch_gateway_k8s() {
+    banner "Installing Batch Gateway"
 
     local model_key="${MODEL_NAME}"
-
     local helm_args=(
-        --set "processor.config.modelGateways.${model_key}.url=${model_url}"
-        --set "processor.config.modelGateways.${model_key}.requestTimeout=${GW_REQUEST_TIMEOUT}"
-        --set "processor.config.modelGateways.${model_key}.maxRetries=${GW_MAX_RETRIES}"
-        --set "processor.config.modelGateways.${model_key}.initialBackoff=${GW_INITIAL_BACKOFF}"
-        --set "processor.config.modelGateways.${model_key}.maxBackoff=${GW_MAX_BACKOFF}"
         --set "apiserver.config.batchAPI.passThroughHeaders={Authorization}"
     )
+
+    if [ "${ENABLE_DISPATCHER}" = "true" ]; then
+        # Async dispatch: processor sends requests via Redis to async-processor
+        helm_args+=(
+            --set "processor.config.dispatchMode=async"
+            --set "processor.config.asyncDispatch.resultPollTimeout=30s"
+            --set "processor.config.modelGateways.${model_key}.inferencePoolName=${LLMD_POOL_NAME}"
+        )
+        log "Async dispatch enabled: processor will route through llm-d-async (pool: ${LLMD_POOL_NAME})"
+    else
+        # Sync dispatch: processor sends requests directly through Internal Gateway
+        local internal_gw_svc
+        internal_gw_svc=$(kubectl get svc -n "${BATCH_INTERNAL_GATEWAY_NAMESPACE}" \
+            -l "gateway.networking.k8s.io/gateway-name=${BATCH_INTERNAL_GATEWAY_NAME}" \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+        [ -z "${internal_gw_svc}" ] && die "No service found for Internal Gateway '${BATCH_INTERNAL_GATEWAY_NAME}'."
+        local model_url="http://${internal_gw_svc}.${BATCH_INTERNAL_GATEWAY_NAMESPACE}.svc.cluster.local/${LLM_NAMESPACE}/${MODEL_NAME}"
+        log "Model URL (via Internal Gateway): ${model_url}"
+
+        helm_args+=(
+            --set "processor.config.modelGateways.${model_key}.url=${model_url}"
+            --set "processor.config.modelGateways.${model_key}.requestTimeout=${GW_REQUEST_TIMEOUT}"
+            --set "processor.config.modelGateways.${model_key}.maxRetries=${GW_MAX_RETRIES}"
+            --set "processor.config.modelGateways.${model_key}.initialBackoff=${GW_INITIAL_BACKOFF}"
+            --set "processor.config.modelGateways.${model_key}.maxBackoff=${GW_MAX_BACKOFF}"
+        )
+    fi
 
     if [ "${ENABLE_FLOW_CONTROL}" = "true" ]; then
         helm_args+=(
@@ -842,14 +1207,19 @@ cmd_install() {
         kubectl label namespace "${ns}" llm-d.ai/gateway-route=true --overwrite
     done
 
+    # cert manager
     install_cert_manager
     create_selfsigned_issuer
+
+    # llm-d deps
     install_llmd_deps
     install_istio
+
+    # kuadrant
     install_kuadrant
 
+    # llm-d
     create_inference_external_gateway
-
     deploy_llmd_model
     if [ "${ENABLE_FLOW_CONTROL}" = "true" ]; then
         create_inference_objectives
@@ -858,14 +1228,21 @@ cmd_install() {
     apply_llm_auth_policy
     apply_llm_token_rate_limit
 
+    # batch gateway
     create_batch_internal_gateway
     create_batch_llm_route
     apply_batch_llm_auth_policy
-
     deploy_batch_gateway_k8s
+    if [ "${ENABLE_DISPATCHER}" = "true" ]; then
+        deploy_dispatcher
+    fi
     apply_batch_auth_policy
     apply_batch_request_rate_limit
 
+    # verify
+    if [ "${ENABLE_DISPATCHER}" = "true" ]; then
+        verify_dispatcher_config
+    fi
     if [ "${ENABLE_FLOW_CONTROL}" = "true" ]; then
         verify_flow_control_config
     fi
@@ -881,6 +1258,9 @@ cmd_install() {
         log "  Batch Gateway version: ${BATCH_DEV_VERSION} (commit chart)"
     else
         log "  Batch Gateway version: latest (local chart)"
+    fi
+    if [ "${ENABLE_DISPATCHER}" = "true" ]; then
+        log "  Async dispatcher: ${DISPATCHER_RELEASE} (${DISPATCHER_IMAGE})"
     fi
     log "Run '$0 test' to verify."
 }
@@ -947,6 +1327,10 @@ EOF
         "${inference_payload}" \
         || test_failures=$?
 
+    if [ "${ENABLE_DISPATCHER}" = "true" ]; then
+        verify_dispatcher_runtime
+    fi
+
     if [ "${ENABLE_FLOW_CONTROL}" = "true" ]; then
         verify_flow_control_runtime
     fi
@@ -976,6 +1360,12 @@ cmd_uninstall() {
     kubectl delete authpolicy batch-route-auth -n "${BATCH_NAMESPACE}" 2>/dev/null || true
     kubectl delete authpolicy llm-route-auth -n "${LLM_NAMESPACE}" 2>/dev/null || true
     kubectl delete tokenratelimitpolicy inference-token-limit -n "${LLM_NAMESPACE}" 2>/dev/null || true
+
+    step "Removing dispatcher resources..."
+    helm uninstall "${DISPATCHER_RELEASE}" -n "${BATCH_NAMESPACE}" --timeout 60s 2>/dev/null || true
+    kubectl delete deployment,svc,sa prometheus -n "${LLM_NAMESPACE}" 2>/dev/null || true
+    kubectl delete configmap prometheus-config -n "${LLM_NAMESPACE}" 2>/dev/null || true
+    kubectl delete clusterrole,clusterrolebinding prometheus 2>/dev/null || true
 
     step "Removing Internal Gateway resources..."
     kubectl delete authpolicy batch-llm-route-auth -n "${LLM_NAMESPACE}" 2>/dev/null || true
@@ -1068,11 +1458,14 @@ usage() {
     echo "  BATCH_RELEASE_VERSION  Install released OCI chart (e.g. v1.0.0)"
     echo "  ENABLE_FLOW_CONTROL   Enable GIE flow control (default: true)"
     echo "  BATCH_FLOW_CONTROL_OBJECTIVE InferenceObjective name for batch (default: batch-sheddable)"
+    echo "  ENABLE_DISPATCHER      Deploy llm-d-async dispatcher for async dispatch (default: false)"
+    echo "  DISPATCHER_VERSION     llm-d-async version (default: v0.7.3)"
     echo "  UNINSTALL_ALL          Set to 1 to also remove Kuadrant/Istio/cert-manager and CRDs (ephemeral clusters only)"
     echo ""
     echo "Examples:"
     echo "  $0 install"
     echo "  MODEL_NAME=my-model LLMD_VERSION=v0.8.1 $0 install"
+    echo "  ENABLE_DISPATCHER=true $0 install"
     exit "${1:-0}"
 }
 


### PR DESCRIPTION
## Why is this PR needed?

The `deploy-k8s.sh` demo script only supports sync dispatch. Users cannot demo or test the async dispatch integration with [llm-d-async](https://github.com/llm-d/llm-d-async).

https://github.com/llm-d/llm-d-batch-gateway/pull/458

## What does this PR do?

Adds `ENABLE_DISPATCHER=true` support to the deploy-k8s.sh demo script:

- **Processor config**: switches to `dispatchMode: async` with `inferencePoolName`
- **Prometheus**: deploys a minimal instance scraping EPP + vLLM metrics (required for `prometheus-budget` gate)
- **async-processor**: deploys via Helm chart, routes through the existing Internal Gateway (pass-through headers carry the user token for AuthPolicy)
- **Verification**: `verify_dispatcher_config` (install) checks processor config + Prometheus metrics; `verify_dispatcher_runtime` (test) checks `successful_requests_total` + `dispatch_budget` + `pool_worker_limit`
- **Docs**: updates `deploy-k8s.md` and `docs/guides/deploy-k8s.md` with async dispatch option

## How was this tested?

- [x] Manual testing performed
- [x] Full end-to-end on OpenShift: `ENABLE_DISPATCHER=true ./deploy-k8s.sh install && ./deploy-k8s.sh test` — 13/13 tests passed + dispatcher config/runtime verification passed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)