### PR TITLE
fix: remove early-exit on pre-dispatch SLO expiration

### DIFF
--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -28,12 +28,6 @@ func (p *Processor) executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx 
 		return nil, fmt.Errorf("read model map: %w", err)
 	}
 
-	if sloCtx.Err() == context.DeadlineExceeded {
-		logger.V(logging.INFO).Info("SLO already expired at execution start",
-			"total", modelMap.LineCount)
-		return &openai.BatchRequestCounts{Total: modelMap.LineCount, Failed: modelMap.RejectedCount}, errExpired
-	}
-
 	files, err := p.openDataFiles(params)
 	if err != nil {
 		return nil, err

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -379,8 +379,9 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 }
 
 // TestExecuteJob_SLOExpiredBeforeDispatch verifies that when the SLO deadline has already
-// passed before execution begins, executeJob returns errExpired immediately with the total
-// request count and no output/error files are written (early-exit fast path).
+// passed before execution begins, the pipeline still runs and drains all requests as
+// batch_expired errors. This ensures that handleExpired can upload a non-empty error file
+// and the DB reflects Failed == Total.
 func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -393,7 +394,6 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{}, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx(t)
-	// SLO deadline already in the past: early check fires before any files are opened.
 	sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer cancel()
 
@@ -408,25 +408,33 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 		t.Fatal("expected non-nil counts")
 		return
 	}
-	// Early exit: total is known from the model map, but no requests were dispatched or drained.
 	if counts.Total != 3 {
 		t.Fatalf("Total = %d, want 3", counts.Total)
 	}
 	if counts.Completed != 0 {
 		t.Fatalf("Completed = %d, want 0", counts.Completed)
 	}
-	if counts.Failed != 0 {
-		t.Fatalf("Failed = %d, want 0 (no drain on early exit)", counts.Failed)
+	if counts.Failed != 3 {
+		t.Fatalf("Failed = %d, want 3 (all requests drained as batch_expired)", counts.Failed)
 	}
 
-	// No output or error files are written on early exit: files are only opened after the SLO check.
-	outputPath, _ := env.p.jobOutputFilePath(jobInfo.JobID, jobInfo.TenantID)
 	errorPath, _ := env.p.jobErrorFilePath(jobInfo.JobID, jobInfo.TenantID)
-	if _, statErr := os.Stat(outputPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("output.jsonl should not exist on early SLO exit, got stat err: %v", statErr)
+	errorData, readErr := os.ReadFile(errorPath)
+	if readErr != nil {
+		t.Fatalf("error.jsonl should exist: %v", readErr)
 	}
-	if _, statErr := os.Stat(errorPath); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("error.jsonl should not exist on early SLO exit, got stat err: %v", statErr)
+	errorLines := bytes.Count(bytes.TrimSpace(errorData), []byte("\n")) + 1
+	if errorLines != 3 {
+		t.Fatalf("error.jsonl lines = %d, want 3", errorLines)
+	}
+
+	outputPath, _ := env.p.jobOutputFilePath(jobInfo.JobID, jobInfo.TenantID)
+	outputData, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		t.Fatalf("output.jsonl should exist: %v", readErr)
+	}
+	if len(outputData) != 0 {
+		t.Fatalf("output.jsonl should be empty, got %d bytes", len(outputData))
 	}
 }
 

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -386,14 +386,14 @@ func (p *Processor) uploadPartialResults(
 //
 //	uploadPartialResults uploads nothing, requestCounts is nil, DB counts remain zero.
 //
-// (2) deadline expired before dispatch began — executeJob skips dispatch:
+// (2) deadline expired before or at dispatch start — the pipeline runs with an
 //
-//	no completions are written to the output file, but error.jsonl may already contain
-//	model_not_found lines from ingestion. uploadPartialResults uploads whatever exists.
+//	already-cancelled context: PreDispatcher drains all requests as batch_expired
+//	errors to error.jsonl. requestCounts has Failed == Total.
 //
 // (3) deadline expired during execution — completed requests remain in the output file
 //
-//	and undispatched entries were drained as "batch_expired" by drainUnprocessedRequests.
+//	and undispatched entries were drained as batch_expired by the dispatcher chain.
 //
 // In all cases, this function uploads whatever files exist and transitions the job to expired status.
 // Uses a detached context so that a concurrent SIGTERM cannot abort the upload or DB write.

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -1957,16 +1957,20 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	if !errors.Is(execErr, errExpired) {
 		t.Fatalf("expected errExpired, got: %v", execErr)
 	}
-	if counts.Failed != 1 {
-		t.Fatalf("Failed = %d, want 1 (model_not_found from ingestion)", counts.Failed)
+	// Failed = 2: 1 model_not_found (ingestion) + 1 batch_expired (pipeline drain for model-a).
+	if counts.Failed != 2 {
+		t.Fatalf("Failed = %d, want 2 (1 model_not_found + 1 batch_expired)", counts.Failed)
 	}
 
-	// error.jsonl should still have the model_not_found entry (not truncated by execution).
+	// error.jsonl should have both the model_not_found and batch_expired entries.
 	errorBytesAfter, err := os.ReadFile(errorPath)
 	if err != nil {
 		t.Fatalf("read error file after execution: %v", err)
 	}
 	if !bytes.Contains(errorBytesAfter, []byte(`"model_not_found"`)) {
 		t.Fatalf("error file lost model_not_found entry after early SLO:\n%s", errorBytesAfter)
+	}
+	if !bytes.Contains(errorBytesAfter, []byte(`"batch_expired"`)) {
+		t.Fatalf("error file missing batch_expired entry for undispatched request:\n%s", errorBytesAfter)
 	}
 }


### PR DESCRIPTION
## Why is this PR needed?
The early-exit path in `executeJobAsync` returned `errExpired` before opening
data files when the SLO deadline was already past. This caused `handleExpired`
to upload an empty error file, making integration tests fail because the DB
showed `Failed == 0` instead of `Failed == Total`.
## What does this PR do?
Removes the pre-dispatch SLO check. When the SLO context is already cancelled,
the pipeline runs normally and the PreDispatcher drains all requests as
`batch_expired` errors to `error.jsonl`. This guarantees a non-empty error file
and accurate `Failed == Total` counts.
## How was this tested?
- [x] Unit tests updated and passing (`TestExecuteJob_SLOExpiredBeforeDispatch`, `TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile`)
- [x] Full worker package tests pass
- [x] Pre-commit checks pass
## Checklist
- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Pre-commit checks pass (`make pre-commit`)
- [x] Unit tests pass (`make test`)
- [x] E2E tests pass (`make test-e2e`)
## Related Issues
Fixes #612