### PR TITLE
deps(go): bump minimum Go version from 1.25 to 1.26

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@
 # excluded from errcheck. Write-path Close errors (e.g. after writing
 # to a file) should still be checked explicitly.
 
-# v2 is required for Go 1.25+ (v1 does not support Go 1.25).
+# v2 is required for Go 1.25+ (v1 does not support Go 1.25 or later).
 # See: https://github.com/golangci/golangci-lint/issues/5873
 version: "2"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Batch Gateway
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/llm-d/llm-d-batch-gateway)](https://goreportcard.com/report/github.com/llm-d/llm-d-batch-gateway)
-[![Go Version](https://img.shields.io/badge/Go-1.25-blue.svg)](https://golang.org/)
+[![Go Version](https://img.shields.io/badge/Go-1.26-blue.svg)](https://golang.org/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://llm-d.slack.com/archives/C0AA8772H7T)
 [![apiserver](https://img.shields.io/github/v/release/llm-d/llm-d-batch-gateway?label=apiserver)](https://github.com/llm-d/llm-d-batch-gateway/pkgs/container/batch-gateway-apiserver)
@@ -162,7 +162,7 @@ batch-gateway/
 
 ### Prerequisites
 
-- Go 1.25 or later.
+- Go 1.26 or later.
 - PostgreSQL 12+ (for metadata storage).
 - Redis 6+ or Valkey 8+ (for job queue).
 - S3-compatible object storage or local filesystem.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-batch-gateway
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -5,7 +5,7 @@ End-to-end tests for the batch-gateway. They run against a live deployment and c
 ## Prerequisites
 
 - `kubectl`, `helm`, `kind`, Docker or Podman
-- Go 1.25+
+- Go 1.26+
 
 ## 1. Deploy the server
 

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/llm-d/llm-d-batch-gateway/test/e2e
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/llm-d/llm-d-async/api v0.7.4

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -13,7 +13,7 @@ Integration tests validate feature-level behavior through the real HTTP stack â€
 
 ## Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Docker or Podman (optional, for inference client tests)
 - S3-compatible service (optional, for S3 tests â€” set `S3_TEST_ENDPOINT`)
 


### PR DESCRIPTION
## Why is this PR needed?

<!-- Explain the motivation: feature request, bug fix, performance improvement, etc. -->

## What does this PR do?

<!-- Describe the changes and their purpose -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
