### PR TITLE
feat(benchmarks): add system-level benchmarks for preprocessor, executor, progress tracking, queue, and file I/O

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm dev-deploy dev-clean dev-rm-cluster pre-commit benchmark-local benchmark-local-teardown benchmark-gpu benchmark-gpu-teardown
+.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench test-bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm dev-deploy dev-clean dev-rm-cluster pre-commit benchmark-local benchmark-local-teardown benchmark-gpu benchmark-gpu-teardown
 
 SHELL := /usr/bin/env bash
 
@@ -190,6 +190,11 @@ test-coverage-func:
 bench:
 	@echo "Running benchmarks (benchtime=$(BENCHTIME))..."
 	$(GO) test -bench=. -benchmem -benchtime=$(BENCHTIME) ./...
+
+## test-bench: Run system-level benchmarks (preprocessor, executor, queue, file I/O)
+test-bench:
+	@echo "Running system benchmarks (benchtime=$(BENCHTIME))..."
+	$(GO) test -bench=. -benchmem -benchtime=$(BENCHTIME) -tags=bench ./test/benchmark/...
 
 ## lint: Run golangci-lint
 lint:

--- a/internal/processor/worker/bench_export.go
+++ b/internal/processor/worker/bench_export.go
@@ -1,0 +1,84 @@
+//go:build bench
+
+package worker
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/clientset"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/semaphore"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+// NewProcessorForTest creates a Processor with semaphores initialised,
+// suitable for calling PreProcessJobForTest / ExecuteJobForTest from
+// external benchmark packages.
+func NewProcessorForTest(
+	cfg *config.ProcessorConfig,
+	clients *clientset.Clientset,
+	logger logr.Logger,
+) (*Processor, error) {
+	p, err := NewProcessor(cfg, clients, "bench-processor", logger)
+	if err != nil {
+		return nil, err
+	}
+	p.tokens, err = semaphore.New(cfg.NumWorkers, nil)
+	if err != nil {
+		return nil, err
+	}
+	p.globalSem, err = semaphore.New(cfg.Concurrency.Global, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.inference != nil {
+		cc := &cfg.Concurrency
+		inferClients := p.inference.Clients()
+		p.endpointLimits = make(map[inference.InferenceClient]*endpointLimit, len(inferClients))
+		for _, client := range inferClients {
+			epLabel := p.inference.ClientLabel(client)
+			epSem, semErr := semaphore.NewAdaptive(cc.PerEndpoint, nil)
+			if semErr != nil {
+				return nil, semErr
+			}
+			var epAIMD *semaphore.AIMDController
+			if cc.AIMD.Enabled {
+				epAIMD = semaphore.NewAIMDController(
+					semaphore.AIMDConfig{
+						MinLimit:         cc.AIMD.Min,
+						MaxLimit:         cc.PerEndpoint,
+						BackoffFactor:    cc.AIMD.BackoffFactor,
+						AdditiveIncrease: cc.AIMD.AdditiveIncrease,
+					},
+					cc.PerEndpoint,
+					func(limit int) { epSem.SetLimit(limit) },
+					logr.Discard(),
+				)
+			}
+			p.endpointLimits[client] = &endpointLimit{sem: epSem, aimd: epAIMD, label: epLabel}
+		}
+	} else {
+		p.endpointLimits = make(map[inference.InferenceClient]*endpointLimit)
+	}
+
+	return p, nil
+}
+
+// PreProcessJobForTest exports preProcessJob for benchmarking.
+func (p *Processor) PreProcessJobForTest(ctx, sloCtx, userCancelCtx context.Context, jobInfo *batch_types.JobInfo) error {
+	return p.preProcessJob(ctx, sloCtx, userCancelCtx, jobInfo)
+}
+
+// ExecuteJobForTest exports the execution pipeline for benchmarking.
+func (p *Processor) ExecuteJobForTest(ctx context.Context, jobInfo *batch_types.JobInfo) (*openai.BatchRequestCounts, error) {
+	params := &jobExecutionParams{
+		updater: p.updater,
+		jobInfo: jobInfo,
+	}
+	return p.executeJobAsync(ctx, ctx, ctx, ctx, params)
+}

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -1,0 +1,56 @@
+# System-Level Benchmarks
+
+Go benchmarks for batch-gateway subsystems: preprocessor ingestion, executor dispatch, progress tracking, queue operations, and file I/O.
+
+## Running
+
+```bash
+# all benchmarks
+make test-bench
+
+# single category
+go test -tags=bench -bench=BenchmarkPreprocessor -benchmem ./test/benchmark/preprocessor/
+
+# adjust duration (default 1s)
+make test-bench BENCHTIME=5s
+```
+
+The `-tags=bench` flag is required for preprocessor and executor benchmarks (they depend on exported test helpers gated behind a build tag). The Makefile target includes it automatically.
+
+## Comparing results
+
+Use [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) to compare runs before and after a change.
+
+```bash
+# install benchstat (one-time)
+go install golang.org/x/perf/cmd/benchstat@latest
+
+# capture baseline
+go test -tags=bench -bench=. -benchmem -count=6 ./test/benchmark/... > old.txt
+
+# make your changes, then capture again
+go test -tags=bench -bench=. -benchmem -count=6 ./test/benchmark/... > new.txt
+
+# compare
+benchstat old.txt new.txt
+```
+
+Use `-count=6` (or higher) so benchstat has enough samples to compute statistical significance. It will flag changes with a p-value and confidence interval:
+
+```
+                          │   old.txt   │              new.txt               │
+                          │   sec/op    │   sec/op     vs base               │
+Preprocessor/1K_lines-18   3.524m ± 2%   3.891m ± 3%  +10.42% (p=0.002 n=6)
+```
+
+A `~` means the difference is not statistically significant. Only act on changes marked with `+` or `-` and a low p-value.
+
+## Benchmark categories
+
+| Package | What it measures | Key metrics |
+|---|---|---|
+| `preprocessor/` | JSONL parsing, validation, FNV hashing, plan file building | lines/sec, MB/sec, allocs/op |
+| `executor/` | Inference dispatch with semaphore hierarchy, output writing | req/sec, p50/p99 latency, allocs/op |
+| `progress/` | ProgressTracker mutex contention, StatusUpdater throughput | ns/op (serial vs parallel) |
+| `queue/` | Redis sorted set enqueue (miniredis), dequeue, mixed r/w | ns/op, allocs/op |
+| `filestore/` | Filesystem store/retrieve at 10MB, 100MB, 500MB | MB/sec, allocs/op |

--- a/test/benchmark/executor/doc.go
+++ b/test/benchmark/executor/doc.go
@@ -1,0 +1,1 @@
+package executor_test

--- a/test/benchmark/executor/executor_bench_test.go
+++ b/test/benchmark/executor/executor_bench_test.go
@@ -1,0 +1,177 @@
+//go:build bench
+
+package executor_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
+	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/worker"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/clientset"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+	benchhelpers "github.com/llm-d/llm-d-batch-gateway/test/benchmark"
+)
+
+var models = []string{"model-a"}
+
+// timingInferenceClient wraps MockInferenceClient and records per-request
+// latency (including semaphore wait time visible from the caller's side).
+type timingInferenceClient struct {
+	mu        sync.Mutex
+	inner     benchhelpers.MockInferenceClient
+	latencies []time.Duration
+}
+
+func (t *timingInferenceClient) Generate(ctx context.Context, req *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+	start := time.Now()
+	resp, err := t.inner.Generate(ctx, req)
+	elapsed := time.Since(start)
+	t.mu.Lock()
+	t.latencies = append(t.latencies, elapsed)
+	t.mu.Unlock()
+	return resp, err
+}
+
+func (t *timingInferenceClient) reset() {
+	t.mu.Lock()
+	t.latencies = t.latencies[:0]
+	t.mu.Unlock()
+}
+
+func (t *timingInferenceClient) percentiles() (p50, p99 time.Duration) {
+	t.mu.Lock()
+	sorted := make([]time.Duration, len(t.latencies))
+	copy(sorted, t.latencies)
+	t.mu.Unlock()
+
+	if len(sorted) == 0 {
+		return 0, 0
+	}
+	slices.Sort(sorted)
+	p50 = sorted[len(sorted)*50/100]
+	p99 = sorted[len(sorted)*99/100]
+	return p50, p99
+}
+
+func BenchmarkExecutor(b *testing.B) {
+	for _, rc := range []struct {
+		name  string
+		count int
+	}{
+		{"1K", 1_000},
+		{"10K", 10_000},
+	} {
+		for _, wc := range []struct {
+			name    string
+			workers int
+		}{
+			{"workers_1", 1},
+			{"workers_10", 10},
+			{"workers_50", 50},
+		} {
+			name := fmt.Sprintf("%s/%s", rc.name, wc.name)
+			b.Run(name, func(b *testing.B) {
+				benchExecute(b, rc.count, wc.workers)
+			})
+		}
+	}
+}
+
+func benchExecute(b *testing.B, requestCount, workers int) {
+	b.Helper()
+	ctx := context.Background()
+
+	cfg := config.NewConfig()
+	cfg.WorkDir = b.TempDir()
+	cfg.NumWorkers = workers
+	cfg.Concurrency.Global = workers
+	cfg.Concurrency.PerEndpoint = workers
+
+	inferClient := &timingInferenceClient{}
+	filesClient := mockfiles.NewMockBatchFilesClient(b.TempDir())
+	fileDBClient := benchhelpers.NewMockFileDBClient()
+
+	clients := &clientset.Clientset{
+		BatchDB:   benchhelpers.NewMockBatchDBClient(),
+		FileDB:    fileDBClient,
+		File:      filesClient,
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Status:    mockdb.NewMockBatchStatusClient(),
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		InFlight:  mockdb.NewMockInFlightClient(),
+		Inference: inference.NewSingleClientResolver(inferClient),
+	}
+
+	p, err := worker.NewProcessorForTest(cfg, clients, benchhelpers.DiscardLogger())
+	if err != nil {
+		b.Fatalf("NewProcessorForTest: %v", err)
+	}
+
+	tenantID := "bench-tenant"
+	inputFileID := "bench-exec-input"
+	inputData := benchhelpers.GenJSONLInput(requestCount, models)
+	benchhelpers.SeedInputFile(b, filesClient, fileDBClient, inputFileID, tenantID, inputData)
+
+	// Preprocess once per iteration to create plan files and model map.
+	for i := range b.N {
+		jobID := fmt.Sprintf("exec-job-%d", i)
+		jobInfo := &batch_types.JobInfo{
+			JobID: jobID,
+			BatchJob: &openai.Batch{
+				ID: jobID,
+				BatchSpec: openai.BatchSpec{
+					InputFileID: inputFileID,
+				},
+				BatchStatusInfo: openai.BatchStatusInfo{
+					Status: openai.BatchStatusInProgress,
+				},
+			},
+			TenantID: tenantID,
+		}
+		if err := p.PreProcessJobForTest(ctx, ctx, ctx, jobInfo); err != nil {
+			b.Fatalf("PreProcessJobForTest (setup iter %d): %v", i, err)
+		}
+	}
+
+	b.ResetTimer()
+	start := time.Now()
+
+	for i := range b.N {
+		inferClient.reset()
+
+		jobID := fmt.Sprintf("exec-job-%d", i)
+		jobInfo := &batch_types.JobInfo{
+			JobID: jobID,
+			BatchJob: &openai.Batch{
+				ID: jobID,
+				BatchSpec: openai.BatchSpec{
+					InputFileID: inputFileID,
+				},
+				BatchStatusInfo: openai.BatchStatusInfo{
+					Status: openai.BatchStatusInProgress,
+				},
+			},
+			TenantID: tenantID,
+		}
+		if _, err := p.ExecuteJobForTest(ctx, jobInfo); err != nil {
+			b.Fatalf("ExecuteJobForTest: %v", err)
+		}
+	}
+
+	b.StopTimer()
+	elapsed := time.Since(start)
+	b.ReportMetric(float64(requestCount)*float64(b.N)/elapsed.Seconds(), "req/sec")
+
+	p50, p99 := inferClient.percentiles()
+	b.ReportMetric(float64(p50.Microseconds()), "p50-µs")
+	b.ReportMetric(float64(p99.Microseconds()), "p99-µs")
+}

--- a/test/benchmark/executor/main_test.go
+++ b/test/benchmark/executor/main_test.go
@@ -1,0 +1,21 @@
+//go:build bench
+
+package executor_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
+)
+
+func TestMain(m *testing.M) {
+	cfg := config.NewConfig()
+	if err := metrics.InitMetrics(*cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init metrics: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/benchmark/filestore/doc.go
+++ b/test/benchmark/filestore/doc.go
@@ -1,0 +1,1 @@
+package filestore_test

--- a/test/benchmark/filestore/filestore_bench_test.go
+++ b/test/benchmark/filestore/filestore_bench_test.go
@@ -1,0 +1,106 @@
+package filestore_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/files_store/fs"
+)
+
+func BenchmarkFSStore(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+		{"500MB", 500 * 1024 * 1024},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchStore(b, tc.size)
+		})
+	}
+}
+
+func benchStore(b *testing.B, size int) {
+	b.Helper()
+	client, err := fs.New(b.TempDir())
+	if err != nil {
+		b.Fatalf("fs.New: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	data := bytes.Repeat([]byte("x"), size)
+	folder := "bench-folder"
+
+	b.ResetTimer()
+	start := time.Now()
+
+	for i := range b.N {
+		name := fmt.Sprintf("bench-store-%d", i)
+		if _, err := client.Store(ctx, name, folder, 0, 0, bytes.NewReader(data)); err != nil {
+			b.Fatalf("Store: %v", err)
+		}
+	}
+
+	b.StopTimer()
+	elapsed := time.Since(start)
+	b.ReportMetric(float64(size)*float64(b.N)/elapsed.Seconds()/(1024*1024), "MB/sec")
+}
+
+func BenchmarkFSRetrieve(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{"10MB", 10 * 1024 * 1024},
+		{"100MB", 100 * 1024 * 1024},
+		{"500MB", 500 * 1024 * 1024},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchRetrieve(b, tc.size)
+		})
+	}
+}
+
+func benchRetrieve(b *testing.B, size int) {
+	b.Helper()
+	client, err := fs.New(b.TempDir())
+	if err != nil {
+		b.Fatalf("fs.New: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+	data := bytes.Repeat([]byte("x"), size)
+	folder := "bench-folder"
+	fileName := "bench-retrieve-file"
+
+	if _, err := client.Store(ctx, fileName, folder, 0, 0, bytes.NewReader(data)); err != nil {
+		b.Fatalf("Store (setup): %v", err)
+	}
+
+	b.ResetTimer()
+	start := time.Now()
+
+	for range b.N {
+		reader, _, err := client.Retrieve(ctx, fileName, folder)
+		if err != nil {
+			b.Fatalf("Retrieve: %v", err)
+		}
+		if _, err := io.Copy(io.Discard, reader); err != nil {
+			reader.Close()
+			b.Fatalf("io.Copy: %v", err)
+		}
+		reader.Close()
+	}
+
+	b.StopTimer()
+	elapsed := time.Since(start)
+	b.ReportMetric(float64(size)*float64(b.N)/elapsed.Seconds()/(1024*1024), "MB/sec")
+}

--- a/test/benchmark/helpers.go
+++ b/test/benchmark/helpers.go
@@ -1,0 +1,97 @@
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
+	filesapi "github.com/llm-d/llm-d-batch-gateway/internal/files_store/api"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	ucom "github.com/llm-d/llm-d-batch-gateway/internal/util/com"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+// MockInferenceClient implements inference.InferenceClient with a fixed response.
+type MockInferenceClient struct{}
+
+func (m *MockInferenceClient) Generate(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
+	return &inference.GenerateResponse{
+		RequestID: "bench-req-1",
+		Response:  []byte(`{"choices":[{"message":{"content":"ok"}}]}`),
+	}, nil
+}
+
+// GenJSONLInput generates count JSONL request lines cycling through models.
+func GenJSONLInput(count int, models []string) []byte {
+	var buf bytes.Buffer
+	for i := range count {
+		m := models[i%len(models)]
+		req := map[string]any{
+			"custom_id": fmt.Sprintf("req-%d", i),
+			"method":    "POST",
+			"url":       "/v1/chat/completions",
+			"body": map[string]any{
+				"model": m,
+				"messages": []map[string]string{
+					{"role": "system", "content": fmt.Sprintf("system-prompt-%d", i%10)},
+					{"role": "user", "content": fmt.Sprintf("question %d", i)},
+				},
+			},
+		}
+		line, _ := json.Marshal(req)
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+// SeedInputFile stores input data in the files client and seeds a FileDB record.
+func SeedInputFile(b *testing.B, filesClient filesapi.BatchFilesClient, fileDBClient db.FileDBClient, inputFileID, tenantID string, data []byte) {
+	b.Helper()
+	folder, err := ucom.GetFolderNameByTenantID(tenantID)
+	if err != nil {
+		b.Fatalf("GetFolderNameByTenantID: %v", err)
+	}
+	filename := "input.jsonl"
+	storageName := ucom.FileStorageName(inputFileID, filename)
+	if _, err := filesClient.Store(context.Background(), storageName, folder, 0, 0, bytes.NewReader(data)); err != nil {
+		b.Fatalf("files.Store: %v", err)
+	}
+	fileSpec := &openai.FileObject{Filename: filename}
+	specBytes, _ := json.Marshal(fileSpec)
+	fileItem := &db.FileItem{
+		BaseIndexes:  db.BaseIndexes{ID: inputFileID, TenantID: tenantID},
+		BaseContents: db.BaseContents{Spec: specBytes},
+	}
+	if err := fileDBClient.DBStore(context.Background(), fileItem); err != nil {
+		b.Fatalf("DBStore file item: %v", err)
+	}
+}
+
+// NewMockBatchDBClient creates a mock BatchDBClient.
+func NewMockBatchDBClient() db.BatchDBClient {
+	return mockdb.NewMockDBClient[db.BatchItem, db.BatchQuery](
+		func(b *db.BatchItem) string { return b.ID },
+		func(q *db.BatchQuery) *db.BaseQuery { return &q.BaseQuery },
+	)
+}
+
+// NewMockFileDBClient creates a mock FileDBClient.
+func NewMockFileDBClient() db.FileDBClient {
+	return mockdb.NewMockDBClient[db.FileItem, db.FileQuery](
+		func(f *db.FileItem) string { return f.ID },
+		func(q *db.FileQuery) *db.BaseQuery { return &q.BaseQuery },
+	)
+}
+
+// DiscardLogger returns a logr.Logger that discards all output.
+func DiscardLogger() logr.Logger {
+	return logr.Discard()
+}

--- a/test/benchmark/preprocessor/doc.go
+++ b/test/benchmark/preprocessor/doc.go
@@ -1,0 +1,1 @@
+package preprocessor_test

--- a/test/benchmark/preprocessor/main_test.go
+++ b/test/benchmark/preprocessor/main_test.go
@@ -1,0 +1,21 @@
+//go:build bench
+
+package preprocessor_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
+)
+
+func TestMain(m *testing.M) {
+	cfg := config.NewConfig()
+	if err := metrics.InitMetrics(*cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to init metrics: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/benchmark/preprocessor/preprocessor_bench_test.go
+++ b/test/benchmark/preprocessor/preprocessor_bench_test.go
@@ -1,0 +1,99 @@
+//go:build bench
+
+package preprocessor_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
+	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/worker"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/clientset"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+	benchhelpers "github.com/llm-d/llm-d-batch-gateway/test/benchmark"
+)
+
+var models = []string{"model-a", "model-b", "model-c"}
+
+func BenchmarkPreprocessor(b *testing.B) {
+	for _, tc := range []struct {
+		name      string
+		lineCount int
+	}{
+		{"1K_lines", 1_000},
+		{"10K_lines", 10_000},
+		{"50K_lines", 50_000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchPreprocess(b, tc.lineCount)
+		})
+	}
+}
+
+func benchPreprocess(b *testing.B, lineCount int) {
+	b.Helper()
+	ctx := context.Background()
+
+	cfg := config.NewConfig()
+	cfg.WorkDir = b.TempDir()
+
+	filesClient := mockfiles.NewMockBatchFilesClient(b.TempDir())
+	fileDBClient := benchhelpers.NewMockFileDBClient()
+
+	inferClient := &benchhelpers.MockInferenceClient{}
+	clients := &clientset.Clientset{
+		BatchDB:   benchhelpers.NewMockBatchDBClient(),
+		FileDB:    fileDBClient,
+		File:      filesClient,
+		Queue:     mockdb.NewMockBatchPriorityQueueClient(),
+		Status:    mockdb.NewMockBatchStatusClient(),
+		Event:     mockdb.NewMockBatchEventChannelClient(),
+		InFlight:  mockdb.NewMockInFlightClient(),
+		Inference: inference.NewSingleClientResolver(inferClient),
+	}
+
+	p, err := worker.NewProcessorForTest(cfg, clients, benchhelpers.DiscardLogger())
+	if err != nil {
+		b.Fatalf("NewProcessorForTest: %v", err)
+	}
+
+	inputFileID := "bench-input-file"
+	tenantID := "bench-tenant"
+	inputData := benchhelpers.GenJSONLInput(lineCount, models)
+
+	benchhelpers.SeedInputFile(b, filesClient, fileDBClient, inputFileID, tenantID, inputData)
+
+	b.ResetTimer()
+	start := time.Now()
+
+	for i := range b.N {
+		jobID := fmt.Sprintf("bench-job-%d", i)
+		jobInfo := &batch_types.JobInfo{
+			JobID: jobID,
+			BatchJob: &openai.Batch{
+				ID: jobID,
+				BatchSpec: openai.BatchSpec{
+					InputFileID: inputFileID,
+				},
+				BatchStatusInfo: openai.BatchStatusInfo{
+					Status: openai.BatchStatusInProgress,
+				},
+			},
+			TenantID: tenantID,
+		}
+		if err := p.PreProcessJobForTest(ctx, ctx, ctx, jobInfo); err != nil {
+			b.Fatalf("PreProcessJobForTest: %v", err)
+		}
+	}
+
+	b.StopTimer()
+	elapsed := time.Since(start)
+	b.ReportMetric(float64(lineCount)*float64(b.N)/elapsed.Seconds(), "lines/sec")
+	b.ReportMetric(float64(len(inputData))*float64(b.N)/elapsed.Seconds()/(1024*1024), "MB/sec")
+}

--- a/test/benchmark/progress/doc.go
+++ b/test/benchmark/progress/doc.go
@@ -1,0 +1,1 @@
+package progress_test

--- a/test/benchmark/progress/progress_bench_test.go
+++ b/test/benchmark/progress/progress_bench_test.go
@@ -1,0 +1,81 @@
+package progress_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/worker"
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	benchhelpers "github.com/llm-d/llm-d-batch-gateway/test/benchmark"
+)
+
+type noopUpdater struct{}
+
+func (noopUpdater) UpdateProgressCounts(_ context.Context, _ string, _ *openai.BatchRequestCounts) error {
+	return nil
+}
+
+func BenchmarkProgressTracker(b *testing.B) {
+	b.Run("record_serial", func(b *testing.B) {
+		tracker := pipeline.NewProgressTracker(
+			int64(b.N), noopUpdater{}, "bench-job", time.Hour, benchhelpers.DiscardLogger(),
+		)
+		b.ResetTimer()
+		for range b.N {
+			tracker.RecordSuccess(pipeline.ResultItem{})
+		}
+	})
+
+	b.Run("record_parallel", func(b *testing.B) {
+		tracker := pipeline.NewProgressTracker(
+			int64(b.N), noopUpdater{}, "bench-job", time.Hour, benchhelpers.DiscardLogger(),
+		)
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				tracker.RecordSuccess(pipeline.ResultItem{})
+			}
+		})
+	})
+}
+
+func BenchmarkUpdateProgressCounts(b *testing.B) {
+	b.Run("serial", func(b *testing.B) {
+		dbClient := benchhelpers.NewMockBatchDBClient()
+		statusClient := mockdb.NewMockBatchStatusClient()
+		updater := worker.NewStatusUpdater(dbClient, statusClient, 86400)
+		counts := &openai.BatchRequestCounts{Total: 1000, Completed: 500, Failed: 0}
+		ctx := context.Background()
+
+		b.ResetTimer()
+		for range b.N {
+			if err := updater.UpdateProgressCounts(ctx, "bench-job", counts); err != nil {
+				b.Fatalf("UpdateProgressCounts: %v", err)
+			}
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		dbClient := benchhelpers.NewMockBatchDBClient()
+		statusClient := mockdb.NewMockBatchStatusClient()
+		updater := worker.NewStatusUpdater(dbClient, statusClient, 86400)
+		counts := &openai.BatchRequestCounts{Total: 1000, Completed: 500, Failed: 0}
+		ctx := context.Background()
+		var counter atomic.Int64
+
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				jobID := fmt.Sprintf("bench-job-%d", counter.Add(1))
+				if err := updater.UpdateProgressCounts(ctx, jobID, counts); err != nil {
+					b.Fatalf("UpdateProgressCounts: %v", err)
+				}
+			}
+		})
+	})
+}

--- a/test/benchmark/queue/doc.go
+++ b/test/benchmark/queue/doc.go
@@ -1,0 +1,1 @@
+package queue_test

--- a/test/benchmark/queue/queue_bench_test.go
+++ b/test/benchmark/queue/queue_bench_test.go
@@ -1,0 +1,183 @@
+package queue_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	db_api "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
+	dbredis "github.com/llm-d/llm-d-batch-gateway/internal/database/redis"
+	uredis "github.com/llm-d/llm-d-batch-gateway/internal/util/redis"
+)
+
+func newRedisExchangeClient(b *testing.B) *dbredis.ExchangeDBClientRedis {
+	b.Helper()
+	mr := miniredis.NewMiniRedis()
+	if err := mr.Start(); err != nil {
+		b.Fatalf("start miniredis: %v", err)
+	}
+	b.Cleanup(func() { mr.Close() })
+
+	ctx := context.Background()
+	cfg := &uredis.RedisClientConfig{
+		Url:         "redis://" + mr.Addr(),
+		ServiceName: "bench-service",
+	}
+	base, err := dbredis.NewDSClientRedis(ctx, cfg, 0)
+	if err != nil {
+		b.Fatalf("NewDSClientRedis: %v", err)
+	}
+	b.Cleanup(func() { _ = base.Close() })
+
+	exch, err := dbredis.NewExchangeDBClientRedis(ctx, base, nil, 0)
+	if err != nil {
+		b.Fatalf("NewExchangeDBClientRedis: %v", err)
+	}
+	return exch
+}
+
+// BenchmarkPQEnqueue measures Redis ZADD NX throughput via miniredis.
+func BenchmarkPQEnqueue(b *testing.B) {
+	b.Run("serial", func(b *testing.B) {
+		exch := newRedisExchangeClient(b)
+		ctx := context.Background()
+		slo := time.Now().Add(24 * time.Hour)
+
+		b.ResetTimer()
+		for i := range b.N {
+			item := &db_api.BatchJobPriority{
+				ID:  fmt.Sprintf("job-%d", i),
+				SLO: slo,
+			}
+			if err := exch.PQEnqueue(ctx, item); err != nil {
+				b.Fatalf("PQEnqueue: %v", err)
+			}
+		}
+	})
+
+	b.Run("parallel_10", func(b *testing.B) {
+		exch := newRedisExchangeClient(b)
+		ctx := context.Background()
+		slo := time.Now().Add(24 * time.Hour)
+		var counter atomic.Int64
+
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				id := counter.Add(1)
+				item := &db_api.BatchJobPriority{
+					ID:  fmt.Sprintf("job-%d", id),
+					SLO: slo,
+				}
+				if err := exch.PQEnqueue(ctx, item); err != nil {
+					b.Fatalf("PQEnqueue: %v", err)
+				}
+			}
+		})
+	})
+}
+
+// BenchmarkPQDequeue measures in-memory priority queue dequeue throughput.
+// Uses the mock client because miniredis does not support ZMPOP/BZMPOP.
+// Keeps a fixed pool of items and refills when depleted.
+func BenchmarkPQDequeue(b *testing.B) {
+	b.Run("serial", func(b *testing.B) {
+		pq := mockdb.NewMockBatchPriorityQueueClient()
+		ctx := context.Background()
+		slo := time.Now().Add(24 * time.Hour)
+
+		const poolSize = 1000
+		var seq int
+		populate := func() {
+			for range poolSize {
+				item := &db_api.BatchJobPriority{
+					ID:  fmt.Sprintf("job-%d", seq),
+					SLO: slo.Add(time.Duration(seq) * time.Microsecond),
+				}
+				_ = pq.PQEnqueue(ctx, item)
+				seq++
+			}
+		}
+		populate()
+		remaining := poolSize
+
+		b.ResetTimer()
+		for range b.N {
+			if remaining == 0 {
+				b.StopTimer()
+				populate()
+				remaining = poolSize
+				b.StartTimer()
+			}
+			_, err := pq.PQDequeue(ctx, 0, 1)
+			if err != nil {
+				b.Fatalf("PQDequeue: %v", err)
+			}
+			remaining--
+		}
+	})
+}
+
+// BenchmarkPQMixed measures concurrent enqueue/dequeue throughput
+// using the mock client.
+func BenchmarkPQMixed(b *testing.B) {
+	pq := mockdb.NewMockBatchPriorityQueueClient()
+	ctx := context.Background()
+	slo := time.Now().Add(24 * time.Hour)
+
+	// Pre-populate so dequeuers have items to consume.
+	for i := range 1000 {
+		item := &db_api.BatchJobPriority{
+			ID:  fmt.Sprintf("pre-%d", i),
+			SLO: slo.Add(time.Duration(i) * time.Microsecond),
+		}
+		if err := pq.PQEnqueue(ctx, item); err != nil {
+			b.Fatalf("PQEnqueue (pre-populate): %v", err)
+		}
+	}
+
+	var enqCounter atomic.Int64
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+
+	// Enqueue goroutines.
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				id := enqCounter.Add(1)
+				if id > int64(b.N) {
+					return
+				}
+				item := &db_api.BatchJobPriority{
+					ID:  fmt.Sprintf("mix-enq-%d", id),
+					SLO: slo,
+				}
+				_ = pq.PQEnqueue(ctx, item)
+			}
+		}()
+	}
+
+	// Dequeue goroutines.
+	var deqCount atomic.Int64
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for deqCount.Add(1) <= int64(b.N) {
+				_, _ = pq.PQDequeue(ctx, 0, 1)
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Why is this PR needed?

The project currently has only micro-benchmarks (handler serialization, semaphore acquire/release, recovery middleware) but lacks benchmarks that measure system-level performance characteristics relevant to production sizing and capacity planning. Without these, performance regressions in critical paths like preprocessing, inference dispatch, and file I/O can go undetected across releases.

## What does this PR do?

Adds system-level Go benchmarks (`go test -bench`) for 5 core subsystems, runnable via `make test-bench`:

| Category | Benchmark | Key Metrics |
|---|---|---|
| Preprocessor throughput | `BenchmarkPreprocessor` (1K/10K/50K lines) | lines/sec, MB/sec, allocs/op |
| Executor dispatch | `BenchmarkExecutor` (1K/10K requests × 1/10/50 workers) | req/sec, p50/p99 latency, allocs/op |
| Status update throughput | `BenchmarkProgressTracker`, `BenchmarkUpdateProgressCounts` (serial + parallel) | ns/op, mutex contention ratio |
| Queue operations | `BenchmarkPQEnqueue` (miniredis), `BenchmarkPQDequeue`, `BenchmarkPQMixed` | ns/op, allocs/op |
| File I/O | `BenchmarkFSStore`, `BenchmarkFSRetrieve` (10MB/100MB/500MB) | MB/sec, allocs/op |

**Structure:**
- All benchmarks live in `test/benchmark/` with per-component subdirectories
- Shared helpers in `test/benchmark/helpers.go` (mock clients, JSONL generation, file seeding)
- Thin exported wrappers in `internal/processor/worker/bench_export.go` gated behind `//go:build bench` to avoid polluting production binaries
- Output is `benchstat`-compatible for regression tracking; README documents comparison workflow

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Related to #207
