### PR TITLE
test(e2e): decouple GC/GIE tests from Kind-specific assumptions

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -39,6 +39,10 @@ var (
 	testPostgresqlRelease = getEnvOrDefault("TEST_POSTGRESQL_RELEASE", "postgresql")
 	testRedisRelease      = getEnvOrDefault("TEST_REDIS_RELEASE", "redis")
 	testDBPod             = getEnvOrDefault("TEST_DB_POD", "")
+	testDBNamespace       = getEnvOrDefault("TEST_DB_NAMESPACE", "")
+	testDBName            = getEnvOrDefault("TEST_DB_NAME", "postgres")
+	testDBUser            = getEnvOrDefault("TEST_DB_USER", "postgres")
+	testEPPNamespace      = getEnvOrDefault("TEST_EPP_NAMESPACE", "")
 
 	// testDBClientType and testExchangeClientType are detected from Helm
 	// releases at startup; see detectDBClientType / detectExchangeClientType.

--- a/test/e2e/flow_control_test.go
+++ b/test/e2e/flow_control_test.go
@@ -311,13 +311,24 @@ func doTestRetryExhaustion(t *testing.T) {
 //   - Mixed load with metrics: verify batch completion alongside interactive
 //     traffic with retry/shedding counters. Requires EPP to export scheduling metrics.
 
-// detectGIEDeployed checks whether at least one EPP deployment exists
-// in the test namespace.
+// detectGIEDeployed checks whether at least one EPP deployment exists.
+// It searches testEPPNamespace (TEST_EPP_NAMESPACE) if set, otherwise
+// testNamespace. Set TEST_GIE_DEPLOYED=true to force-enable GIE tests
+// when the EPP naming convention differs (e.g. RHOAI).
 func detectGIEDeployed(t *testing.T) bool {
 	t.Helper()
 
+	if strings.EqualFold(getEnvOrDefault("TEST_GIE_DEPLOYED", ""), "true") {
+		return true
+	}
+
+	ns := testEPPNamespace
+	if ns == "" {
+		ns = testNamespace
+	}
+
 	out, err := exec.Command("kubectl", "get", "deployments",
-		"-n", testNamespace,
+		"-n", ns,
 		"-o", "name",
 	).CombinedOutput()
 	if err != nil {

--- a/test/e2e/gc_test.go
+++ b/test/e2e/gc_test.go
@@ -52,11 +52,19 @@ func expireInPostgresql(t *testing.T, table, id string) {
 		podName = fmt.Sprintf("%s-0", testPostgresqlRelease)
 	}
 
+	ns := testDBNamespace
+	if ns == "" {
+		ns = testNamespace
+	}
+
 	sql := fmt.Sprintf("UPDATE %s SET expiry = 1 WHERE id = '%s'", table, id)
-	cmd := fmt.Sprintf(`PGPASSWORD="$(cat "$POSTGRES_PASSWORD_FILE")" psql -U postgres -d postgres -c %q`, sql)
+	cmd := fmt.Sprintf(
+		`PGPASSWORD="${POSTGRESQL_PASSWORD:-$(cat "$POSTGRES_PASSWORD_FILE" 2>/dev/null)}" psql -U %s -d %s -c %q`,
+		testDBUser, testDBName, sql,
+	)
 	out, err := exec.Command("kubectl", "exec",
 		podName,
-		"-n", testNamespace,
+		"-n", ns,
 		"--", "bash", "-c", cmd,
 	).CombinedOutput()
 	if err != nil {

--- a/test/e2e/gc_test.go
+++ b/test/e2e/gc_test.go
@@ -59,7 +59,7 @@ func expireInPostgresql(t *testing.T, table, id string) {
 
 	sql := fmt.Sprintf("UPDATE %s SET expiry = 1 WHERE id = '%s'", table, id)
 	cmd := fmt.Sprintf(
-		`PGPASSWORD="${POSTGRESQL_PASSWORD:-$(cat "$POSTGRES_PASSWORD_FILE" 2>/dev/null)}" psql -U %s -d %s -c %q`,
+		`PGPASSWORD="${POSTGRESQL_PASSWORD:-$(cat "$POSTGRES_PASSWORD_FILE" 2>/dev/null)}" psql -U '%s' -d '%s' -c %q`,
 		testDBUser, testDBName, sql,
 	)
 	out, err := exec.Command("kubectl", "exec",


### PR DESCRIPTION
## Why is this PR needed?

E2E tests fail on RHOAI due to hardcoded assumptions for Kind dev-deploy:
- **GarbageCollection tests** assume DB pod is in `TEST_NAMESPACE`, uses Bitnami password convention, and connects to database `postgres`
- **GIE tests** assume EPP deployments are in `TEST_NAMESPACE` with names containing `"epp-"`

On RHOAI, the DB is in a separate namespace with RHEL PostgreSQL conventions, and EPP deployments use different naming/namespace patterns.

## What does this PR do?

Adds environment variables to support RHOAI deployments:

**GarbageCollection tests:**
- `TEST_DB_NAMESPACE` — DB pod namespace (default: `TEST_NAMESPACE`)
- `TEST_DB_NAME` — database name (default: `postgres`)
- `TEST_DB_USER` — database user (default: `postgres`)
- Password: tries `$POSTGRESQL_PASSWORD` first, falls back to `$POSTGRES_PASSWORD_FILE`

**GIE tests:**
- `TEST_EPP_NAMESPACE` — EPP namespace (default: `TEST_NAMESPACE`)
- `TEST_GIE_DEPLOYED=true` — force-enable when EPP naming doesn't match `"epp-"`

Fully backwards compatible with existing Kind deployments.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

