### PR TITLE
feat(tls): add `--tls-min-version` and `--tls-cipher-suites` CLI flags to API server

### DIFF
--- a/internal/apiserver/common/config.go
+++ b/internal/apiserver/common/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	sharedcfg "github.com/llm-d/llm-d-batch-gateway/internal/shared/config"
+	utls "github.com/llm-d/llm-d-batch-gateway/internal/util/tls"
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 )
@@ -110,6 +111,8 @@ type ServerConfig struct {
 	ObservabilityPort string            `yaml:"observability_port"`
 	SSLCertFile       string            `yaml:"ssl_cert_file"`
 	SSLKeyFile        string            `yaml:"ssl_key_file"`
+	TLSMinVersion     string            `yaml:"-"`
+	TLSCipherSuites   string            `yaml:"-"`
 	InputHeaders      map[string]string `yaml:"input_headers"`
 
 	// HTTP server timeout configurations (in seconds)
@@ -150,6 +153,8 @@ func (c *ServerConfig) Load() error {
 
 	var configFile string
 	fs.StringVar(&configFile, "config", "cmd/apiserver/config.yaml", "path to YAML config file")
+	fs.StringVar(&c.TLSMinVersion, "tls-min-version", "", "minimum TLS version (VersionTLS12 or VersionTLS13)")
+	fs.StringVar(&c.TLSCipherSuites, "tls-cipher-suites", "", "comma-separated list of TLS cipher suite names")
 
 	// Parse all flags (klog flags and application flags)
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -175,13 +180,19 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("both ssl-cert-file and ssl-private-key-file must be provided together")
 	}
 
-	// Verify SSL files exist if provided
-	if c.SSLCertFile != "" {
+	// Verify SSL files exist and TLS profile flags are valid when TLS is enabled
+	if c.SSLEnabled() {
 		if _, err := os.Stat(c.SSLCertFile); err != nil {
 			return fmt.Errorf("ssl cert file not found: %w", err)
 		}
 		if _, err := os.Stat(c.SSLKeyFile); err != nil {
 			return fmt.Errorf("ssl key file not found: %w", err)
+		}
+		if _, err := utls.ParseMinVersion(c.TLSMinVersion); err != nil {
+			return fmt.Errorf("invalid --tls-min-version: %w", err)
+		}
+		if _, err := utls.ParseCipherSuites(c.TLSCipherSuites); err != nil {
+			return fmt.Errorf("invalid --tls-cipher-suites: %w", err)
 		}
 	}
 

--- a/internal/apiserver/common/config_test.go
+++ b/internal/apiserver/common/config_test.go
@@ -147,6 +147,99 @@ file_client:
 		}
 	})
 
+	t.Run("TLSFlags", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			enableSSL        bool
+			args             []string
+			wantMinVersion   string
+			wantCipherSuites string
+			wantErr          bool
+		}{
+			{
+				name:           "no TLS flags leaves fields empty",
+				args:           nil,
+				wantMinVersion: "",
+			},
+			{
+				name:           "tls-min-version flag is parsed",
+				args:           []string{"--tls-min-version=VersionTLS13"},
+				wantMinVersion: "VersionTLS13",
+			},
+			{
+				name:             "tls-cipher-suites flag is parsed",
+				args:             []string{"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				wantCipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+			{
+				name:      "invalid tls-min-version rejected when SSL enabled",
+				enableSSL: true,
+				args:      []string{"--tls-min-version=VersionTLS10"},
+				wantErr:   true,
+			},
+			{
+				name:      "invalid cipher suite rejected when SSL enabled",
+				enableSSL: true,
+				args:      []string{"--tls-cipher-suites=UNKNOWN_CIPHER"},
+				wantErr:   true,
+			},
+			{
+				name:             "TLS flags ignored when SSL disabled",
+				args:             []string{"--tls-min-version=VersionTLS13", "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				wantMinVersion:   "VersionTLS13",
+				wantCipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tmpDir := t.TempDir()
+				configFile := filepath.Join(tmpDir, "config.yaml")
+				yamlConfig := `
+host: 0.0.0.0
+port: "8080"
+db_client:
+  type: "mock"
+file_client:
+  type: "fs"
+  fs_base_path: "/tmp/batch-gateway"
+`
+				if tt.enableSSL {
+					setupTestSSLFiles(t)
+					defer cleanupTestSSLFiles(t)
+					yamlConfig += `ssl_cert_file: testdata/cert.pem
+ssl_key_file: testdata/key.pem
+`
+				}
+
+				if err := os.WriteFile(configFile, []byte(yamlConfig), 0644); err != nil {
+					t.Fatalf("Failed to create test config file: %v", err)
+				}
+
+				oldArgs := os.Args
+				defer func() { os.Args = oldArgs }()
+
+				os.Args = append([]string{"test", "--config=" + configFile}, tt.args...)
+
+				config := NewConfig()
+				err := config.Load()
+
+				if (err != nil) != tt.wantErr {
+					t.Fatalf("Load() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if tt.wantErr {
+					return
+				}
+				if config.TLSMinVersion != tt.wantMinVersion {
+					t.Errorf("TLSMinVersion = %q, want %q", config.TLSMinVersion, tt.wantMinVersion)
+				}
+				if config.TLSCipherSuites != tt.wantCipherSuites {
+					t.Errorf("TLSCipherSuites = %q, want %q", config.TLSCipherSuites, tt.wantCipherSuites)
+				}
+			})
+		}
+	})
+
 	t.Run("LoadNegative", func(t *testing.T) {
 		t.Run("MissingConfigFile", func(t *testing.T) {
 			// Save original os.Args and restore after test

--- a/internal/apiserver/server/server.go
+++ b/internal/apiserver/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/internal/apiserver/readiness"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/clientset"
 	ucom "github.com/llm-d/llm-d-batch-gateway/internal/util/com"
+	utls "github.com/llm-d/llm-d-batch-gateway/internal/util/tls"
 )
 
 type Server struct {
@@ -171,11 +172,36 @@ func (s *Server) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		minVersion, err := utls.ParseMinVersion(s.config.TLSMinVersion)
+		if err != nil {
+			return fmt.Errorf("failed to configure TLS: %w", err)
+		}
+		cipherSuites, err := utls.ParseCipherSuites(s.config.TLSCipherSuites)
+		if err != nil {
+			return fmt.Errorf("failed to configure TLS: %w", err)
+		}
+		if minVersion >= tls.VersionTLS13 && len(cipherSuites) > 0 {
+			s.logger.Info("--tls-cipher-suites has no effect with TLS 1.3; cipher suites are fixed by the TLS 1.3 specification")
+			cipherSuites = nil
+		}
 		httpserver.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
+			MinVersion:   minVersion,
+			CipherSuites: cipherSuites,
+			NextProtos:   []string{"h2", "http/1.1"},
 		}
-		s.logger.Info("API server TLS configured", "minVersion", "TLS 1.2")
+		minVersionLog := s.config.TLSMinVersion
+		if minVersionLog == "" {
+			minVersionLog = "VersionTLS12"
+		}
+		cipherSuitesLog := s.config.TLSCipherSuites
+		if cipherSuitesLog == "" {
+			cipherSuitesLog = "Go defaults"
+		}
+		s.logger.Info("API server TLS configured",
+			"minVersion", minVersionLog,
+			"cipherSuites", cipherSuitesLog,
+		)
 	} else if s.config.SSLCertFile != "" || s.config.SSLKeyFile != "" {
 		err := fmt.Errorf("both tls-cert-file and tls-private-key-file must be provided to enable TLS")
 		return err

--- a/internal/util/tls/profile.go
+++ b/internal/util/tls/profile.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+// ParseMinVersion converts a TLS version name to its crypto/tls constant.
+// An empty string defaults to TLS 1.2 for backward compatibility.
+func ParseMinVersion(v string) (uint16, error) {
+	switch v {
+	case "", "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q: must be VersionTLS12 or VersionTLS13", v)
+	}
+}
+
+// ParseCipherSuites converts a comma-separated list of cipher suite names
+// to their uint16 IDs. An empty string returns nil (Go default cipher list).
+// Only cipher suites from tls.CipherSuites() (secure) are accepted.
+func ParseCipherSuites(s string) ([]uint16, error) {
+	if s == "" {
+		return nil, nil
+	}
+
+	secure := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		secure[cs.Name] = cs.ID
+	}
+
+	insecure := make(map[string]bool)
+	for _, cs := range tls.InsecureCipherSuites() {
+		insecure[cs.Name] = true
+	}
+
+	parts := strings.Split(s, ",")
+	ids := make([]uint16, 0, len(parts))
+	for _, name := range parts {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if id, ok := secure[name]; ok {
+			ids = append(ids, id)
+			continue
+		}
+		if insecure[name] {
+			return nil, fmt.Errorf("cipher suite %q is insecure and not supported", name)
+		}
+		return nil, fmt.Errorf("unknown cipher suite %q", name)
+	}
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	return ids, nil
+}

--- a/internal/util/tls/profile_test.go
+++ b/internal/util/tls/profile_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestParseMinVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{
+			name:  "empty string defaults to TLS 1.2",
+			input: "",
+			want:  tls.VersionTLS12,
+		},
+		{
+			name:  "VersionTLS12",
+			input: "VersionTLS12",
+			want:  tls.VersionTLS12,
+		},
+		{
+			name:  "VersionTLS13",
+			input: "VersionTLS13",
+			want:  tls.VersionTLS13,
+		},
+		{
+			name:    "VersionTLS10 rejected",
+			input:   "VersionTLS10",
+			wantErr: true,
+		},
+		{
+			name:    "VersionTLS11 rejected",
+			input:   "VersionTLS11",
+			wantErr: true,
+		},
+		{
+			name:    "numeric version rejected",
+			input:   "1.2",
+			wantErr: true,
+		},
+		{
+			name:    "garbage rejected",
+			input:   "garbage",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseMinVersion(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseMinVersion(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Fatalf("ParseMinVersion(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCipherSuites(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "empty string returns nil",
+			input:   "",
+			wantNil: true,
+		},
+		{
+			name:    "single valid cipher",
+			input:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantLen: 1,
+		},
+		{
+			name:    "multiple valid ciphers",
+			input:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			wantLen: 2,
+		},
+		{
+			name:    "whitespace trimmed",
+			input:   " TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ",
+			wantLen: 2,
+		},
+		{
+			name:    "trailing comma ignored",
+			input:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,",
+			wantLen: 1,
+		},
+		{
+			name:    "unknown cipher rejected",
+			input:   "UNKNOWN_CIPHER",
+			wantErr: true,
+		},
+		{
+			name:    "insecure cipher rejected",
+			input:   "TLS_RSA_WITH_RC4_128_SHA",
+			wantErr: true,
+		},
+		{
+			name:    "only whitespace returns nil",
+			input:   " , , ",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCipherSuites(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseCipherSuites(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if tt.wantNil && got != nil {
+				t.Fatalf("ParseCipherSuites(%q) = %v, want nil", tt.input, got)
+			}
+			if !tt.wantNil && len(got) != tt.wantLen {
+				t.Fatalf("ParseCipherSuites(%q) returned %d IDs, want %d", tt.input, len(got), tt.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

The batch-gateway API server hardcodes `tls.VersionTLS12` as the minimum TLS version when TLS is enabled, with no cipher suite control and no ALPN (`NextProtos`). This means the server cannot honor the cluster TLS profile — if an administrator sets the profile to Modern or Custom, the batch-gateway ignores it. Per OCP TLS guidance, all TLS servers must respect the configurable cluster profile. The deploying operator needs a mechanism to project profile values into the batch-gateway at runtime.

## What does this PR do?

Adds `--tls-min-version` and `--tls-cipher-suites` CLI flags to the API server so the deploying operator can pass cluster TLS profile values as container args.

- **`--tls-min-version`**: Accepts `VersionTLS12` (default) or `VersionTLS13`. Empty string preserves the existing TLS 1.2 floor for backward compatibility.
- **`--tls-cipher-suites`**: Accepts a comma-separated list of secure cipher suite names (from `tls.CipherSuites()`). Rejects insecure suites explicitly. Empty string uses Go's default secure cipher list.
- Sets `NextProtos: ["h2", "http/1.1"]` for proper HTTP/2 ALPN negotiation when TLS is enabled.
- Warns and clears cipher suites when combined with TLS 1.3 (Go ignores `CipherSuites` for TLS 1.3 per spec).
- TLS flag validation only runs when SSL is enabled (`SSLCertFile` + `SSLKeyFile` provided), avoiding false errors or silent misconfiguration on plain-HTTP deployments.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

