### PR TITLE
enh: use single context with cancel cause in `Processor#runJob()`

### DIFF
--- a/internal/processor/batchctx/batchctx.go
+++ b/internal/processor/batchctx/batchctx.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package batchctx defines the cancellation causes carried by a batch job's
+// abort context and maps them back to routing sentinels.
+//
+// runJob drives every phase from a single context created with
+// context.WithCancelCause. Each source records a distinct cause by calling the
+// cancel func with a sentinel — first call wins, because cancelling a context
+// propagates the cause down to its not-yet-cancelled descendants but never
+// overwrites an already-cancelled one:
+//
+//	base := context.WithoutCancel(parent)
+//	if !deadline.IsZero() {
+//		base, stopDeadline = context.WithDeadline(base, deadline) // -> DeadlineExceeded
+//	}
+//	ctx, cause := context.WithCancelCause(base)
+//	// user cancel:  cause(batchctx.ErrCancelled)
+//	// SIGTERM:       cause(batchctx.ErrShutdown)
+//	// reconciler:    cause(context.Canceled)   // neutral
+//
+// Read the outcome with batchctx.Cause(ctx).
+package batchctx
+
+import (
+	"context"
+	"errors"
+)
+
+// Cause sentinels carried by an abort context. Expiry is reported as the stdlib
+// context.DeadlineExceeded (so it composes with context.WithDeadline and any
+// existing deadline checks); Cause maps that to ErrExpired for routing.
+var (
+	// ErrCancelled signals a user-initiated batch job cancellation.
+	ErrCancelled = errors.New("batch job cancelled")
+	// ErrShutdown signals that the processor is shutting down (SIGTERM).
+	ErrShutdown = errors.New("processor shutting down")
+	// ErrExpired signals that the batch SLO deadline was reached.
+	ErrExpired = errors.New("batch SLO expired")
+)
+
+// Cause maps ctx's cancellation cause to a routing sentinel, or nil if ctx was
+// not cancelled for a known reason. A neutral context.Canceled (a reconciler
+// abort or cleanup) maps to nil so it routes as a system error, not a terminal
+// user/shutdown/expiry state.
+func Cause(ctx context.Context) error {
+	switch cause := context.Cause(ctx); {
+	case errors.Is(cause, context.DeadlineExceeded):
+		return ErrExpired
+	case errors.Is(cause, ErrCancelled):
+		return ErrCancelled
+	case errors.Is(cause, ErrShutdown):
+		return ErrShutdown
+	default:
+		return nil
+	}
+}
+
+// IsTerminal reports whether err is one of the expected terminal routing
+// sentinels (ErrExpired, ErrCancelled, ErrShutdown) rather than a system error.
+// These represent normal end states of a batch job, so callers use it to skip
+// error-level logging and span error recording.
+func IsTerminal(err error) bool {
+	return errors.Is(err, ErrExpired) ||
+		errors.Is(err, ErrCancelled) ||
+		errors.Is(err, ErrShutdown)
+}

--- a/internal/processor/batchctx/batchctx_test.go
+++ b/internal/processor/batchctx/batchctx_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batchctx
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCause(t *testing.T) {
+	tests := []struct {
+		name string
+		// build returns the context whose Cause is under test.
+		build func() context.Context
+		want  error
+	}{
+		{
+			name:  "not cancelled",
+			build: func() context.Context { return context.Background() },
+			want:  nil,
+		},
+		{
+			name: "user cancel",
+			build: func() context.Context {
+				ctx, cause := context.WithCancelCause(context.Background())
+				cause(ErrCancelled)
+				return ctx
+			},
+			want: ErrCancelled,
+		},
+		{
+			name: "shutdown",
+			build: func() context.Context {
+				ctx, cause := context.WithCancelCause(context.Background())
+				cause(ErrShutdown)
+				return ctx
+			},
+			want: ErrShutdown,
+		},
+		{
+			name: "expired deadline",
+			build: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+				t.Cleanup(cancel)
+				return ctx
+			},
+			want: ErrExpired,
+		},
+		{
+			name: "neutral cancel maps to nil",
+			build: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Cause(tt.build()); !errors.Is(got, tt.want) {
+				t.Fatalf("Cause = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "expired", err: ErrExpired, want: true},
+		{name: "cancelled", err: ErrCancelled, want: true},
+		{name: "shutdown", err: ErrShutdown, want: true},
+		{name: "wrapped terminal", err: fmt.Errorf("finalize: %w", ErrCancelled), want: true},
+		{name: "neutral canceled", err: context.Canceled, want: false},
+		{name: "system error", err: errors.New("boom"), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminal(tt.err); got != tt.want {
+				t.Fatalf("IsTerminal(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCause_FirstCauseWins verifies the load-bearing property of the nested-layer
+// design: when several sources fire on one abort context, Cause reports whichever
+// tripped first, regardless of the layer's position — a later cancellation is a
+// no-op on an already-cancelled context.
+func TestCause_FirstCauseWins(t *testing.T) {
+	tests := []struct {
+		name string
+		// build stacks a shutdown (outer) and user-cancel (inner) layer, then trips
+		// them in a specific order; it returns the innermost work context.
+		build func() context.Context
+		want  error
+	}{
+		{
+			name: "user cancel before shutdown",
+			build: func() context.Context {
+				base, tripShutdown := context.WithCancelCause(context.Background())
+				ctx, cancelUser := context.WithCancelCause(base)
+				cancelUser(ErrCancelled)  // first
+				tripShutdown(ErrShutdown) // no-op on the already-cancelled inner layer
+				return ctx
+			},
+			want: ErrCancelled,
+		},
+		{
+			name: "shutdown before user cancel",
+			build: func() context.Context {
+				base, tripShutdown := context.WithCancelCause(context.Background())
+				ctx, cancelUser := context.WithCancelCause(base)
+				tripShutdown(ErrShutdown) // first: propagates down to the inner layer
+				cancelUser(ErrCancelled)  // no-op on the already-cancelled inner layer
+				return ctx
+			},
+			want: ErrShutdown,
+		},
+		{
+			name: "neutral cause wins over later terminal causes",
+			build: func() context.Context {
+				ctx, cause := context.WithCancelCause(context.Background())
+				cause(context.Canceled) // neutral, first
+				cause(ErrCancelled)     // no-op
+				return ctx
+			},
+			want: nil, // neutral fired first -> not a terminal routing cause
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Cause(tt.build()); !errors.Is(got, tt.want) {
+				t.Fatalf("Cause = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/processor/worker/cancel.go
+++ b/internal/processor/worker/cancel.go
@@ -45,9 +45,9 @@ func (p *Processor) watchCancel(ctx context.Context, params *jobExecutionParams)
 			if event.Type == db.BatchEventCancel {
 				logger.V(logging.INFO).Info("watchCancel: cancel event received")
 
-				// userCancelFn marks userCancelCtx as cancelled. requestAbortCtx is
-				// automatically cancelled via context.AfterFunc wired in runJob.
-				params.userCancelFn()
+				// Trip the user-cancel layer so batchctx.Cause attributes the
+				// stop to a user cancellation.
+				params.cancelUser()
 
 				// We don't update the DB status to 'cancelling' here because
 				// the API server already wrote 'cancelling' before sending this event.

--- a/internal/processor/worker/errors.go
+++ b/internal/processor/worker/errors.go
@@ -19,25 +19,14 @@ package worker
 import "errors"
 
 // Sentinel errors used for routing within the processor worker.
+// The cancellation-cause sentinels (cancelled / expired / shutdown) live in the
+// batchctx package, which owns the abort context and its cause mapping.
 
 var (
-	// errCancelled signals a user-initiated batch job cancellation.
-	// Returned by preprocessor and executor when userCancelCtx is cancelled.
-	errCancelled = errors.New("batch job cancelled")
-
-	// errExpired signals that the batch SLO deadline was reached during execution.
-	// Returned by executor when the SLO context expires.
-	errExpired = errors.New("batch SLO expired")
-
 	// errRequestInputRead signals a fatal failure reading a request entry from the
 	// plan input file. Unlike per-request errors (which are embedded in output),
 	// this prevents the entire model from processing further.
 	errRequestInputRead = errors.New("failed to read request from input file")
-
-	// errShutdown signals that the processor is shutting down (SIGTERM).
-	// The job is left in its current non-terminal state for the orphan
-	// reconciler to detect and transition to a terminal state.
-	errShutdown = errors.New("processor shutting down")
 
 	// errFinalizeFailedOver signals that a terminal status transition (completed,
 	// cancelled) or an upload failed, but the fallback to failed status with

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -100,19 +100,27 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	// Finally, start and wait for completion.
 	counts, execErr := executor.Execute(ctx)
 
-	// Classify the terminal state from the abort cause (first-cause-wins). Expiry
-	// and user cancel are terminal regardless of progress; a shutdown that lands
-	// after every request already succeeded is ignored so the job still finalizes.
-	// Any other stop surfaces the executor's own error (nil on the happy path).
-	switch cause := batchctx.Cause(ctx); {
+	return counts, classifyOutcome(batchctx.Cause(ctx), counts, execErr)
+}
+
+// classifyOutcome maps the abort cause, request counts, and executor error to the
+// job's terminal error (nil = complete). Expiry and user cancel are terminal
+// regardless of progress; a shutdown that lands after every request already
+// succeeded is ignored so the job still finalizes. Any other stop surfaces the
+// executor's own error (nil on the happy path).
+func classifyOutcome(cause error, counts *openai.BatchRequestCounts, execErr error) error {
+	switch {
 	case errors.Is(cause, batchctx.ErrExpired), errors.Is(cause, batchctx.ErrCancelled):
-		return counts, cause
-	case counts.AllSucceeded():
-		return counts, nil
+		return cause
 	case errors.Is(cause, batchctx.ErrShutdown):
-		return counts, cause
+		if counts.AllSucceeded() {
+			return nil // finished before shutdown landed — let the job finalize
+		}
+		return cause
 	}
-	return counts, execErr
+	// No terminal cause: surface the executor's error, if any (e.g. a persistence
+	// failure that arrived after every request was recorded as completed).
+	return execErr
 }
 
 func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, logger logr.Logger) (pipeline.RequestDispatcher, error) {

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -9,12 +10,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 )
 
-func (p *Processor) executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
+func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Starting execution (v2 pipeline)")
 
@@ -39,11 +41,10 @@ func (p *Processor) executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx 
 		return nil, err
 	}
 
+	// A zero SLODeadline means "no SLO"; the source treats it accordingly.
 	var sloDeadline time.Time
-	var hasSLO bool
-	if dl, ok := sloCtx.Deadline(); ok {
-		sloDeadline = dl
-		hasSLO = true
+	if params.task != nil {
+		sloDeadline = params.task.SLO
 	}
 
 	logPassThroughHeaders(params, logger)
@@ -67,7 +68,6 @@ func (p *Processor) executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx 
 		Cfg:                p.cfg,
 		PassThroughHeaders: params.jobInfo.PassThroughHeaders,
 		SLODeadline:        sloDeadline,
-		HasSLO:             hasSLO,
 		TenantID:           params.jobInfo.TenantID,
 		Logger:             logger,
 	})
@@ -98,20 +98,21 @@ func (p *Processor) executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx 
 	})
 
 	// Finally, start and wait for completion.
-	counts, execErr := executor.Execute(requestAbortCtx)
+	counts, execErr := executor.Execute(ctx)
 
-	switch {
-	case sloCtx.Err() == context.DeadlineExceeded:
-		return counts, errExpired
-	case userCancelCtx.Err() != nil:
-		return counts, errCancelled
-	case ctx.Err() != nil && !counts.AllSucceeded():
-		return counts, errShutdown
-	case execErr != nil:
-		return counts, execErr
+	// Classify the terminal state from the abort cause (first-cause-wins). Expiry
+	// and user cancel are terminal regardless of progress; a shutdown that lands
+	// after every request already succeeded is ignored so the job still finalizes.
+	// Any other stop surfaces the executor's own error (nil on the happy path).
+	switch cause := batchctx.Cause(ctx); {
+	case errors.Is(cause, batchctx.ErrExpired), errors.Is(cause, batchctx.ErrCancelled):
+		return counts, cause
+	case counts.AllSucceeded():
+		return counts, nil
+	case errors.Is(cause, batchctx.ErrShutdown):
+		return counts, cause
 	}
-
-	return counts, nil
+	return counts, execErr
 }
 
 func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, logger logr.Logger) (pipeline.RequestDispatcher, error) {

--- a/internal/processor/worker/executor.go
+++ b/internal/processor/worker/executor.go
@@ -51,6 +51,6 @@ func newBatchRequestID(requestID string) string {
 
 // Deprecated: executeJob delegates to executeJobAsync. Kept so existing
 // tests compile until they are migrated or removed.
-func (p *Processor) executeJob(ctx, sloCtx, userCancelCtx, requestAbortCtx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
-	return p.executeJobAsync(ctx, sloCtx, userCancelCtx, requestAbortCtx, params)
+func (p *Processor) executeJob(ctx context.Context, params *jobExecutionParams) (*openai.BatchRequestCounts, error) {
+	return p.executeJobAsync(ctx, params)
 }

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -17,6 +17,7 @@ import (
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
 	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
@@ -39,7 +40,7 @@ func TestExecuteJob_SingleModel(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
@@ -110,7 +111,7 @@ func TestExecuteJob_MultipleModels(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1", "m2": "m2"})
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
@@ -165,41 +166,36 @@ func TestExecuteJob_ContextCancelled(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	ctx, cancel := context.WithCancel(testLoggerCtx(t))
-	cancel()
+	// Cancel with the batchctx.ErrCancelled cause so batchctx.Cause classifies this as a
+	// user cancellation (a bare cancel is the neutral cause and routes to execErr).
+	ctx, cancel := context.WithCancelCause(testLoggerCtx(t))
+	cancel(batchctx.ErrCancelled)
 
-	_, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	_, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
 	if err == nil {
 		t.Fatalf("expected error on cancelled context")
 	}
-	// All four contexts are the same cancelled context. sloCtx.Err() == context.Canceled
-	// (not DeadlineExceeded), so the SLO branch is skipped. userCancelCtx.Err() != nil,
-	// so the drain switch routes to errCancelled.
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled, got: %v", err)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled, got: %v", err)
 	}
 }
 
-// TestExecuteJob_UserCancelFlag verifies that when only userCancelCtx is cancelled
-// (ctx, sloCtx, and requestAbortCtx all remain alive), executeJob returns errCancelled.
-// This enforces the separation contract: userCancelCtx is an independent signal derived
-// from context.Background() in production. requestAbortCtx must NOT be cancelled here —
-// the dispatch loop runs to completion, the mock returns a normal response, and the
-// post-execution switch detects userCancelCtx.Err() to produce errCancelled.
-// If requestAbortCtx were also cancelled, the test would pass even if the two contexts
-// were conflated, hiding regressions.
+// TestExecuteJob_UserCancelFlag verifies that a user cancel (batchctx.ErrCancelled cause)
+// which arrives after the request has already completed still routes to batchctx.ErrCancelled,
+// so the job is not finalized as completed. The mock returns a normal response and
+// trips the cause, exercising the batchctx.ErrCancelled branch winning over AllSucceeded.
 func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
-	userCancelCtx, cancelFn := context.WithCancel(context.Background())
+	ctx, cancelFn := context.WithCancelCause(testLoggerCtx(t))
 
 	mock := &mockInferenceClient{
 		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			cancelFn()
+			cancelFn(batchctx.ErrCancelled)
 			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
 		},
 	}
@@ -209,14 +205,12 @@ func TestExecuteJob_UserCancelFlag(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	ctx := testLoggerCtx(t)
-
-	counts, err := env.p.executeJob(ctx, ctx, userCancelCtx, ctx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled, got: %v", err)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled, got: %v", err)
 	}
 	if counts == nil || counts.Total != 1 {
 		t.Fatalf("expected counts with Total=1, got %+v", counts)
@@ -228,19 +222,19 @@ func TestExecuteJob_UserCancelFlag(t *testing.T) {
 
 // TestExecuteJob_CancelAfterAllRequestsComplete verifies that if userCancelCtx is cancelled
 // after all requests have already been dispatched and completed successfully (i.e. context
-// cancellation never interrupted dispatch), executeJob still returns errCancelled rather than
+// cancellation never interrupted dispatch), executeJob still returns batchctx.ErrCancelled rather than
 // nil, preventing the job from being finalized as "completed".
 func TestExecuteJob_CancelAfterAllRequestsComplete(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
-	userCancelCtx, abortFn := context.WithCancel(context.Background())
+	ctx, abortFn := context.WithCancelCause(testLoggerCtx(t))
 
-	// The mock cancels userCancelCtx after the inference call returns, simulating
+	// The mock trips the ErrCancelled cause after the inference call returns, simulating
 	// the race where the cancel event arrives while (or just after) the last request completes.
 	mock := &mockInferenceClient{
 		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			abortFn()
+			abortFn(batchctx.ErrCancelled)
 			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
 		},
 	}
@@ -250,30 +244,29 @@ func TestExecuteJob_CancelAfterAllRequestsComplete(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	ctx := testLoggerCtx(t)
-	_, err := env.p.executeJob(ctx, ctx, userCancelCtx, ctx, &jobExecutionParams{
+	_, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled when cancel arrives after all requests complete, got: %v", err)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled when cancel arrives after all requests complete, got: %v", err)
 	}
 }
 
 // TestExecuteJob_SIGTERMAfterAllComplete verifies that when all requests finish successfully
-// and SIGTERM arrives before executeJob returns, the function returns nil (not errShutdown).
+// and SIGTERM arrives before executeJob returns, the function returns nil (not batchctx.ErrShutdown).
 // This ensures the caller proceeds to finalizeJob (which uses a detached context) rather than
-// taking the errShutdown path (which leaves the job for the orphan reconciler).
+// taking the batchctx.ErrShutdown path (which leaves the job for the orphan reconciler).
 func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
 
-	// ctx (processor/main context) is cancelled after the inference call returns,
+	// ctx is tripped with the ErrShutdown cause after the inference call returns,
 	// simulating SIGTERM arriving just after the last request completes.
-	mainCtx, mainCancel := context.WithCancel(testLoggerCtx(t))
+	mainCtx, mainCancel := context.WithCancelCause(testLoggerCtx(t))
 	mock := &mockInferenceClient{
 		generateFn: func(_ context.Context, _ *inference.GenerateRequest) (*inference.GenerateResponse, *inference.ClientError) {
-			mainCancel()
+			mainCancel(batchctx.ErrShutdown)
 			return &inference.GenerateResponse{RequestID: "srv", Response: []byte(`{"ok":true}`)}, nil
 		},
 	}
@@ -283,8 +276,7 @@ func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	userCancelCtx := context.Background()
-	counts, err := env.p.executeJob(mainCtx, mainCtx, userCancelCtx, mainCtx, &jobExecutionParams{
+	counts, err := env.p.executeJob(mainCtx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
@@ -302,10 +294,10 @@ func TestExecuteJob_SIGTERMAfterAllComplete(t *testing.T) {
 }
 
 // TestExecuteJob_AbortCtxCancel_AbortsInflightRequests verifies that a user cancel aborts
-// in-flight inference requests. The test calls both userCancelFn() (user-cancel signal) and
-// requestAbortFn() (stops dispatch), mirroring watchCancel's production behavior. The mock
-// blocks until requestAbortCtx cancellation propagates to its ctx argument. executeJob must
-// return errCancelled with the in-flight request counted as failed.
+// in-flight inference requests. The test trips params.cancelUser(), mirroring
+// watchCancel's production behavior. The mock blocks until the abort context propagates to
+// its ctx argument. executeJob must return batchctx.ErrCancelled with the in-flight request counted
+// as failed.
 func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -329,17 +321,16 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	ctx := testLoggerCtx(t)
-	// userCancelCtx must be background-derived (user-cancel-only signal, no parent propagation).
-	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
-	// requestAbortCtx is pre-set in params before the goroutine starts, matching the production
-	// flow where runJob sets requestAbortFn before starting watchCancel.
-	requestAbortCtx, requestAbortFn := context.WithCancel(ctx)
+	// cancelUser is pre-set in params before the goroutine starts, matching the production
+	// flow where runJob sets params.cancelUser (a closure baking the ErrCancelled cause)
+	// before starting watchCancel.
+	ctx, cause := context.WithCancelCause(testLoggerCtx(t))
+	cancelUser := func() { cause(batchctx.ErrCancelled) }
 
 	params := &jobExecutionParams{
-		updater:        env.updater,
-		jobInfo:        jobInfo,
-		requestAbortFn: requestAbortFn,
+		updater:    env.updater,
+		jobInfo:    jobInfo,
+		cancelUser: cancelUser,
 	}
 	type result struct {
 		counts *openai.BatchRequestCounts
@@ -347,19 +338,18 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, ctx, userCancelCtx, requestAbortCtx, params)
+		counts, err := env.p.executeJob(ctx, params)
 		resCh <- result{counts, err}
 	}()
 
 	<-inferStarted
-	// Simulate watchCancel: set userCancelCtx (user-cancel signal) and stop dispatch via requestAbortFn.
-	userCancelFn()
-	requestAbortFn()
+	// Simulate watchCancel tripping the user-cancel layer, which aborts dispatch.
+	cancelUser()
 
 	select {
 	case res := <-resCh:
-		if !errors.Is(res.err, errCancelled) {
-			t.Fatalf("expected errCancelled, got: %v", res.err)
+		if !errors.Is(res.err, batchctx.ErrCancelled) {
+			t.Fatalf("expected batchctx.ErrCancelled, got: %v", res.err)
 		}
 		if res.counts == nil {
 			t.Fatal("expected non-nil counts")
@@ -374,7 +364,7 @@ func TestExecuteJob_AbortCtxCancel_AbortsInflightRequests(t *testing.T) {
 			t.Errorf("Failed = %d, want 1 (aborted request counted as failed)", res.counts.Failed)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("executeJob did not return within 5s after userCancelCtx cancellation")
+		t.Fatal("executeJob did not return within 5s after abort cause was set")
 	}
 }
 
@@ -393,16 +383,17 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, &mockInferenceClient{}, requests, map[string]string{"m1": "m1"})
 
-	ctx := testLoggerCtx(t)
-	sloCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
+	// A past deadline makes context.Cause report DeadlineExceeded, which both drains
+	// undispatched requests as batch_expired and classifies the job as batchctx.ErrExpired.
+	ctx, cancel := context.WithDeadline(testLoggerCtx(t), time.Now().Add(-1*time.Second))
 	defer cancel()
 
-	counts, err := env.p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
-	if !errors.Is(err, errExpired) {
-		t.Fatalf("expected errExpired, got: %v", err)
+	if !errors.Is(err, batchctx.ErrExpired) {
+		t.Fatalf("expected batchctx.ErrExpired, got: %v", err)
 	}
 	if counts == nil {
 		t.Fatal("expected non-nil counts")
@@ -441,17 +432,11 @@ func TestExecuteJob_SLOExpiredBeforeDispatch(t *testing.T) {
 // TestExecuteJob_SLOExpiredDuringDispatch verifies that when the SLO deadline fires while
 // requests are being dispatched, completed requests are preserved in the output file,
 // undispatched requests are drained to the error file as batch_expired, and executeJob
-// returns errExpired with accurate partial counts.
+// returns batchctx.ErrExpired with accurate partial counts.
 //
-// Context hierarchy for SLO expiry:
-//
-//	processorCtx → sloCtx (WithDeadline) → requestAbortCtx (WithCancel)
-//	                        DeadlineExceeded        Canceled (propagated)
-//
-//	userCancelCtx (WithCancel, derived from context.Background — NOT in the chain above)
-//
-// requestAbortCtx sees Canceled to stop dispatch;
-// processModel's drain switch checks sloCtx.Err() == DeadlineExceeded to select batch_expired.
+// The single abort context carries the deadline, so context.Cause reports
+// DeadlineExceeded: dispatch stops, the drain path selects batch_expired, and the
+// post-execution switch classifies the job as batchctx.ErrExpired.
 func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -476,9 +461,8 @@ func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 	}
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
-	ctx := testLoggerCtx(t)
-	// Use context.WithDeadline so sloCtx.Err() returns DeadlineExceeded (matching real code).
-	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(100*time.Millisecond))
+	// Use context.WithDeadline so context.Cause returns DeadlineExceeded (matching real code).
+	ctx, sloCancel := context.WithDeadline(testLoggerCtx(t), time.Now().Add(100*time.Millisecond))
 	defer sloCancel()
 
 	type result struct {
@@ -487,7 +471,7 @@ func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 	}
 	resCh := make(chan result, 1)
 	go func() {
-		counts, err := env.p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+		counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 			updater: env.updater,
 			jobInfo: jobInfo,
 		})
@@ -496,8 +480,8 @@ func TestExecuteJob_SLOExpiredDuringDispatch(t *testing.T) {
 
 	select {
 	case res := <-resCh:
-		if !errors.Is(res.err, errExpired) {
-			t.Fatalf("expected errExpired, got: %v", res.err)
+		if !errors.Is(res.err, batchctx.ErrExpired) {
+			t.Fatalf("expected batchctx.ErrExpired, got: %v", res.err)
 		}
 		if res.counts == nil {
 			t.Fatal("expected non-nil counts")
@@ -562,7 +546,7 @@ func TestFinalizeJob_Success(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts)
+	err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts)
 	if err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
@@ -610,7 +594,7 @@ func TestFinalizeJob_UploadFailure(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1}
 
 	ctx := testLoggerCtx(t)
-	err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts)
+	err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts)
 	if !errors.Is(err, errFinalizeFailedOver) {
 		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
 	}
@@ -655,7 +639,7 @@ func TestExecuteJob_SeparatesSuccessAndErrors(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
@@ -735,7 +719,7 @@ func TestExecuteJob_HTTPErrorGoesToOutputFile(t *testing.T) {
 	env, jobInfo := setupExecutionJob(t, cfg, mock, requests, map[string]string{"m1": "m1"})
 
 	ctx := testLoggerCtx(t)
-	counts, err := env.p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	counts, err := env.p.executeJob(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobInfo: jobInfo,
 	})
@@ -841,7 +825,7 @@ func TestFinalizeJob_EmptyOutputFile_OutputFileIDOmitted(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 0, Failed: 1}
 
 	ctx := testLoggerCtx(t)
-	if err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts); err != nil {
+	if err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts); err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
 
@@ -891,7 +875,7 @@ func TestFinalizeJob_EmptyErrorFile_ErrorFileIDOmitted(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
 	ctx := testLoggerCtx(t)
-	if err := env.p.finalizeJob(ctx, context.Background(), env.updater, dbJob, jobInfo, counts); err != nil {
+	if err := env.p.finalizeJob(ctx, env.updater, dbJob, jobInfo, counts); err != nil {
 		t.Fatalf("finalizeJob error: %v", err)
 	}
 
@@ -934,7 +918,7 @@ func TestHandleJobError_errCancelled(t *testing.T) {
 		updater: env.updater,
 		jobItem: dbJob,
 		jobInfo: ji,
-	}, errCancelled)
+	}, batchctx.ErrCancelled)
 
 	after := gatherHistogramSampleCount(t, "batch_job_e2e_latency_seconds", map[string]string{"status": "cancelled"})
 	if delta := after - before; delta != 1 {
@@ -973,7 +957,7 @@ func TestHandleJobError_Shutdown_LeavesJobForReconciler(t *testing.T) {
 		jobItem: dbJob,
 		task:    task,
 		jobInfo: ji,
-	}, errShutdown)
+	}, batchctx.ErrShutdown)
 
 	// Job must NOT be re-enqueued — reconciler handles recovery.
 	tasks, err := env.pqClient.PQDequeue(ctx, 0, 10)
@@ -1011,7 +995,7 @@ func TestHandleJobError_Shutdown_NilTask(t *testing.T) {
 	env.p.handleJobError(ctx, &jobExecutionParams{
 		updater: env.updater,
 		jobItem: dbJob,
-	}, errShutdown)
+	}, batchctx.ErrShutdown)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-ctx-nil"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1094,7 +1078,7 @@ func TestHandleJobError_ExpiredWithCancelledCtx_StillTransitionsExpired(t *testi
 		jobItem:       dbJob,
 		jobInfo:       ji,
 		requestCounts: counts,
-	}, errExpired)
+	}, batchctx.ErrExpired)
 
 	items, _, _, err := env.dbClient.DBGet(context.Background(), &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {
@@ -1113,7 +1097,7 @@ func TestHandleJobError_ExpiredWithCancelledCtx_StillTransitionsExpired(t *testi
 }
 
 // TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired verifies that
-// handleJobError routes errExpired with nil requestCounts (SLO expired during preprocessing,
+// handleJobError routes batchctx.ErrExpired with nil requestCounts (SLO expired during preprocessing,
 // before executeJob ran) to handleExpired, which tolerates nil counts and transitions the
 // job to expired status.
 func TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired(t *testing.T) {
@@ -1134,7 +1118,7 @@ func TestHandleJobError_ExpiredDuringIngestion_NilCountsTransitionsExpired(t *te
 		jobItem:       dbJob,
 		jobInfo:       ji,
 		requestCounts: nil, // nil: SLO expired before executeJob ran
-	}, errExpired)
+	}, batchctx.ErrExpired)
 
 	items, _, _, err := env.dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{"job-expired-ingestion"}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {

--- a/internal/processor/worker/executor_test.go
+++ b/internal/processor/worker/executor_test.go
@@ -28,6 +28,39 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 )
 
+func TestClassifyOutcome(t *testing.T) {
+	persistErr := errors.New("output file flush failed")
+	allSucceeded := &openai.BatchRequestCounts{Total: 2, Completed: 2, Failed: 0}
+	partial := &openai.BatchRequestCounts{Total: 2, Completed: 1, Failed: 1}
+
+	tests := []struct {
+		name    string
+		cause   error
+		counts  *openai.BatchRequestCounts
+		execErr error
+		want    error
+	}{
+		{name: "expired wins over progress", cause: batchctx.ErrExpired, counts: allSucceeded, want: batchctx.ErrExpired},
+		{name: "cancelled wins over progress", cause: batchctx.ErrCancelled, counts: allSucceeded, want: batchctx.ErrCancelled},
+		{name: "shutdown after all succeeded finalizes", cause: batchctx.ErrShutdown, counts: allSucceeded, want: nil},
+		{name: "shutdown with work left is terminal", cause: batchctx.ErrShutdown, counts: partial, want: batchctx.ErrShutdown},
+		{name: "happy path", cause: nil, counts: allSucceeded, want: nil},
+		{name: "executor error surfaces", cause: nil, counts: partial, execErr: persistErr, want: persistErr},
+		// Regression: a persistence/flush error can arrive after every request was
+		// recorded as completed (AllSucceeded), with no cancel/expiry/shutdown cause.
+		// The outcome must be the executor error, not a masked success.
+		{name: "persistence error not masked by all-succeeded", cause: nil, counts: allSucceeded, execErr: persistErr, want: persistErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyOutcome(tt.cause, tt.counts, tt.execErr); !errors.Is(got, tt.want) {
+				t.Fatalf("classifyOutcome(%v, counts, %v) = %v, want %v", tt.cause, tt.execErr, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecuteJob_SingleModel(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/converter"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
@@ -89,7 +90,6 @@ var finalizationTimeout = 5 * time.Minute
 // creates file records in the database, and updates job status to completed.
 func (p *Processor) finalizeJob(
 	ctx context.Context,
-	userCancelCtx context.Context,
 	updater *StatusUpdater,
 	dbJob *db.BatchItem,
 	jobInfo *batch_types.JobInfo,
@@ -157,9 +157,9 @@ func (p *Processor) finalizeJob(
 	}
 
 	// Best-effort: honour a user cancel that arrived during finalization.
-	// userCancelCtx is background-derived so it only fires for explicit user cancellation;
-	// SLO expiry and SIGTERM do not propagate here.
-	if userCancelCtx.Err() != nil {
+	// Only an explicit user cancel routes here — context.Cause is batchctx.ErrCancelled
+	// exclusively for user cancellation; SLO expiry and SIGTERM are other causes.
+	if errors.Is(context.Cause(ctx), batchctx.ErrCancelled) {
 		logger.V(logging.INFO).Info("Cancel requested during finalization; finalizing as cancelled")
 		if err := updater.UpdateCancelledStatus(ioCtx, dbJob, requestCounts, outputFileID, errorFileID); err != nil {
 			logger.Error(err, "Failed to update cancelled status, falling back to failed with file IDs preserved")
@@ -169,7 +169,7 @@ func (p *Processor) finalizeJob(
 			return fmt.Errorf("cancelled status write failed: %w", errFinalizeFailedOver)
 		}
 		setRequestCountAttrs(ctx, requestCounts)
-		return errCancelled
+		return batchctx.ErrCancelled
 	}
 
 	// finalizing → completed

--- a/internal/processor/worker/finalizer_test.go
+++ b/internal/processor/worker/finalizer_test.go
@@ -14,6 +14,7 @@ import (
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
 	filesapi "github.com/llm-d/llm-d-batch-gateway/internal/files_store/api"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/converter"
@@ -284,13 +285,14 @@ func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 		},
 	}
 
-	// Simulate that the worker observed the cancel request before writing the final status.
-	cancelledCtx, cancelFn := context.WithCancel(ctx)
-	cancelFn()
+	// Simulate that the worker observed the cancel request before writing the final status:
+	// the abort context carries the batchctx.ErrCancelled cause.
+	cancelledCtx, cancelFn := context.WithCancelCause(ctx)
+	cancelFn(batchctx.ErrCancelled)
 
-	err := p.finalizeJob(ctx, cancelledCtx, updater, staleJob, jobInfo, counts)
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled, got: %v", err)
+	err := p.finalizeJob(cancelledCtx, updater, staleJob, jobInfo, counts)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled, got: %v", err)
 	}
 
 	// Verify that the final status written to the DB is cancelled, not completed.
@@ -310,9 +312,8 @@ func TestFinalizeJob_CancelRequested_FinalizesCancelled(t *testing.T) {
 }
 
 // TestFinalizeJob_ShutdownDuringFinalization_CompletesNotCancelled verifies that a SIGTERM
-// (ctx cancelled) during finalization does NOT route the job to cancelled.
-// userCancelCtx is derived from context.Background(), so SIGTERM does not propagate into it.
-// The job must transition to completed regardless of whether the parent ctx is cancelled.
+// (batchctx.ErrShutdown cause) during finalization does NOT route the job to cancelled.
+// Only the batchctx.ErrCancelled cause takes the cancel path; the job must transition to completed.
 func TestFinalizeJob_ShutdownDuringFinalization_CompletesNotCancelled(t *testing.T) {
 	cfg := config.NewConfig()
 	cfg.WorkDir = t.TempDir()
@@ -361,14 +362,11 @@ func TestFinalizeJob_ShutdownDuringFinalization_CompletesNotCancelled(t *testing
 	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
-	// Simulate SIGTERM: parent ctx is cancelled.
-	// userCancelCtx is derived from context.Background() — NOT from ctx — so it is not cancelled.
-	shutdownCtx, shutdownCancel := context.WithCancel(testLoggerCtx(t))
-	shutdownCancel() // SIGTERM fires
+	// Simulate SIGTERM: the abort context carries the ErrShutdown cause (not ErrCancelled).
+	shutdownCtx, shutdownCancel := context.WithCancelCause(testLoggerCtx(t))
+	shutdownCancel(batchctx.ErrShutdown) // SIGTERM fires
 
-	userCancelCtx := context.Background() // no user cancel
-
-	err := p.finalizeJob(shutdownCtx, userCancelCtx, updater, staleJob, jobInfo, counts)
+	err := p.finalizeJob(shutdownCtx, updater, staleJob, jobInfo, counts)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -438,7 +436,7 @@ func TestFinalizeJob_CompletedWriteFails_FallsBackToFailedWithFileIDs(t *testing
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
 	ctx := testLoggerCtx(t)
-	err := p.finalizeJob(ctx, context.Background(), updater, staleJob, jobInfo, counts)
+	err := p.finalizeJob(ctx, updater, staleJob, jobInfo, counts)
 
 	// Must return errFinalizeFailedOver (fallback succeeded).
 	if !errors.Is(err, errFinalizeFailedOver) {
@@ -514,12 +512,12 @@ func TestFinalizeJob_CancelledWriteFails_FallsBackToFailedWithFileIDs(t *testing
 	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
 	counts := &openai.BatchRequestCounts{Total: 1, Completed: 1, Failed: 0}
 
-	// userCancelCtx is cancelled → finalization takes the cancel path.
 	ctx := testLoggerCtx(t)
-	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
-	userCancelFn()
+	// The abort context carries the ErrCancelled cause → finalization takes the cancel path.
+	cancelledCtx, cancelFn := context.WithCancelCause(ctx)
+	cancelFn(batchctx.ErrCancelled)
 
-	err := p.finalizeJob(ctx, userCancelCtx, updater, staleJob, jobInfo, counts)
+	err := p.finalizeJob(cancelledCtx, updater, staleJob, jobInfo, counts)
 
 	if !errors.Is(err, errFinalizeFailedOver) {
 		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
@@ -598,7 +596,7 @@ func TestFinalizeJob_OneUploadFails_FailedWithSurvivingFileID(t *testing.T) {
 	counts := &openai.BatchRequestCounts{Total: 2, Completed: 1, Failed: 1}
 
 	ctx := testLoggerCtx(t)
-	err := p.finalizeJob(ctx, context.Background(), updater, staleJob, jobInfo, counts)
+	err := p.finalizeJob(ctx, updater, staleJob, jobInfo, counts)
 	if !errors.Is(err, errFinalizeFailedOver) {
 		t.Fatalf("expected errFinalizeFailedOver, got: %v", err)
 	}
@@ -723,7 +721,7 @@ func TestFinalizeJob_UploadsFilesInParallel(t *testing.T) {
 	jobInfo := &batch_types.JobInfo{JobID: jobID, TenantID: tenantID}
 	counts := &openai.BatchRequestCounts{Total: 2, Completed: 1, Failed: 1}
 
-	err := p.finalizeJob(ctx, context.Background(), updater, dbJob, jobInfo, counts)
+	err := p.finalizeJob(ctx, updater, dbJob, jobInfo, counts)
 	if err != nil {
 		t.Fatalf("finalizeJob returned error: %v", err)
 	}

--- a/internal/processor/worker/job_execution.go
+++ b/internal/processor/worker/job_execution.go
@@ -26,20 +26,18 @@ import (
 
 // jobExecutionParams holds the job-scoped state shared across processing stages.
 // Contexts are NOT stored here — they are passed explicitly per Go convention.
-// userCancelFn and requestAbortFn are exceptions: they are cancel functions stored
-// here so that the watchCancel goroutine can call them when a cancel event arrives.
-// userCancelFn cancels userCancelCtx (user-cancel signal, derived from context.Background).
-// requestAbortFn cancels requestAbortCtx (dispatch loop control, derived from sloCtx) to stop
-// dispatch immediately when the user cancels.
+// cancelUser is an exception: it is a no-arg closure that trips the abort
+// context's cause func with batchctx.ErrCancelled, stored here so the watchCancel
+// goroutine can call it when a user cancel event arrives. The recorded cause is
+// later read via batchctx.Cause to classify the terminal state.
 type jobExecutionParams struct {
 	updater *StatusUpdater
 	jobItem *db.BatchItem
 	jobInfo *batch_types.JobInfo
 	task    *db.BatchJobPriority
 
-	eventWatcher   *db.BatchEventsChan
-	userCancelFn   context.CancelFunc
-	requestAbortFn context.CancelFunc
+	eventWatcher *db.BatchEventsChan
+	cancelUser   context.CancelFunc
 
 	requestCounts *openai.BatchRequestCounts
 }

--- a/internal/processor/worker/job_runner.go
+++ b/internal/processor/worker/job_runner.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
@@ -105,14 +106,6 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 
 	jobStart := time.Now()
 
-	// If an SLO deadline is set, create a child context that cancels when the deadline fires.
-	// This context is passed to executeJob to bound dispatch and trigger expiration handling.
-	sloCtx, sloCancel := ctx, func() {}
-	if params.task != nil && !params.task.SLO.IsZero() {
-		sloCtx, sloCancel = context.WithDeadline(ctx, params.task.SLO)
-	}
-	defer sloCancel()
-
 	// event watcher for cancel event
 	eventWatcher, err := p.event.ECConsumerGetChannel(ctx, params.jobInfo.JobID)
 	if err != nil {
@@ -137,21 +130,33 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	}
 	defer eventWatcher.CloseFn()
 
-	// userCancelCtx is a user-cancel-only signal: it is derived from context.Background so that
-	// SIGTERM and SLO expiry do NOT propagate into it. userCancelCtx.Err() != nil exclusively means
-	// the user requested cancellation via the API.
-	userCancelCtx, userCancelFn := context.WithCancel(context.Background())
-	params.userCancelFn = userCancelFn
-	defer userCancelFn()
+	// abortCtx is the single context that drives every phase. It carries the
+	// process-batch span + logger values but records *why* it was cancelled via
+	// context.Cause, so the terminal state can be classified from one signal:
+	//   - SLO deadline  -> context.DeadlineExceeded (from WithDeadline below)
+	//   - user cancel    -> batchctx.ErrCancelled (watchCancel)
+	//   - SIGTERM        -> batchctx.ErrShutdown (AfterFunc on the parent ctx)
+	//   - reconciler/IO  -> context.Canceled (heartbeat / fatal I/O; neutral)
+	// The deadline is placed on WithoutCancel(ctx) so SIGTERM cannot mask an SLO
+	// expiry as a plain cancellation, and vice versa.
+	abortBase := context.WithoutCancel(ctx)
+	sloStop := context.CancelFunc(func() {})
+	if params.task != nil && !params.task.SLO.IsZero() {
+		abortBase, sloStop = context.WithDeadline(abortBase, params.task.SLO)
+	}
+	defer sloStop()
 
-	// requestAbortCtx is derived from sloCtx so SLO expiry and SIGTERM propagate automatically
-	// to all dispatch loops and inference calls. User cancel is wired via AfterFunc so that
-	// cancelling userCancelCtx automatically cancels requestAbortCtx without manual dispatch.
-	// Fatal I/O errors in executor.go still call requestAbortFn directly.
-	requestAbortCtx, requestAbortFn := context.WithCancel(sloCtx)
-	context.AfterFunc(userCancelCtx, requestAbortFn)
-	params.requestAbortFn = requestAbortFn
-	defer requestAbortFn()
+	// One cancel-cause func drives every phase; each source is a no-arg closure
+	// that bakes its own cause. First call wins — batchctx.Cause reads it back to
+	// classify the terminal state. The cleanup defer uses the neutral
+	// context.Canceled so a normal return is not mistaken for an abort.
+	abortCtx, abortCause := context.WithCancelCause(abortBase)
+	defer abortCause(context.Canceled)
+	params.cancelUser = func() { abortCause(batchctx.ErrCancelled) }
+
+	// SIGTERM / pod shutdown propagates from the original ctx as ErrShutdown.
+	stopShutdown := context.AfterFunc(ctx, func() { abortCause(batchctx.ErrShutdown) })
+	defer stopShutdown()
 
 	// watch for cancel event
 	params.eventWatcher = eventWatcher
@@ -160,24 +165,24 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	// Start heartbeat: periodically refreshes the in-flight entry so the
 	// orphan reconciler knows this job is still being actively processed.
 	// On each tick it also checks the DB status — if the reconciler acted
-	// (terminal status or reverted to validating), it calls requestAbortFn
-	// to stop all in-flight requests. The processor's terminal CAS write
-	// will then fail with ErrConflict, and the processor yields.
+	// (terminal status or reverted to validating), it aborts (neutral
+	// context.Canceled) to stop all in-flight requests. The processor's terminal
+	// CAS write will then fail with ErrConflict, and the processor yields.
 	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
 	defer heartbeatCancel()
-	go p.heartbeat(heartbeatCtx, params.jobItem.ID, requestAbortFn)
+	go p.heartbeat(heartbeatCtx, params.jobItem.ID, func() { abortCause(context.Canceled) })
 
 	// ingestion: pre-process job (rejects unregistered-model requests early)
-	ingestCtx, ingestSpan := uotel.StartSpan(ctx, "ingest-and-plan")
-	err = p.preProcessJob(ingestCtx, sloCtx, userCancelCtx, params.jobInfo)
-	if err != nil && !errors.Is(err, errExpired) && !errors.Is(err, errCancelled) && !errors.Is(err, errShutdown) {
+	ingestCtx, ingestSpan := uotel.StartSpan(abortCtx, "ingest-and-plan")
+	err = p.preProcessJob(ingestCtx, params.jobInfo)
+	if err != nil && !batchctx.IsTerminal(err) {
 		ingestSpan.RecordError(err)
 		ingestSpan.SetStatus(codes.Error, "pre-process failed")
 	}
 	ingestSpan.End()
 	if err != nil {
-		// errExpired, errCancelled, and errShutdown are expected terminal states, not system errors.
-		if !errors.Is(err, errExpired) && !errors.Is(err, errCancelled) && !errors.Is(err, errShutdown) {
+		// Terminal states (expired/cancelled/shutdown) are expected, not system errors.
+		if !batchctx.IsTerminal(err) {
 			logger.Error(err, "Pre-processing failed")
 		}
 		p.handleJobError(ctx, params, err)
@@ -200,10 +205,10 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	transitionedToInProgress = true
 
 	// execution: execute inference requests
-	execCtx, execSpan := uotel.StartSpan(ctx, "execute-job")
+	execCtx, execSpan := uotel.StartSpan(abortCtx, "execute-job")
 	var execErr error
-	requestCounts, execErr = p.executeJobAsync(execCtx, sloCtx, userCancelCtx, requestAbortCtx, params)
-	if execErr != nil && !errors.Is(execErr, errExpired) && !errors.Is(execErr, errCancelled) && !errors.Is(execErr, errShutdown) {
+	requestCounts, execErr = p.executeJobAsync(execCtx, params)
+	if execErr != nil && !batchctx.IsTerminal(execErr) {
 		execSpan.RecordError(execErr)
 		execSpan.SetStatus(codes.Error, "execution failed")
 	}
@@ -213,7 +218,7 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 		p.handleJobError(ctx, params, execErr)
 		// Record processing duration for any job that ran (partially or fully).
 		// executeJob always returns non-nil counts alongside its sentinel errors
-		// (errExpired, errCancelled, errShutdown, system errors) because partial
+		// (batchctx.ErrExpired, batchctx.ErrCancelled, batchctx.ErrShutdown, system errors) because partial
 		// work was done. The nil guard remains defensive for unexpected future paths.
 		if requestCounts != nil {
 			metrics.RecordJobProcessingDuration(time.Since(jobStart), metrics.GetSizeBucket(int(requestCounts.Total)))
@@ -222,8 +227,8 @@ func (p *Processor) runJob(ctx context.Context, params *jobExecutionParams) {
 	}
 
 	// finalization: upload output, update status to completed
-	if err := p.finalizeJob(ctx, userCancelCtx, params.updater, params.jobItem, params.jobInfo, requestCounts); err != nil {
-		if errors.Is(err, errCancelled) {
+	if err := p.finalizeJob(abortCtx, params.updater, params.jobItem, params.jobInfo, requestCounts); err != nil {
+		if errors.Is(err, batchctx.ErrCancelled) {
 			// Cancel arrived during finalization — DB already updated to cancelled.
 			// Treat as successful cancellation (same as handleCancelled).
 			// Use background context: ctx may be cancelled (SIGTERM) and cleanup is local I/O only.
@@ -305,9 +310,9 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 	logger := logr.FromContextOrDiscard(ctx)
 
 	switch {
-	case errors.Is(err, errCancelled):
+	case errors.Is(err, batchctx.ErrCancelled):
 		// User-initiated cancel at any phase. requestCounts is nil for ingestion-phase cancels
-		// (preProcessJob returns errCancelled before execution begins) and non-nil for
+		// (preProcessJob returns batchctx.ErrCancelled before execution begins) and non-nil for
 		// execution-phase cancels (executeJob returns partial counts). handleCancelled
 		// uses requestCounts == nil as the signal to skip partial-output upload.
 		if cancelErr := p.handleCancelled(ctx, params); cancelErr != nil {
@@ -318,7 +323,7 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 			}
 		}
 
-	case errors.Is(err, errExpired):
+	case errors.Is(err, batchctx.ErrExpired):
 		// SLO deadline reached. requestCounts may be nil if SLO expired during preprocessing
 		// (before executeJob ran). handleExpired and UpdateExpiredStatus both tolerate nil
 		// counts — the DB field is left at zero, which is correct since no requests were processed.
@@ -326,7 +331,7 @@ func (p *Processor) handleJobError(ctx context.Context, params *jobExecutionPara
 			logger.Error(expiredErr, "Failed to finalize expired job")
 		}
 
-	case errors.Is(err, errShutdown):
+	case errors.Is(err, batchctx.ErrShutdown):
 		// SIGTERM received — leave the job in its current state for the orphan
 		// reconciler to handle. The reconciler detects non-terminal jobs that
 		// are not in the queue and have a stale (or missing) in-flight entry,

--- a/internal/processor/worker/job_runner_test.go
+++ b/internal/processor/worker/job_runner_test.go
@@ -12,6 +12,7 @@ import (
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
 	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/converter"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
@@ -732,7 +733,7 @@ func TestRunJob_FinalizeFailedOver_PreservesFileIDsAndDoesNotCallHandleFailed(t 
 	}
 }
 
-// TestHandleJobError_Shutdown_LeavesJobInProgress verifies that errShutdown
+// TestHandleJobError_Shutdown_LeavesJobInProgress verifies that batchctx.ErrShutdown
 // does NOT re-enqueue or call handleFailed. The job stays in_progress for
 // the orphan reconciler to detect and transition to a terminal state.
 func TestHandleJobError_Shutdown_LeavesJobInProgress(t *testing.T) {
@@ -782,7 +783,7 @@ func TestHandleJobError_Shutdown_LeavesJobInProgress(t *testing.T) {
 		task:          &db.BatchJobPriority{ID: jobID},
 	}
 
-	p.handleJobError(ctx, params, errShutdown)
+	p.handleJobError(ctx, params, batchctx.ErrShutdown)
 
 	items, _, _, err := dbClient.DBGet(ctx, &db.BatchQuery{BaseQuery: db.BaseQuery{IDs: []string{jobID}}}, true, 0, 1)
 	if err != nil || len(items) != 1 {

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -34,6 +33,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/metrics"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
@@ -47,9 +47,20 @@ import (
 // error entries for requests targeting unregistered models.
 // The rejected count is persisted in model_map.json so executeJob can
 // seed BatchRequestCounts.Failed without an extra parameter.
-func (p *Processor) preProcessJob(ctx, sloCtx, userCancelCtx context.Context, jobInfo *batch_types.JobInfo) error {
+func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobInfo) (err error) {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Pre-processing job") // job id is in the logger already
+
+	// The single ctx now also cancels the input-file download, so an I/O error
+	// may actually be an abort in disguise. If ctx was cancelled for a known
+	// reason, route to that terminal sentinel rather than a generic failure.
+	defer func() {
+		if err != nil {
+			if s := batchctx.Cause(ctx); s != nil {
+				err = s
+			}
+		}
+	}()
 	planBuildStart := time.Now()
 	jobID := jobInfo.JobID
 	inputFileID := jobInfo.BatchJob.InputFileID
@@ -130,18 +141,11 @@ func (p *Processor) preProcessJob(ctx, sloCtx, userCancelCtx context.Context, jo
 	inputFileReader := bufio.NewReaderSize(reader, 1024*1024)
 
 	for {
-		// Priority: SLO expiry > user cancel > pod shutdown, matching processModel's
-		// drain switch. This ensures a user cancel is honoured even when SIGTERM arrives
-		// concurrently, instead of re-enqueueing a job the user asked to cancel.
-		if errors.Is(sloCtx.Err(), context.DeadlineExceeded) {
-			return errExpired
-		}
-		if userCancelCtx.Err() != nil {
-			logger.V(logging.INFO).Info("preProcess: cancel requested")
-			return errCancelled
-		}
-		if ctx.Err() != nil {
-			return errShutdown
+		// The abort context records why it stopped (SLO / user cancel / SIGTERM);
+		// batchctx.Cause maps that to the terminal routing sentinel. First-cause
+		// wins, so a user cancel racing SIGTERM is honoured by whichever fired first.
+		if s := batchctx.Cause(ctx); s != nil {
+			return s
 		}
 
 		// read a line from the input file

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -51,11 +52,12 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.V(logging.INFO).Info("Pre-processing job") // job id is in the logger already
 
-	// The single ctx now also cancels the input-file download, so an I/O error
-	// may actually be an abort in disguise. If ctx was cancelled for a known
-	// reason, route to that terminal sentinel rather than a generic failure.
+	// The single ctx now also cancels the input-file download, so a cancellation
+	// can surface as an I/O error. Reclassify only errors that actually stem from
+	// ctx cancellation (they wrap ctx.Err()); a genuine preprocessing failure that
+	// merely races a cancel must still surface as-is with its diagnostics.
 	defer func() {
-		if err != nil {
+		if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 			if s := batchctx.Cause(ctx); s != nil {
 				err = s
 			}

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -483,6 +483,35 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 }
 
 // TestPreProcess_CancelBeforeSIGTERM_ReturnsErrCancelled verifies first-cause-wins:
+// TestPreProcess_GenuineErrorNotMaskedByCancel verifies that a real preprocessing
+// failure which coincides with a cancelled context surfaces as itself, not
+// reclassified as a terminal cancel/expiry/shutdown. The empty-InputFileID check
+// returns before the loop's cause-check, so only the deferred wrapper could mask it.
+func TestPreProcess_GenuineErrorNotMaskedByCancel(t *testing.T) {
+	p := mustNewProcessor(t, config.NewConfig(), &clientset.Clientset{})
+
+	// Context is cancelled with a user-cancel cause...
+	ctx, cancel := context.WithCancelCause(testLoggerCtx(t))
+	cancel(batchctx.ErrCancelled)
+
+	// ...but the failure is a genuine config error, not a cancellation.
+	jobInfo := &batch_types.JobInfo{
+		JobID:    "job-genuine-err",
+		BatchJob: &openai.Batch{BatchSpec: openai.BatchSpec{InputFileID: ""}},
+	}
+
+	err := p.preProcessJob(ctx, jobInfo)
+	if err == nil {
+		t.Fatal("expected an error for empty input file ID")
+	}
+	if batchctx.IsTerminal(err) {
+		t.Fatalf("genuine error was masked as a terminal state: %v", err)
+	}
+	if !strings.Contains(err.Error(), "input file ID is empty") {
+		t.Fatalf("expected 'input file ID is empty', got: %v", err)
+	}
+}
+
 // when a user cancel is recorded before a later SIGTERM on the same abort context,
 // preProcessJob returns batchctx.ErrCancelled — the shutdown is a no-op on the
 // already-cancelled context, so the job is cancelled rather than left for the reconciler.

--- a/internal/processor/worker/preprocessor_test.go
+++ b/internal/processor/worker/preprocessor_test.go
@@ -15,6 +15,7 @@ import (
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	mockdb "github.com/llm-d/llm-d-batch-gateway/internal/database/mock"
 	mockfiles "github.com/llm-d/llm-d-batch-gateway/internal/files_store/mock"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
@@ -102,7 +103,7 @@ func TestPreProcess_BuildsPlansAndModelMap_OffsetsCorrect(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -251,7 +252,7 @@ func TestPreProcess_SystemPrompts_PrefixHashAndSortOrder(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -372,16 +373,13 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 	}
 	defer evCh.CloseFn()
 
-	userCancelCtx, userCancelFn := context.WithCancel(ctx)
-	requestAbortCtx, requestAbortFn := context.WithCancel(ctx)
-	context.AfterFunc(userCancelCtx, requestAbortFn)
+	abortCtx, cause := context.WithCancelCause(ctx)
 
 	params := &jobExecutionParams{
-		eventWatcher:   evCh,
-		updater:        updater,
-		jobItem:        jobItem,
-		userCancelFn:   userCancelFn,
-		requestAbortFn: requestAbortFn,
+		eventWatcher: evCh,
+		updater:      updater,
+		jobItem:      jobItem,
+		cancelUser:   func() { cause(batchctx.ErrCancelled) },
 	}
 	go p.watchCancel(ctx, params)
 
@@ -389,18 +387,14 @@ func TestWatchCancel_SetsFlag_CancelsInferContext(t *testing.T) {
 		{ID: jobID, Type: db.BatchEventCancel, TTL: 60},
 	})
 
-	// Verify userCancelFn was called (user-cancel signal).
+	// Verify watchCancel tripped the user-cancel layer with the ErrCancelled cause.
 	select {
-	case <-userCancelCtx.Done():
+	case <-abortCtx.Done():
+		if !errors.Is(batchctx.Cause(abortCtx), batchctx.ErrCancelled) {
+			t.Fatalf("expected batchctx.ErrCancelled cause, got: %v", batchctx.Cause(abortCtx))
+		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("userCancelCtx was not cancelled within 2s after cancel event")
-	}
-
-	// Verify requestAbortFn was called (dispatch abort signal).
-	select {
-	case <-requestAbortCtx.Done():
-	case <-time.After(2 * time.Second):
-		t.Fatal("requestAbortCtx was not cancelled within 2s after cancel event")
+		t.Fatal("abort context was not cancelled within 2s after cancel event")
 	}
 
 	// Verify that watchCancel does NOT update status to cancelling
@@ -480,19 +474,19 @@ func TestPreProcess_CancelFlag_ReturnsErrCancelled(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	userCancelCtx, abortFn := context.WithCancel(ctx)
-	abortFn()
-	err = p.preProcessJob(ctx, ctx, userCancelCtx, jobInfo)
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled, got: %v", err)
+	cancelCtx, cancel := context.WithCancelCause(ctx)
+	cancel(batchctx.ErrCancelled)
+	err = p.preProcessJob(cancelCtx, jobInfo)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled, got: %v", err)
 	}
 }
 
-// TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled verifies that when both userCancelCtx
-// and ctx (SIGTERM) are cancelled, preProcessJob returns errCancelled — not errShutdown.
-// This matches processModel's priority (SLO > cancel > shutdown) and ensures the job
-// is cancelled rather than left for the orphan reconciler.
-func TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled(t *testing.T) {
+// TestPreProcess_CancelBeforeSIGTERM_ReturnsErrCancelled verifies first-cause-wins:
+// when a user cancel is recorded before a later SIGTERM on the same abort context,
+// preProcessJob returns batchctx.ErrCancelled — the shutdown is a no-op on the
+// already-cancelled context, so the job is cancelled rather than left for the reconciler.
+func TestPreProcess_CancelBeforeSIGTERM_ReturnsErrCancelled(t *testing.T) {
 	ctx := testLoggerCtx(t)
 
 	workDir := t.TempDir()
@@ -552,16 +546,17 @@ func TestPreProcess_CancelPlusSIGTERM_ReturnsErrCancelled(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	// Both ctx (SIGTERM) and userCancelCtx are cancelled.
-	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
-	shutdownCancel()
+	// Both fire, but the user cancel is recorded first. The shutdown layer is the
+	// parent; the user-cancel layer is nested below it (as in runJob). Tripping the
+	// inner cancel first sets the cause; the later shutdown is a no-op on it.
+	shutdownBase, tripShutdown := context.WithCancelCause(ctx)
+	cancelCtx, cancelUser := context.WithCancelCause(shutdownBase)
+	cancelUser(batchctx.ErrCancelled)  // user cancel first
+	tripShutdown(batchctx.ErrShutdown) // SIGTERM second — no-op on the already-cancelled inner layer
 
-	userCancelCtx, userCancelFn := context.WithCancel(ctx)
-	userCancelFn()
-
-	err = p.preProcessJob(shutdownCtx, shutdownCtx, userCancelCtx, jobInfo)
-	if !errors.Is(err, errCancelled) {
-		t.Fatalf("expected errCancelled when both SIGTERM and user cancel fire, got: %v", err)
+	err = p.preProcessJob(cancelCtx, jobInfo)
+	if !errors.Is(err, batchctx.ErrCancelled) {
+		t.Fatalf("expected batchctx.ErrCancelled when user cancel is recorded before SIGTERM, got: %v", err)
 	}
 }
 
@@ -591,7 +586,7 @@ func TestPreProcess_SLOExpiredDuringIngestion_ReturnsErrExpired(t *testing.T) {
 	}
 
 	// A single request is enough: sloCtx is already expired, so the ingestion loop
-	// returns errExpired on the first iteration before reading any lines.
+	// returns batchctx.ErrExpired on the first iteration before reading any lines.
 	lines := makeInputLines([]string{"any-model"}) // content irrelevant; loop exits before reading
 	var remoteBuf bytes.Buffer
 	for _, ln := range lines {
@@ -625,13 +620,13 @@ func TestPreProcess_SLOExpiredDuringIngestion_ReturnsErrExpired(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	// Use a context with a deadline in the past so sloCtx.Err() == DeadlineExceeded immediately.
+	// Use a context with a deadline in the past so context.Cause == DeadlineExceeded immediately.
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-1*time.Second))
 	defer sloCancel()
 
-	err = p.preProcessJob(ctx, sloCtx, context.Background(), jobInfo)
-	if !errors.Is(err, errExpired) {
-		t.Fatalf("expected errExpired, got: %v", err)
+	err = p.preProcessJob(sloCtx, jobInfo)
+	if !errors.Is(err, batchctx.ErrExpired) {
+		t.Fatalf("expected batchctx.ErrExpired, got: %v", err)
 	}
 }
 
@@ -1377,7 +1372,7 @@ func TestPreProcess_StreamTrue_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	err = p.preProcessJob(ctx, ctx, context.Background(), jobInfo)
+	err = p.preProcessJob(ctx, jobInfo)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for input with stream: true")
 	}
@@ -1444,7 +1439,7 @@ func TestPreProcess_DuplicateCustomID_FailsJob(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	err = p.preProcessJob(ctx, ctx, context.Background(), jobInfo)
+	err = p.preProcessJob(ctx, jobInfo)
 	if err == nil {
 		t.Fatal("expected preProcessJob to fail for duplicate custom_id")
 	}
@@ -1514,7 +1509,7 @@ func TestPreProcess_UniqueCustomIDs_Succeeds(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("expected preProcessJob to succeed with unique custom_ids, got: %v", err)
 	}
 }
@@ -1592,7 +1587,7 @@ func TestPreProcess_UnregisteredModel_RejectedToErrorFile(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1711,7 +1706,7 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 		TenantID: tenantID,
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1754,7 +1749,7 @@ func TestPreProcess_AllRequestsUnregistered_ExecuteJobCounts(t *testing.T) {
 		t.Fatalf("plan files = %d, want 0", planFiles)
 	}
 
-	counts, execErr := p.executeJob(ctx, ctx, ctx, ctx, &jobExecutionParams{
+	counts, execErr := p.executeJob(ctx, &jobExecutionParams{
 		updater: NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
 		jobInfo: jobInfo,
 	})
@@ -1846,7 +1841,7 @@ func TestPreProcess_ReEnqueue_TruncatesStaleErrorFile(t *testing.T) {
 		t.Fatalf("WriteFile stale error: %v", err)
 	}
 
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1931,7 +1926,7 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 	}
 
 	// Run ingestion — should reject model-b and write to error.jsonl.
-	if err := p.preProcessJob(ctx, ctx, context.Background(), jobInfo); err != nil {
+	if err := p.preProcessJob(ctx, jobInfo); err != nil {
 		t.Fatalf("preProcessJob: %v", err)
 	}
 
@@ -1946,16 +1941,16 @@ func TestPreProcess_ModelNotFound_ThenEarlySLO_PreservesErrorFile(t *testing.T) 
 		t.Fatalf("error file lines before execution = %d, want 1", len(errorLines))
 	}
 
-	// Simulate early SLO expiration: create an already-expired sloCtx.
+	// Simulate early SLO expiration: create an already-expired context.
 	sloCtx, sloCancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
 	defer sloCancel()
 
-	counts, execErr := p.executeJob(ctx, sloCtx, context.Background(), sloCtx, &jobExecutionParams{
+	counts, execErr := p.executeJob(sloCtx, &jobExecutionParams{
 		updater: NewStatusUpdater(dbClient, mockdb.NewMockBatchStatusClient(), 86400),
 		jobInfo: jobInfo,
 	})
-	if !errors.Is(execErr, errExpired) {
-		t.Fatalf("expected errExpired, got: %v", execErr)
+	if !errors.Is(execErr, batchctx.ErrExpired) {
+		t.Fatalf("expected batchctx.ErrExpired, got: %v", execErr)
 	}
 	// Failed = 2: 1 model_not_found (ingestion) + 1 batch_expired (pipeline drain for model-a).
 	if counts.Failed != 2 {

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -29,7 +29,6 @@ type PlanFileSource struct {
 	cfg                *config.ProcessorConfig
 	passThroughHeaders map[string]string
 	sloDeadline        time.Time
-	hasSLO             bool
 	tenantID           string
 	logger             logr.Logger
 }
@@ -44,7 +43,6 @@ type PlanFileSourceConfig struct {
 	Cfg                *config.ProcessorConfig
 	PassThroughHeaders map[string]string
 	SLODeadline        time.Time
-	HasSLO             bool
 	TenantID           string
 	Logger             logr.Logger
 }
@@ -58,7 +56,6 @@ func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 		cfg:                cfg.Cfg,
 		passThroughHeaders: cfg.PassThroughHeaders,
 		sloDeadline:        cfg.SLODeadline,
-		hasSLO:             cfg.HasSLO,
 		tenantID:           cfg.TenantID,
 		logger:             cfg.Logger,
 	}
@@ -129,7 +126,7 @@ func (s *PlanFileSource) mergeHeaders(headers map[string]string, modelID string)
 		headers = make(map[string]string)
 	}
 
-	if s.hasSLO {
+	if !s.sloDeadline.IsZero() {
 		ms := time.Until(s.sloDeadline).Milliseconds()
 		if ms >= 0 {
 			headers[sloTTFTMSHeader] = strconv.FormatInt(ms, 10)

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -40,7 +40,6 @@ func TestMergeHeaders(t *testing.T) {
 		want := 5*time.Second + 100*time.Millisecond
 		s := &PlanFileSource{
 			cfg:         config.NewConfig(),
-			hasSLO:      true,
 			sloDeadline: time.Now().Add(want),
 			logger:      logr.Discard(),
 		}
@@ -60,7 +59,6 @@ func TestMergeHeaders(t *testing.T) {
 	t.Run("SLO deadline in the past omits header", func(t *testing.T) {
 		s := &PlanFileSource{
 			cfg:         config.NewConfig(),
-			hasSLO:      true,
 			sloDeadline: time.Now().Add(-time.Second),
 			logger:      logr.Discard(),
 		}
@@ -73,7 +71,6 @@ func TestMergeHeaders(t *testing.T) {
 	t.Run("preserves existing headers", func(t *testing.T) {
 		s := &PlanFileSource{
 			cfg:         config.NewConfig(),
-			hasSLO:      true,
 			sloDeadline: time.Now().Add(time.Minute),
 			logger:      logr.Discard(),
 		}
@@ -192,7 +189,6 @@ func TestMergeHeaders(t *testing.T) {
 		}
 		s := &PlanFileSource{
 			cfg:         cfg,
-			hasSLO:      true,
 			sloDeadline: time.Now().Add(10 * time.Second),
 			tenantID:    "tenant-xyz",
 			logger:      logr.Discard(),


### PR DESCRIPTION
## Why is this PR needed?

Addressing a comment in  #580, specifically:

> The current executor ([executor.go:182](https://github.com/llm-d/llm-d-batch-gateway/blob/main/internal/processor/worker/executor.go#L182)) uses four independent contexts to distinguish why execution stopped:

I argued that I believe that we could simplify that with a single context, carrying the cause for termination instead.

Having 4 independent contexts is a bit confusing and probably not idiomatic, moreover they basically only existed only so a trailing switch could inspect `.Err()` to figure out why execution stopped.

## What does this PR do?

We consolidate over one single context, carrying the cause for termination and propagate the changes throughout the codebase. 

### Summary of the changes

New package internal/processor/batchctx

  - Owns the cause "enum": ErrCancelled, ErrShutdown, ErrExpired (expiry stays stdlib DeadlineExceeded on the wire, mapped to ErrExpired).
  - Cause(ctx) — maps the recorded cause to a routing sentinel (neutral context.Canceled → nil).
  - IsTerminal(err) — is this an expected terminal state vs. a system error.
  - No constructors: one primitive everywhere — context.WithCancelCause + cause(batchctx.ErrX).

Production rewiring

  - runJob builds a single abort context: WithCancelCause over WithoutCancel(ctx) (+WithDeadline for SLO). Each source is a no-arg closure baking its cause — user cancel (watchCancel), SIGTERM
  (AfterFunc), heartbeat/cleanup (neutral). First cause wins. Only 3 cleanup defers.
  - executeJobAsync / preProcessJob / finalizeJob now take one ctx and classify via batchctx.Cause.
  - params: userCancelFn/requestAbortFn → a single cancelUser.
  - runJob's repeated three-way sentinel checks → batchctx.IsTerminal.
  - Removed the worker sentinels + causeToSentinel, and the redundant HasSLO flag (zero SLODeadline already means "no SLO").

## How was this tested?

Added unit tests and validated e2e was working.

- [x] Unit tests added/updated/verified
- [x] Integration/e2e tests added/updated/verified
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [x] E2E tests pass (`make test-e2e`)

## Related Issues

Follow up to #580