### PR TITLE
refactor(release): change release process

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,8 +1,11 @@
 <!--
-  Optional template for release descriptions.
-  The Release workflow uses auto-generated notes from .github/release.yml.
-  You can paste the sections below when drafting or editing a release, or
-  use them as a checklist for release communication.
+  NOT used by any workflow. The Release workflow (create-release.yml) generates
+  release notes automatically from merged PR labels via .github/release.yml.
+
+  This file is a manual reference only. If you want the boilerplate below
+  (Docker image names, Helm install command, binary instructions) to appear
+  in the release description, paste it manually when editing the release on
+  GitHub, above the auto-generated changelog.
 -->
 
 ## Docker images

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,11 +1,12 @@
-name: CI Release
+# CI Build: builds and pushes container images to GHCR on every merge to main.
+# Release images (version-tagged) are built by create-release.yml.
+
+name: CI Build
 
 on:
   push:
     branches:
       - main
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
 
 env:
@@ -41,25 +42,16 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          # Get the commit SHA (short version)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
           echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
 
-          # Get the current timestamp
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
 
-          # Determine the version and tag based on the event
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            # For tag pushes, use the tag name as version
-            VERSION="${{ github.ref_name }}"
-            TAG="${{ github.ref_name }}"
-          elif [[ "${{ github.ref_name }}" == "main" ]]; then
-            # For main branch, use 'latest'
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
             VERSION="main-${COMMIT_SHA}"
             TAG="latest"
           else
-            # For PRs and other branches, use 'dev'
             VERSION="dev-${COMMIT_SHA}"
             TAG="dev"
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,6 +1,7 @@
-# Release workflow: creates a GitHub Release on version tags (v*.*.*),
-# builds multi-arch binaries (as .tar.gz to preserve execute bit), and publishes release notes.
-# Docker images for the same tag are built by ci-release.yaml.
+# Release workflow: triggered by a v*.*.* tag created via scripts/generate-release.sh.
+# Builds multi-arch binaries (.tar.gz), builds and pushes Docker images, packages and
+# publishes the Helm chart to GHCR, then creates the GitHub Release with generated notes.
+# Docker images are built before the Helm chart so image references are always resolvable.
 
 name: Release
 
@@ -59,7 +60,7 @@ jobs:
           fi
           echo "Tag ${TAG} matches release line v${branch_major}.${branch_minor}.*"
 
-  build:
+  build-binaries:
     name: Build binaries
     needs: verify-tag-on-allowed-branch
     runs-on: ubuntu-latest
@@ -83,9 +84,61 @@ jobs:
           name: release-binaries
           path: bin/batch-gateway-*
 
+  build-images:
+    name: Build and push Docker images
+    needs: verify-tag-on-allowed-branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker images
+        uses: docker/bake-action@v7
+        with:
+          files: docker-bake.hcl
+          targets: default
+          push: true
+        env:
+          REGISTRY: ghcr.io/llm-d
+          COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
+          BUILD_DATE: ${{ steps.meta.outputs.build_date }}
+          VERSION: ${{ github.ref_name }}
+          TAG: ${{ github.ref_name }}
+
+      - name: Output image tags
+        run: |
+          echo "Images pushed:"
+          echo "  - ghcr.io/llm-d/batch-gateway-apiserver:${{ steps.meta.outputs.commit_sha }}"
+          echo "  - ghcr.io/llm-d/batch-gateway-apiserver:${{ github.ref_name }}"
+          echo "  - ghcr.io/llm-d/batch-gateway-processor:${{ steps.meta.outputs.commit_sha }}"
+          echo "  - ghcr.io/llm-d/batch-gateway-processor:${{ github.ref_name }}"
+          echo "  - ghcr.io/llm-d/batch-gateway-gc:${{ steps.meta.outputs.commit_sha }}"
+          echo "  - ghcr.io/llm-d/batch-gateway-gc:${{ github.ref_name }}"
+
   release:
     name: Create release
-    needs: build
+    needs: [build-binaries, build-images]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -108,8 +108,6 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
 
@@ -121,7 +119,6 @@ jobs:
           push: true
         env:
           REGISTRY: ghcr.io/llm-d
-          COMMIT_SHA: ${{ steps.meta.outputs.commit_sha }}
           BUILD_DATE: ${{ steps.meta.outputs.build_date }}
           VERSION: ${{ github.ref_name }}
           TAG: ${{ github.ref_name }}
@@ -129,11 +126,8 @@ jobs:
       - name: Output image tags
         run: |
           echo "Images pushed:"
-          echo "  - ghcr.io/llm-d/batch-gateway-apiserver:${{ steps.meta.outputs.commit_sha }}"
           echo "  - ghcr.io/llm-d/batch-gateway-apiserver:${{ github.ref_name }}"
-          echo "  - ghcr.io/llm-d/batch-gateway-processor:${{ steps.meta.outputs.commit_sha }}"
           echo "  - ghcr.io/llm-d/batch-gateway-processor:${{ github.ref_name }}"
-          echo "  - ghcr.io/llm-d/batch-gateway-gc:${{ steps.meta.outputs.commit_sha }}"
           echo "  - ghcr.io/llm-d/batch-gateway-gc:${{ github.ref_name }}"
 
   release:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm dev-deploy dev-clean dev-rm-cluster pre-commit benchmark-local benchmark-local-teardown benchmark-gpu benchmark-gpu-teardown
+.PHONY: help build build-apiserver build-processor build-gc run-apiserver run-processor run-gc run-apiserver-dev run-processor-dev run-gc-dev build-release package-release publish-helm-chart generate-release test test-coverage test-coverage-func clean lint fmt vet tidy install-tools deps-get deps-verify bench check check-container-tool ci image-build image-build-apiserver image-build-processor image-build-gc test-regression test-integration test-all test-e2e test-helm test-scripts dev-deploy dev-clean dev-rm-cluster pre-commit benchmark-local benchmark-local-teardown benchmark-gpu benchmark-gpu-teardown
 
 SHELL := /usr/bin/env bash
 
@@ -108,16 +108,13 @@ publish-helm-chart:
 	export GITHUB_ACTOR="$(GITHUB_ACTOR)"; \
 	./scripts/publish-helm-chart.sh
 
-## generate-release: Create and push a release tag (requires REL_VERSION; optional REL_BRANCH=main|release-vX.Y.Z , default main)
+## generate-release: Create a release branch and tag on GitHub from a commit SHA (requires REL_SHA, REL_VERSION; uses gh CLI, no local git changes)
 generate-release:
-	@if [ -z "$(REL_VERSION)" ]; then \
-	  echo "Error: REL_VERSION is required. Example: make generate-release REL_VERSION=0.0.1"; exit 1; \
+	@if [ -z "$(REL_SHA)" ] || [ -z "$(REL_VERSION)" ]; then \
+	  echo "Error: REL_SHA and REL_VERSION are required."; \
+	  echo "Example: make generate-release REL_SHA=<commit-sha> REL_VERSION=0.4.0"; exit 1; \
 	fi
-	@if [ -n "$(REL_BRANCH)" ]; then \
-	  ./scripts/generate-release.sh $(REL_VERSION) $(REL_BRANCH); \
-	else \
-	  ./scripts/generate-release.sh $(REL_VERSION); \
-	fi
+	@./scripts/generate-release.sh $(REL_SHA) $(REL_VERSION)
 
 ## run-apiserver: Run the apiserver
 run-apiserver: build-apiserver
@@ -171,6 +168,11 @@ test:
 	fi; \
 	rm -f $$OUT; \
 	exit $$TEST_EXIT
+
+## test-scripts: Run shell script tests (stubbed-gh, no cluster/network needed)
+test-scripts:
+	@echo "Running shell script tests..."
+	@bash scripts/generate-release_test.sh
 
 ## test-coverage: Run tests with coverage
 test-coverage:
@@ -330,8 +332,8 @@ test-integration:
 		(echo "\n❌ Integration tests failed" && exit 1)
 	@echo "\n✅ Integration tests passed!"
 
-## test-all: Run all tests (unit + regression + integration)
-test-all: test test-regression test-integration
+## test-all: Run all tests (unit + regression + integration + scripts)
+test-all: test test-regression test-integration test-scripts
 
 KIND_CLUSTER_NAME ?= batch-gateway-dev
 

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ publish-helm-chart:
 	export GITHUB_ACTOR="$(GITHUB_ACTOR)"; \
 	./scripts/publish-helm-chart.sh
 
-## generate-release: Create a release branch and tag on GitHub from a commit SHA (requires REL_SHA, REL_VERSION; uses gh CLI, no local git changes)
+## generate-release: Create a tag (and a release branch for final releases) on GitHub from a commit SHA (requires REL_SHA, REL_VERSION; uses gh CLI, no local git changes)
 generate-release:
 	@if [ -z "$(REL_SHA)" ] || [ -z "$(REL_VERSION)" ]; then \
 	  echo "Error: REL_SHA and REL_VERSION are required."; \

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -101,8 +101,8 @@ To remove a release and its tag (e.g. after a test release):
    ```bash
    gh api repos/{owner}/{repo}/git/refs/tags/<tag> --method DELETE
    ```
-3. **Delete the release branch** if no longer needed:
+3. **Delete the release branch** (final releases only) if no longer needed:
    ```bash
-   gh api repos/{owner}/{repo}/git/refs/heads/release-<version> --method DELETE
+   gh api repos/{owner}/{repo}/git/refs/heads/release-<tag> --method DELETE
    ```
 4. **Docker images and Helm charts** already pushed to GHCR for that tag are **not** removed. Delete them in the **Packages** area of the repo if needed.

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -6,7 +6,7 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 - **Release workflow** (`.github/workflows/create-release.yml`): Runs when a tag matching `v*.*.*` is pushed. It **only proceeds if that tag points at a commit on `main` or on a `release-vX.Y.Z` branch** (reachable from `origin/main` or from such a branch on `origin`), then runs these steps in order:
   1. **Build binaries** (parallel with images): Linux amd64 and arm64, packaged as **`.tar.gz`** with **`SHA256SUMS`**.
-  2. **Build and push Docker images** (parallel with binaries): all three images tagged with the version and commit SHA, pushed to GHCR.
+  2. **Build and push Docker images** (parallel with binaries): all three images tagged with the version (e.g. `v0.4.0`), pushed to GHCR.
   3. **Publish Helm chart**: pins image tags in `values.yaml` to the release version, packages the chart, publishes it to `oci://ghcr.io/llm-d/charts/batch-gateway`, appends chart digest to `SHA256SUMS`.
   4. **Create GitHub Release**: generated release notes, all `.tar.gz` and `.tgz` assets, `SHA256SUMS`.
   Docker images are guaranteed to exist before the Helm chart is published.

--- a/docs/guides/managing-releases.md
+++ b/docs/guides/managing-releases.md
@@ -4,63 +4,64 @@ This guide describes how to create a new release of Batch Gateway and manage rel
 
 ## Overview
 
-- **Release workflow** (`.github/workflows/create-release.yml`): Runs when you push a tag matching `v*.*.*` (e.g. `v1.0.0`). It **only proceeds if that tag points at a commit on `main` or on a `release-vX.Y.Z` branch** (e.g. `release-v1.0.0`; reachable from `origin/main` or from such a branch on `origin`), then builds Linux binaries (amd64, arm64), packages them as `**.tar.gz**` (so execute permission survives browser download), writes `**SHA256SUMS**`, pins image tags in the Helm chart `values.yaml` to the release version, packages and publishes the Helm chart to the OCI registry (GHCR), creates a GitHub Release with notes generated automatically, and uploads those assets. Tags with a `-` in the name (e.g. `v0.3.0-RC1`) are marked as **Pre-release**; tags without one (e.g. `v0.3.0`) are full releases and marked **Latest**.
-- **Docker workflow** (`.github/workflows/ci-release.yaml`): Builds and pushes container images to GHCR. It runs on the following triggers:
-  - **Push to `main`**: Images are tagged `latest` and with the commit SHA.
-  - **Push of version tag** (`v*.*.*`): Images are tagged with the version (e.g. `v1.0.0`) and with the commit SHA.
-- **Release notes config** (`.github/release.yml`): Defines how PRs are grouped in release notes generated automatically (e.g. Features, Bug fixes, Documentation).
-- **Release template** (`.github/RELEASE_TEMPLATE.md`): Optional template you can copy into a release description (e.g. Docker image names, upgrade notes).
-
-## Tagging policy (main or release-vX.Y.Z branches)
-
-**The tagged commit must be reachable from `origin/main` or from an `origin/release-vX.Y.Z` branch** (branch name must match `release-v` plus the same semver-like pattern as a version tag). The workflow enforces this so release tags are not cut from arbitrary feature branches.
-
-- **Normal releases:** merge to `main`, then tag from `main` (default), e.g. `./scripts/generate-release.sh 1.0.0` or `make generate-release REL_VERSION=1.0.0`.
-- **Hotfixes on a release line:** use the corresponding `release-vX.Y.Z` branch (e.g. `release-v0.1.0`), merge or cherry-pick the fix there, then tag from that branch: `./scripts/generate-release.sh 0.1.1 release-v0.1.0` or `make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0`.
-- **Version must match the release line:** when tagging from a `release-vX.Y.Z` branch, the version tag must share the same major and minor (`vX.Y.*`). For example, `release-v0.1.0` only accepts tags like `v0.1.1` or `v0.1.2-rc1`; a tag like `v0.3.0` will be rejected. This is enforced both by `generate-release.sh` locally and by the `create-release.yml` workflow in CI.
-- **Don't:** push a release tag that points only at a commit that is not on `main` and not on any allowed `release-vX.Y.Z` branch the workflow can see.
-
-Pushing `v*.*.*` **always** triggers the workflow if the check passes.
+- **Release workflow** (`.github/workflows/create-release.yml`): Runs when a tag matching `v*.*.*` is pushed. It **only proceeds if that tag points at a commit on `main` or on a `release-vX.Y.Z` branch** (reachable from `origin/main` or from such a branch on `origin`), then runs these steps in order:
+  1. **Build binaries** (parallel with images): Linux amd64 and arm64, packaged as **`.tar.gz`** with **`SHA256SUMS`**.
+  2. **Build and push Docker images** (parallel with binaries): all three images tagged with the version and commit SHA, pushed to GHCR.
+  3. **Publish Helm chart**: pins image tags in `values.yaml` to the release version, packages the chart, publishes it to `oci://ghcr.io/llm-d/charts/batch-gateway`, appends chart digest to `SHA256SUMS`.
+  4. **Create GitHub Release**: generated release notes, all `.tar.gz` and `.tgz` assets, `SHA256SUMS`.
+  Docker images are guaranteed to exist before the Helm chart is published.
+  Tags with a `-` (e.g. `v0.3.0-RC1`) are marked **Pre-release**; tags without one (e.g. `v0.3.0`) are full releases marked **Latest**.
+- **CI Build workflow** (`.github/workflows/ci-build.yaml`): Builds and pushes container images on every merge to `main`. Images are tagged `latest` and with the commit SHA. Does **not** run on version tags — those are handled entirely by `create-release.yml`.
+- **Release notes config** (`.github/release.yml`): Defines how PRs are grouped in auto-generated release notes (e.g. Features, Bug fixes, Documentation).
+- **Release template** (`.github/RELEASE_TEMPLATE.md`): **Not used by any workflow.** Manual reference only — paste it into the release description on GitHub if you want the boilerplate (Docker image names, Helm install command, binary instructions) to appear above the auto-generated changelog.
 
 ## Creating a release
 
-1. **Ensure the target branch is in a good state**
-  For tags from `main`, CI and tests should be passing on `main`. For hotfixes, validate the relevant `release-vX.Y.Z` branch.
-2. **Create and push a version tag** (semantic version with optional `v` prefix; script normalizes to `v*.*.*`):
+1. **Ensure the target commit is in a good state** — CI and tests should be passing on the commit you want to release from.
 
-   From **main** (default):
-
+2. **Find the commit SHA** you want to release from — no local clone needed:
    ```bash
-   ./scripts/generate-release.sh 1.0.0
+   # tip of main
+   gh api repos/{owner}/{repo}/commits/main --jq '.sha'
+   # tip of any branch
+   gh api repos/{owner}/{repo}/commits/<branch> --jq '.sha'
+   # merge commit of a specific PR
+   gh pr view <number> --json mergeCommit --jq '.mergeCommit.oid'
    ```
 
-   From a **release branch** (e.g. patch after `v0.1.0`):
-
+3. **Create the release branch and tag** via the GitHub API (no local git changes):
    ```bash
-   ./scripts/generate-release.sh 0.1.1 release-v0.1.0
+   ./scripts/generate-release.sh <commit-sha> 0.4.0
    ```
+   Or using the Makefile:
+   ```bash
+   make generate-release REL_SHA=<commit-sha> REL_VERSION=0.4.0
+   ```
+   This creates `release-v0.4.0` branch and `v0.4.0` tag on that commit directly on the remote.
 
-   Or using the Makefile (for admins):
+4. **Let automation run** — the Release workflow runs automatically on the tag push:
+   - Binaries and Docker images build in parallel.
+   - The Helm chart is published after images are confirmed pushed.
+   - The GitHub Release is created with notes, assets, and `SHA256SUMS`.
 
-  ```bash
-  make generate-release REL_VERSION=1.0.0
-  make generate-release REL_VERSION=0.1.1 REL_BRANCH=release-v0.1.0
-  ```
+5. **Optional: edit the release** — GitHub **Releases** → open the new release → **Edit**. Paste content from `.github/RELEASE_TEMPLATE.md` (Docker image section, Helm install command, upgrade notes) and adjust generated notes if needed.
 
-3. **Let automation run**
-  - **create-release.yml**: Packages binaries as `.tar.gz`, pins Helm chart image tags to the release version, publishes the Helm chart to `oci://ghcr.io/llm-d/charts/batch-gateway`, creates the GitHub Release with generated notes, attaches binaries, chart `.tgz`, and `SHA256SUMS`.
-  - **ci-release.yaml**: Builds and pushes images for that tag to GHCR.
-4. **Optional: edit the release**
-  - In GitHub: **Releases** → open the new release → **Edit**.
-  - You can paste content from `.github/RELEASE_TEMPLATE.md` (Docker image section, upgrade notes) and adjust the generated notes if needed.
+## Tagging policy
+
+**The tagged commit must be reachable from `origin/main` or from an `origin/release-vX.Y.Z` branch.** The workflow enforces this.
+
+The script handles two cases:
+
+- **Pre-release** (e.g. `v0.4.0-rc1`, `v0.4.0-alpha.1`): tag only, no branch created. The commit is expected to be on `main` — the verify check passes because it is reachable from `origin/main`.
+- **Final release** (e.g. `v0.4.0`): creates `release-v0.4.0` from the given commit and tags it. The verify check passes because the commit is the tip of the release branch.
 
 ## Release notes
 
-Release notes are generated from merged PRs and grouped by labels. See `.github/release.yml` for exclusions and categories. Assign appropriate labels to PRs so they appear in the correct section.
+Release notes are generated from merged PRs grouped by labels. See `.github/release.yml` for exclusions and categories. Assign appropriate labels to PRs so they appear in the correct section.
 
 ## Verifying checksums
 
-Each release includes `**SHA256SUMS`** for every binary `**.tar.gz**` and the Helm chart `**.tgz**`. After downloading into one directory:
+Each release includes `SHA256SUMS` for every binary `.tar.gz` and the Helm chart `.tgz`. After downloading into one directory:
 
 ```bash
 sha256sum -c SHA256SUMS
@@ -72,32 +73,21 @@ Extract a binary (execute bit preserved):
 tar xzf batch-gateway-apiserver-linux-amd64.tar.gz
 ```
 
-## Release template
-
-`.github/RELEASE_TEMPLATE.md` is for human use when drafting or editing a release. It reminds you to mention:
-
-- Docker image names and tag
-- Helm chart OCI URL and install command
-- Upgrade or migration notes
-- That Linux binaries are attached as `.tar.gz`, the Helm chart as `.tgz`, with `SHA256SUMS` covering those files
-
-The workflow does **not** automatically inject this file into the release body; it only uses GitHub's generated notes. Paste the template content manually if you want it in the description.
-
 ## Testing the release workflow
 
-To verify the release workflow without affecting a real version, use the same `generate-release` script with a test tag (e.g. `v0.0.0-test`):
+To verify the release workflow without affecting a real version, use a test tag (e.g. `v0.0.0-test`):
 
-1. **Create a test tag** on `main` or a `release-vX.Y.Z` branch (the same reachability rules as a real release apply):
-  ```bash
-   ./scripts/generate-release.sh v0.0.0-test
-   # or from a release branch:
-   ./scripts/generate-release.sh v0.0.0-test release-v0.0.1
-  ```
+1. **Create a test tag** from any commit on `main` or a `release-vX.Y.Z` branch:
+   ```bash
+   ./scripts/generate-release.sh $(git rev-parse HEAD) v0.0.0-test
+   # or via Make:
+   make generate-release REL_SHA=$(git rev-parse HEAD) REL_VERSION=v0.0.0-test
+   ```
 
-   Equivalent with Make: `make generate-release REL_VERSION=v0.0.0-test REL_BRANCH=release-v0.0.1`
+2. **Check that the workflow runs** in the **Actions** tab. When it finishes, a new release and new image tags will exist.
 
-2. **Check that workflows run** in the **Actions** tab: **Release** and **CI Release** should run for that tag. When they finish, a new release and new image tags will exist.
-3. **Important:** Running a failed workflow again uses the workflow file from the original trigger commit. To run with updated workflow code (e.g. after fixing ci-release.yaml), push the fix and then push the tag again from the new commit so a fresh run is triggered.
+3. **Important:** Running a failed workflow again uses the workflow file from the original trigger commit. To run with updated workflow code, push the fix and then re-create the tag from the new commit so a fresh run is triggered.
+
 4. **Clean up when done** — see [Manually deleting a release](#manually-deleting-a-release).
 
 ## Manually deleting a release
@@ -105,11 +95,14 @@ To verify the release workflow without affecting a real version, use the same `g
 To remove a release and its tag (e.g. after a test release):
 
 1. **Delete the GitHub Release first**
-  - On GitHub: **Releases** → open the release → **Delete this release**
-  - Or with [GitHub CLI](https://cli.github.com/): `gh release delete <tag> --yes`
-2. **Delete the tag** locally and remotely:
-  ```bash
-   git tag -d <tag>
-   git push origin --delete <tag>
-  ```
-3. **Docker images and Helm charts** already pushed to GHCR for that tag are **not** removed. Delete them in the **Packages** area of the repo if needed.
+   - On GitHub: **Releases** → open the release → **Delete this release**
+   - Or with [GitHub CLI](https://cli.github.com/): `gh release delete <tag> --yes`
+2. **Delete the tag** via the GitHub API:
+   ```bash
+   gh api repos/{owner}/{repo}/git/refs/tags/<tag> --method DELETE
+   ```
+3. **Delete the release branch** if no longer needed:
+   ```bash
+   gh api repos/{owner}/{repo}/git/refs/heads/release-<version> --method DELETE
+   ```
+4. **Docker images and Helm charts** already pushed to GHCR for that tag are **not** removed. Delete them in the **Packages** area of the repo if needed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@
 
 | Script                  | Description                                                                                                                                               |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate-release.sh`   | Creates a `release-<version>` branch and `v*.*.*` tag on GitHub from a given commit SHA via the `gh` CLI (no local git changes). Triggers the Release workflow. See [managing releases](../docs/guides/managing-releases.md). |
+| `generate-release.sh`   | Creates a `v*.*.*` tag on GitHub from a given commit SHA via the `gh` CLI, plus a `release-<tag>` branch for final releases (no local git changes). Triggers the Release workflow. See [managing releases](../docs/guides/managing-releases.md). |
 | `publish-helm-chart.sh` | Packages the helm chart for a tag and pushes it to `oci://ghcr.io/llm-d/charts` (invoked as `make publish-helm-chart` in release CI).          |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,5 +13,5 @@
 
 | Script                  | Description                                                                                                                                               |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate-release.sh`   | Creates and pushes a `v*.*.*` tag from `main` (default) or a `release-vX.Y.Z` branch, which triggers the GitHub release workflows. See [managing releases](../docs/guides/managing-releases.md). |
+| `generate-release.sh`   | Creates a `release-<version>` branch and `v*.*.*` tag on GitHub from a given commit SHA via the `gh` CLI (no local git changes). Triggers the Release workflow. See [managing releases](../docs/guides/managing-releases.md). |
 | `publish-helm-chart.sh` | Packages the helm chart for a tag and pushes it to `oci://ghcr.io/llm-d/charts` (invoked as `make publish-helm-chart` in release CI).          |

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -1,92 +1,147 @@
 #!/bin/bash
-# Generates a release by creating and pushing a version tag from main or a release-vX.Y.Z branch.
-# This triggers the create-release and ci-release workflows.
+# Creates a version tag on GitHub, and for final releases also creates a release branch.
+# All operations use the gh CLI against the GitHub API — no local git changes are made.
+# Always targets llm-d/llm-d-batch-gateway regardless of local remotes.
 #
-# Usage: ./scripts/generate-release.sh <version> [branch]
-#   branch defaults to main; must be main or release-vX.Y.Z (same form as a version tag, e.g. release-v0.1.0).
+# Usage: ./scripts/generate-release.sh <commit-sha> <version>
+#   commit-sha  Commit SHA (full or abbreviated) to release from.
+#               Obtain from GitHub (UI, gh CLI) — no local clone needed:
+#                 gh api repos/{owner}/{repo}/commits/main --jq '.sha'
+#                 gh api repos/{owner}/{repo}/commits/<branch> --jq '.sha'
+#                 gh pr view <number> --json mergeCommit --jq '.mergeCommit.oid'
+#   version     Semver version: vX.Y.Z for a final release, or vX.Y.Z-<pre-release>
+#               for a pre-release (e.g. v0.4.0-rc1, v1.0.0-alpha.1).
+#               The 'v' prefix is added automatically if omitted.
 #
-# Example: ./scripts/generate-release.sh 1.0.0
-#          ./scripts/generate-release.sh 0.1.1 release-v0.1.0
-#          ./scripts/generate-release.sh v1.0.0
-#          ./scripts/generate-release.sh v0.0.0-test              # test tag from main
-#          ./scripts/generate-release.sh v0.0.0-test release-v0.0.1   # test tag from a release branch
+# Behavior:
+#   Final release (e.g. v0.1.9):
+#     - Creates branch release-v0.1.9 from <commit-sha>
+#     - Creates tag v0.1.9 on <commit-sha>
+#   Pre-release (e.g. v0.1.9-rc1):
+#     - Creates tag v0.1.9-rc1 on <commit-sha> (expected to be on main)
+#     - No branch is created
 #
-# The version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test). The 'v' prefix is added if omitted.
-# When tagging from release-vX.Y.Z, the version must be vX.Y.*.
+# Pushing the tag triggers the Release workflow (create-release.yml).
+#
+# Examples:
+#   ./scripts/generate-release.sh abc1234 0.4.0       # final release
+#   ./scripts/generate-release.sh abc1234 v0.4.0-rc1  # pre-release
 
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <version> [branch]"
+    echo "Usage: $0 <commit-sha> <version>"
     echo ""
-    echo "Creates and pushes a release tag from the given branch (default: main)."
-    echo "Branch must be main or release-vX.Y.Z (same form as a tag, e.g. release-v0.1.0). Triggers create-release and ci-release workflows."
+    echo "Creates a version tag on GitHub. For final releases (vX.Y.Z), also creates"
+    echo "a release-vX.Y.Z branch. Pre-releases (vX.Y.Z-<suffix>) only create a tag."
+    echo ""
+    echo "Arguments:"
+    echo "  commit-sha  Commit SHA (full or abbreviated) to release from."
+    echo "              Get it from GitHub without a local clone:"
+    echo "                gh api repos/{owner}/{repo}/commits/main --jq '.sha'"
+    echo "                gh pr view <number> --json mergeCommit --jq '.mergeCommit.oid'"
+    echo "  version     vX.Y.Z (final) or vX.Y.Z-<pre-release> (e.g. v0.4.0-rc1, v1.0.0-alpha.1)."
+    echo "              The 'v' prefix is added automatically if omitted."
     echo ""
     echo "Examples:"
-    echo "  $0 1.0.0                    # tags v1.0.0 from main"
-    echo "  $0 0.1.1 release-v0.1.0     # hotfix tag from release branch"
-    echo "  $0 v1.0.0                   # tags as v1.0.0 from main"
-    echo "  $0 v0.0.0-test              # test tag from main"
-    echo "  $0 v0.0.0-test release-v0.0.1   # test tag from a release branch"
-    echo ""
-    echo "The tagged commit must already be on the branch you select (merge or push there first)."
+    echo "  $0 abc1234 0.4.0        # final: creates release-v0.4.0 branch + tag"
+    echo "  $0 abc1234 v0.4.0-rc1   # pre-release: tag only, no branch"
     exit 1
 }
 
-if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+if [ $# -ne 2 ]; then
     usage
 fi
 
-VERSION="$1"
-BRANCH="${2:-main}"
+COMMIT_SHA="$1"
+VERSION="$2"
 
-# Semver-like tag body: vX.Y.Z or vX.Y.Z-suffix (release branches are release-<same>, e.g. release-v0.1.0)
-_SEMVER_V='v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?'
-
-if [[ "$BRANCH" != "main" && ! "$BRANCH" =~ ^release-${_SEMVER_V}$ ]]; then
-    echo "Error: branch must be 'main' or 'release-vX.Y.Z' matching the tag pattern (e.g. release-v0.1.0) (got: ${BRANCH})" >&2
+# Validate commit SHA (at least 7 hex chars)
+if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{7,}$ ]]; then
+    echo "Error: commit-sha must be a hex SHA of at least 7 characters (got: ${COMMIT_SHA})" >&2
     exit 1
 fi
-# Add 'v' prefix if not present
+
+# Normalize version (add v prefix if missing)
 if [[ ! "$VERSION" =~ ^v ]]; then
     VERSION="v${VERSION}"
 fi
 
-# Validate semver-like format (v*.*.* or v*.*.*-suffix for test tags)
-if [[ ! "$VERSION" =~ ^${_SEMVER_V}$ ]]; then
-    echo "Error: version must match v*.*.* (e.g. v1.0.0) or v*.*.*-suffix (e.g. v0.0.0-test)" >&2
+# Validate semver-like format (vX.Y.Z or vX.Y.Z-<pre-release> e.g. v0.4.0-rc1, v1.0.0-alpha.1)
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+    echo "Error: version must be vX.Y.Z or vX.Y.Z-<pre-release> (e.g. v0.4.0, v0.4.0-rc1, v1.0.0-alpha.1) (got: ${VERSION})" >&2
     exit 1
 fi
 
-# If tagging from release-vX.Y.Z, ensure the tag stays on that release line (vX.Y.*).
-if [[ "$BRANCH" =~ ^release-v([0-9]+)\.([0-9]+)\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
-    BRANCH_MAJOR="${BASH_REMATCH[1]}"
-    BRANCH_MINOR="${BASH_REMATCH[2]}"
-    if [[ "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
-        VERSION_MAJOR="${BASH_REMATCH[1]}"
-        VERSION_MINOR="${BASH_REMATCH[2]}"
-        if [[ "$VERSION_MAJOR" != "$BRANCH_MAJOR" || "$VERSION_MINOR" != "$BRANCH_MINOR" ]]; then
-            echo "Error: version ${VERSION} is not valid for branch ${BRANCH}. Expected v${BRANCH_MAJOR}.${BRANCH_MINOR}.* for this release branch." >&2
-            exit 1
-        fi
-    fi
+# Determine if this is a final release or a pre-release
+IS_PRERELEASE=false
+if [[ "$VERSION" == *-* ]]; then
+    IS_PRERELEASE=true
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-cd "${REPO_ROOT}"
+REPO="llm-d/llm-d-batch-gateway"
 
-echo "Generating release ${VERSION} from branch ${BRANCH}..."
-echo "  - Checking out ${BRANCH} and pulling latest"
-git checkout "${BRANCH}"
-git pull origin "${BRANCH}"
+command -v gh >/dev/null 2>&1 || {
+    echo "Error: gh CLI is required (https://cli.github.com/)" >&2
+    exit 1
+}
+gh auth status >/dev/null 2>&1 || {
+    echo "Error: gh CLI is not authenticated. Run: gh auth login" >&2
+    exit 1
+}
 
-echo "  - Creating tag ${VERSION}"
-git tag "${VERSION}"
+echo "Repository : ${REPO}"
+echo "Commit SHA : ${COMMIT_SHA}"
+echo "Tag        : ${VERSION}"
+if [ "$IS_PRERELEASE" = true ]; then
+    echo "Type       : pre-release (tag only, no branch)"
+else
+    echo "Type       : final release (branch + tag)"
+    echo "Branch     : release-${VERSION}"
+fi
+echo ""
 
-echo "  - Pushing tag ${VERSION} to origin"
-git push origin "${VERSION}"
+echo "Verifying commit exists..."
+# Resolve to the full 40-char SHA: the create-ref API operates on raw objects
+# and rejects abbreviated SHAs with a 422, whereas commits/{sha} resolves ref-ish values.
+RESOLVED_SHA="$(gh api "repos/${REPO}/commits/${COMMIT_SHA}" --jq '.sha' 2>/dev/null)" || {
+    echo "Error: commit ${COMMIT_SHA} not found in ${REPO}" >&2
+    exit 1
+}
+echo "Commit verified (${RESOLVED_SHA})."
+echo ""
+
+# create_ref idempotently points a ref at RESOLVED_SHA. If the ref already
+# exists at the same SHA it is left as-is, so a re-run after a partial failure
+# (e.g. the branch was created but the tag POST failed) is safe. If it exists
+# at a different SHA it is an error rather than a silent move.
+create_ref() {
+    local ref="$1"  # e.g. refs/heads/release-v1.2.3
+    local existing
+    if existing="$(gh api "repos/${REPO}/git/ref/${ref#refs/}" --jq '.object.sha' 2>/dev/null)"; then
+        if [ "$existing" = "$RESOLVED_SHA" ]; then
+            echo "  ${ref} already at ${RESOLVED_SHA}, skipping."
+            return 0
+        fi
+        echo "Error: ${ref} already exists at ${existing} (want ${RESOLVED_SHA}); delete it or re-run with the matching SHA" >&2
+        return 1
+    fi
+    gh api "repos/${REPO}/git/refs" \
+        --method POST \
+        -f "ref=${ref}" \
+        -f "sha=${RESOLVED_SHA}"
+}
+
+if [ "$IS_PRERELEASE" = false ]; then
+    echo "Creating branch release-${VERSION}..."
+    create_ref "refs/heads/release-${VERSION}"
+    echo "Branch release-${VERSION} ready."
+fi
+
+echo "Creating tag ${VERSION}..."
+create_ref "refs/tags/${VERSION}"
+echo "Tag ${VERSION} ready."
 
 echo ""
-echo "Release tag ${VERSION} pushed. Workflows (create-release, ci-release) will run automatically."
-echo "Monitor progress in the Actions tab of your repository."
+echo "Done. The Release workflow will run automatically."
+echo "Monitor progress at: https://github.com/${REPO}/actions"

--- a/scripts/generate-release.sh
+++ b/scripts/generate-release.sh
@@ -56,9 +56,9 @@ fi
 COMMIT_SHA="$1"
 VERSION="$2"
 
-# Validate commit SHA (at least 7 hex chars)
-if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{7,}$ ]]; then
-    echo "Error: commit-sha must be a hex SHA of at least 7 characters (got: ${COMMIT_SHA})" >&2
+# Validate commit SHA (7-40 hex chars, either case)
+if [[ ! "$COMMIT_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+    echo "Error: commit-sha must be a hex SHA of 7-40 characters (got: ${COMMIT_SHA})" >&2
     exit 1
 fi
 

--- a/scripts/generate-release_test.sh
+++ b/scripts/generate-release_test.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Tests for generate-release.sh. Stubs the gh CLI on PATH and asserts which
+# git/refs POSTs the script makes (or that it bails before any gh call).
+# No bats or other harness required — plain bash. Run via: make test-scripts
+#
+# Covers the release-driving logic that performs irreversible remote writes:
+#   - final release (vX.Y.Z)        -> branch + tag
+#   - pre-release   (vX.Y.Z-<pre>)  -> tag only, no branch
+#   - abbreviated SHA is resolved to the full 40-char SHA before create-ref
+#   - malformed SHA/version bail before any gh api call
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/generate-release.sh"
+
+RESOLVED_SHA="0123456789abcdef0123456789abcdef01234567"
+
+FAILURES=0
+pass() { echo "ok   - $1"; }
+fail() { echo "FAIL - $1"; FAILURES=$((FAILURES + 1)); }
+
+# Build a throwaway dir holding a fake gh whose api invocations are logged to
+# $GH_LOG. Prepending it to PATH shadows the real gh for the script under test.
+# Ref state lives in $STUB_DIR/refs ("<ref> <sha>" per line): a create-ref POST
+# appends to it, and a git/ref GET reads from it (404 if absent), so the stub
+# models ref existence across calls. Pre-seed it to simulate a prior partial run.
+setup_stub() {
+    STUB_DIR="$(mktemp -d)"
+    GH_LOG="${STUB_DIR}/gh.log"
+    : >"$GH_LOG"
+    : >"${STUB_DIR}/refs"
+    cat >"${STUB_DIR}/gh" <<STUB
+#!/bin/bash
+echo "\$*" >>"${GH_LOG}"
+[ "\$1" = "auth" ] && exit 0
+[ "\$1" = "api" ] || exit 0
+refs="${STUB_DIR}/refs"
+ref=""; sha=""
+for a in "\$@"; do
+    case "\$a" in
+        ref=*) ref="\${a#ref=}" ;;
+        sha=*) sha="\${a#sha=}" ;;
+    esac
+done
+if [ "\$3" = "--method" ] && [ "\$4" = "POST" ]; then
+    echo "\${ref} \${sha}" >>"\$refs"
+    exit 0
+fi
+case "\$2" in
+    */commits/*) echo "${RESOLVED_SHA}"; exit 0 ;;
+    */git/ref/*)
+        want="refs/\${2#*/git/ref/}"
+        line="\$(grep "^\${want} " "\$refs" 2>/dev/null | head -1)"
+        [ -n "\$line" ] && { echo "\${line#* }"; exit 0; }
+        exit 1
+        ;;
+esac
+exit 0
+STUB
+    chmod +x "${STUB_DIR}/gh"
+}
+
+teardown_stub() { rm -rf "$STUB_DIR"; }
+
+# invoke <sha> <version> ; requires an active stub; sets $STATUS.
+invoke() {
+    PATH="${STUB_DIR}:${PATH}" "$TARGET" "$1" "$2" >/dev/null 2>&1
+    STATUS=$?
+}
+
+# run_script <sha> <version> ; fresh stub, then invoke.
+run_script() {
+    setup_stub
+    invoke "$1" "$2"
+}
+
+# --- final release: branch + tag, both with the resolved full SHA ---
+run_script "$RESOLVED_SHA" "v1.2.3"
+if [ "$STATUS" -eq 0 ] \
+    && grep -q "git/refs --method POST -f ref=refs/heads/release-v1.2.3 -f sha=${RESOLVED_SHA}" "$GH_LOG" \
+    && grep -q "git/refs --method POST -f ref=refs/tags/v1.2.3 -f sha=${RESOLVED_SHA}" "$GH_LOG"; then
+    pass "final release v1.2.3 creates branch + tag on resolved SHA"
+else
+    fail "final release v1.2.3 creates branch + tag on resolved SHA"
+fi
+teardown_stub
+
+# --- pre-release: tag only, no branch ---
+run_script "$RESOLVED_SHA" "v1.2.3-rc1"
+if [ "$STATUS" -eq 0 ] \
+    && grep -q "git/refs --method POST -f ref=refs/tags/v1.2.3-rc1 -f sha=${RESOLVED_SHA}" "$GH_LOG" \
+    && ! grep -q "ref=refs/heads/" "$GH_LOG"; then
+    pass "pre-release v1.2.3-rc1 creates tag only, no branch"
+else
+    fail "pre-release v1.2.3-rc1 creates tag only, no branch"
+fi
+teardown_stub
+
+# --- abbreviated SHA is resolved before create-ref (the 422-avoidance fix) ---
+run_script "abc1234" "v1.2.3"
+if [ "$STATUS" -eq 0 ] \
+    && grep -q "sha=${RESOLVED_SHA}" "$GH_LOG" \
+    && ! grep -q "sha=abc1234" "$GH_LOG"; then
+    pass "abbreviated SHA resolved to full SHA for create-ref"
+else
+    fail "abbreviated SHA resolved to full SHA for create-ref"
+fi
+teardown_stub
+
+# --- malformed SHA bails before any gh api call ---
+run_script "nothexsha!" "v1.2.3"
+if [ "$STATUS" -ne 0 ] && ! grep -q '^api' "$GH_LOG"; then
+    pass "malformed SHA bails before any gh api call"
+else
+    fail "malformed SHA bails before any gh api call"
+fi
+teardown_stub
+
+# --- malformed version bails before any gh api call ---
+run_script "$RESOLVED_SHA" "1.2"
+if [ "$STATUS" -ne 0 ] && ! grep -q '^api' "$GH_LOG"; then
+    pass "malformed version bails before any gh api call"
+else
+    fail "malformed version bails before any gh api call"
+fi
+teardown_stub
+
+# --- re-run after a partial failure: existing branch at target SHA is reused,
+#     tag still gets created (recovery is safe, no manual branch delete) ---
+setup_stub
+echo "refs/heads/release-v1.2.3 ${RESOLVED_SHA}" >"${STUB_DIR}/refs"
+invoke "$RESOLVED_SHA" "v1.2.3"
+if [ "$STATUS" -eq 0 ] \
+    && ! grep -q "method POST -f ref=refs/heads/release-v1.2.3" "$GH_LOG" \
+    && grep -q "method POST -f ref=refs/tags/v1.2.3 -f sha=${RESOLVED_SHA}" "$GH_LOG"; then
+    pass "re-run reuses existing branch and creates the tag"
+else
+    fail "re-run reuses existing branch and creates the tag"
+fi
+teardown_stub
+
+# --- existing ref at a different SHA is an error, not a silent move ---
+setup_stub
+echo "refs/heads/release-v1.2.3 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" >"${STUB_DIR}/refs"
+invoke "$RESOLVED_SHA" "v1.2.3"
+if [ "$STATUS" -ne 0 ] && ! grep -q "method POST" "$GH_LOG"; then
+    pass "existing ref at a different SHA errors before any create-ref"
+else
+    fail "existing ref at a different SHA errors before any create-ref"
+fi
+teardown_stub
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "✅ All generate-release.sh tests passed!"
+    exit 0
+fi
+echo "❌ ${FAILURES} generate-release.sh test(s) failed"
+exit 1


### PR DESCRIPTION
## Why is this PR needed?

<!-- Explain the motivation: feature request, bug fix, performance improvement, etc. -->
make release simple not rely on local code also create release branch in case we need z stream patch in the future

## What does this PR do?
- rename GHA workflow: ci-release.yaml to ci-build.yaml only build "lateset" image for new commits on main branch move build image function to create-release.yaml which now does build binary, helm chart, docker image, push
- update generate-release.sh do not rely on local SHA1, it uses "gh" remote create tag, and release branch if it is an offical release, and take SHA1 as input so user no need create tag just give a SHA1 to script.
- make RELEASE_TEMPLATE.md clear: not in use
- update docs

<!-- Describe the changes and their purpose -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated/verified
- [ ] Integration/e2e tests added/updated/verified
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] CI checks pass (`make ci`)
- [ ] E2E tests pass (`make test-e2e`)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


cc @vishbhat 
