### PR TITLE
docs: add FOSSA license scan badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![apiserver](https://img.shields.io/github/v/release/llm-d/llm-d-batch-gateway?label=apiserver)](https://github.com/llm-d/llm-d-batch-gateway/pkgs/container/batch-gateway-apiserver)
 [![processor](https://img.shields.io/github/v/release/llm-d/llm-d-batch-gateway?label=processor)](https://github.com/llm-d/llm-d-batch-gateway/pkgs/container/batch-gateway-processor)
 [![gc](https://img.shields.io/github/v/release/llm-d/llm-d-batch-gateway?label=gc)](https://github.com/llm-d/llm-d-batch-gateway/pkgs/container/batch-gateway-gc)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-batch-gateway.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-batch-gateway?ref=badge_shield)
 
 ## Overview
 
@@ -458,6 +459,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-batch-gateway.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fllm-d%2Fllm-d-batch-gateway?ref=badge_large)
 
 ## Related Projects
 


### PR DESCRIPTION
## What

Adds the FOSSA license scan badge to the README (a small shield badge in the badge row at the top, and a large status badge above "Related Projects").

## Why

This re-does #567, which was opened by `fossabot`. That PR could not be merged because the bot-generated commit was unsigned and had no sign-off, failing DCO, signed-commits, pre-commit, and title-and-labels checks. As suggested in [#567](https://github.com/llm-d/llm-d-batch-gateway/pull/567#issuecomment-5026124742), the badge change is cherry-picked here into a signed, signed-off commit.

## Review comments from #567 addressed

- **Sign-off / DCO / signed-commits** — commit is signed off (`git commit -s`).
- **Trailing newline** ([review comment](https://github.com/llm-d/llm-d-batch-gateway/pull/567)) — the original PR dropped the EOF newline; it is preserved here.
- **Failing red badge** ([review comment](https://github.com/llm-d/llm-d-batch-gateway/pull/567)) — at review time (2026-07-13) FOSSA reported 1 licensing issue and the badge rendered red/failing. As of 2026-08-05 the FOSSA scan reports **"No issues found"**, so the badge renders green/passing.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)