### PR TITLE
fix(processor): key AIMD endpoint state by route key, switch to route_key_method

### DIFF
--- a/charts/batch-gateway/templates/processor-configmap.yaml
+++ b/charts/batch-gateway/templates/processor-configmap.yaml
@@ -130,8 +130,8 @@ data:
     {{- if .Values.processor.config.sendFairnessHeader }}
     send_fairness_header: true
     {{- end }}
-    {{- if .Values.processor.config.routeKeyByTenant }}
-    route_key_by_tenant: true
+    {{- if .Values.processor.config.routeKeyMethod }}
+    route_key_method: {{ .Values.processor.config.routeKeyMethod | quote }}
     {{- end }}
     default_output_expiration_seconds: {{ .Values.processor.config.defaultOutputExpirationSeconds }}
     progress_ttl_seconds: {{ .Values.processor.config.progressTTLSeconds }}

--- a/charts/batch-gateway/tests/processor-configmap_test.yaml
+++ b/charts/batch-gateway/tests/processor-configmap_test.yaml
@@ -388,19 +388,19 @@ tests:
           path: data["config.yaml"]
           pattern: 'send_fairness_header: true'
 
-  - it: should not render route_key_by_tenant when false (default)
+  - it: should not render route_key_method when empty (default)
     asserts:
       - notMatchRegex:
           path: data["config.yaml"]
-          pattern: 'route_key_by_tenant:'
+          pattern: 'route_key_method:'
 
-  - it: should render route_key_by_tenant when enabled
+  - it: should render route_key_method when set to tenant
     set:
-      processor.config.routeKeyByTenant: true
+      processor.config.routeKeyMethod: tenant
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: 'route_key_by_tenant: true'
+          pattern: 'route_key_method: "tenant"'
 
   - it: should not render ConfigMap when processor is disabled
     set:

--- a/charts/batch-gateway/values.yaml
+++ b/charts/batch-gateway/values.yaml
@@ -393,10 +393,12 @@ processor:
     #     inferenceObjective: "batch-sheddable-b"   # references gie-b pool
     #     requestTimeout: "2m"
     #     maxRetries: 1
-    # Scope modelGateways lookups by the persisted job tenant ID. When enabled,
+    # How modelGateways lookup keys are derived from a request model ID.
+    # Set to "tenant" to scope lookups by the persisted job tenant ID; then
     # configure keys as "<tenantID>/<modelID>". The forwarded request body keeps
     # its original model ID so the runtime still receives its served model name.
-    routeKeyByTenant: false
+    # Empty keeps bare-model lookups. Additional methods may be added later.
+    routeKeyMethod: ""
 
     # Async dispatch mode (alternative to sync).
     # Set dispatchMode: "async" and configure asyncDispatch.models instead

--- a/internal/processor/config/config.go
+++ b/internal/processor/config/config.go
@@ -81,6 +81,17 @@ const (
 	DispatchModeAsync DispatchMode = "async"
 )
 
+// RouteKeyMethod selects how model_gateways lookup keys are derived from a
+// request model ID.
+type RouteKeyMethod string
+
+const (
+	// RouteKeyMethodBare (default, empty) keys lookups by the bare model ID.
+	RouteKeyMethodBare RouteKeyMethod = ""
+	// RouteKeyMethodTenant scopes lookups as "<tenantID>/<modelID>".
+	RouteKeyMethodTenant RouteKeyMethod = "tenant"
+)
+
 // AsyncModelConfig describes the async dispatch target for a single model.
 type AsyncModelConfig struct {
 	// InferencePoolName identifies the async dispatch pool for this model.
@@ -174,13 +185,13 @@ type ProcessorConfig struct {
 	// Ignored when GlobalInferenceGateway is set.
 	ModelGateways map[string]ModelGatewayConfig `yaml:"model_gateways"`
 
-	// RouteKeyByTenant scopes model_gateways lookups by the job's tenant ID:
-	// when enabled, requests resolve gateways under "<tenantID>/<modelID>",
-	// so identically-named models of different tenants route to their own
-	// backends on a shared apiserver. The forwarded request body is left
-	// untouched (the runtime still sees the bare model name). Default false
-	// keeps bare-model lookups.
-	RouteKeyByTenant bool `yaml:"route_key_by_tenant"`
+	// RouteKeyMethod selects how model_gateways lookup keys are derived.
+	// "tenant" scopes lookups by the job's tenant ID: requests resolve
+	// gateways under "<tenantID>/<modelID>", so identically-named models of
+	// different tenants route to their own backends on a shared apiserver.
+	// The forwarded request body is left untouched (the runtime still sees
+	// the bare model name). Empty (default) keeps bare-model lookups.
+	RouteKeyMethod RouteKeyMethod `yaml:"route_key_method"`
 
 	// DefaultOutputExpirationSeconds is the default TTL for batch output/error files in seconds.
 	// Used as fallback when the user does not provide output_expires_after in POST /v1/batches.
@@ -415,6 +426,12 @@ func (c *ProcessorConfig) Validate() error {
 
 	if c.ProgressTTLSeconds <= 0 {
 		return fmt.Errorf("progress_ttl_seconds must be > 0")
+	}
+
+	switch c.RouteKeyMethod {
+	case RouteKeyMethodBare, RouteKeyMethodTenant:
+	default:
+		return fmt.Errorf("route_key_method must be empty or %q, got %q", RouteKeyMethodTenant, c.RouteKeyMethod)
 	}
 
 	if err := c.validateGateways(); err != nil {

--- a/internal/processor/config/config_test.go
+++ b/internal/processor/config/config_test.go
@@ -89,8 +89,8 @@ func TestNewConfig_Defaults(t *testing.T) {
 	if c.SendFairnessHeader {
 		t.Fatalf("SendFairnessHeader = true, want false by default")
 	}
-	if c.RouteKeyByTenant {
-		t.Fatalf("RouteKeyByTenant = true, want false by default")
+	if c.RouteKeyMethod != RouteKeyMethodBare {
+		t.Fatalf("RouteKeyMethod = %q, want empty (bare) by default", c.RouteKeyMethod)
 	}
 
 	want90Days := int64(90 * 24 * 60 * 60)
@@ -565,7 +565,7 @@ model_gateways:
 default_output_expiration_seconds: 86400
 progress_ttl_seconds: 3600
 send_fairness_header: true
-route_key_by_tenant: true
+route_key_method: tenant
 `)
 
 	if err := os.WriteFile(path, yamlData, 0o600); err != nil {
@@ -643,8 +643,33 @@ route_key_by_tenant: true
 	if !c.SendFairnessHeader {
 		t.Fatalf("SendFairnessHeader = false, want true")
 	}
-	if !c.RouteKeyByTenant {
-		t.Fatalf("RouteKeyByTenant = false, want true")
+	if c.RouteKeyMethod != RouteKeyMethodTenant {
+		t.Fatalf("RouteKeyMethod = %q, want %q", c.RouteKeyMethod, RouteKeyMethodTenant)
+	}
+}
+
+func TestValidate_RouteKeyMethod(t *testing.T) {
+	base := func() *ProcessorConfig {
+		c := NewConfig()
+		c.ModelGateways = validPerModelConfig()
+		return c
+	}
+
+	c := base()
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error for default route_key_method: %v", err)
+	}
+
+	c = base()
+	c.RouteKeyMethod = RouteKeyMethodTenant
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error for tenant route_key_method: %v", err)
+	}
+
+	c = base()
+	c.RouteKeyMethod = RouteKeyMethod("geography")
+	if err := c.Validate(); err == nil {
+		t.Fatal("Validate() expected error for unknown route_key_method, got nil")
 	}
 }
 

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
@@ -74,7 +75,7 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 
 	// The dispatcher forwards requests for processing.
 	pending := pipeline.NewPendingRequests(modelMap.LineCount)
-	dispatcher, err := p.buildRequestDispatcher(modelMap, pending, logger)
+	dispatcher, err := p.buildRequestDispatcher(modelMap, pending, params.jobInfo.TenantID, logger)
 	if err != nil {
 		return nil, fmt.Errorf("build dispatcher: %w", err)
 	}
@@ -123,14 +124,14 @@ func classifyOutcome(cause error, counts *openai.BatchRequestCounts, execErr err
 	return execErr
 }
 
-func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, logger logr.Logger) (pipeline.RequestDispatcher, error) {
+func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipeline.PendingRequests, tenantID string, logger logr.Logger) (pipeline.RequestDispatcher, error) {
 	switch {
 	case p.asyncInference != nil:
 		broadcasters := p.broadcasters.forModels(modelMap)
 		async := pipeline.NewAsyncDispatcher(p.asyncInference, broadcasters, pending, logger)
 		return pipeline.NewPreDispatcher(async), nil
 	case p.cfg.Concurrency.AIMD.Enabled:
-		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits)
+		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
 		direct := pipeline.NewDirectDispatcher(p.inference, logger)
 		aimd, err := pipeline.NewAIMDDispatcher(direct, models, p.cfg.Concurrency.Global, logger)
 		if err != nil {
@@ -142,7 +143,7 @@ func (p *Processor) buildRequestDispatcher(modelMap *modelMapFile, pending *pipe
 		// EndpointAIMD.AIMD is nil so recordAIMDSignal is a no-op, but the semaphores
 		// still enforce fixed concurrency limits (global + per-endpoint). Without this,
 		// DirectDispatcher would dispatch all requests as unbounded goroutines.
-		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits)
+		models := buildAIMDModels(modelMap, p.inference, p.endpointLimits, p.cfg.RouteKeyMethod, tenantID)
 		direct := pipeline.NewDirectDispatcher(p.inference, logger)
 		aimd, err := pipeline.NewAIMDDispatcher(direct, models, p.cfg.Concurrency.Global, logger)
 		if err != nil {
@@ -215,10 +216,16 @@ func (p *Processor) openDataFiles(params *jobExecutionParams) (*dataFiles, error
 	return &dataFiles{input: inputFile, output: outputFile, error: errorFile}, nil
 }
 
-func buildAIMDModels(modelMap *modelMapFile, resolver *inference.GatewayResolver, endpointLimits map[inference.InferenceClient]*endpointLimit) map[string]*pipeline.EndpointAIMD {
+// buildAIMDModels keys per-endpoint concurrency state by route key: dispatch
+// items carry the route key as their ModelID, so the lookup key, the resolver
+// key and the map key must all be derived the same way. Keying by the bare
+// model ID would leave the map empty under tenant-scoped routing and silently
+// disable per-endpoint limiting and AIMD backoff.
+func buildAIMDModels(modelMap *modelMapFile, resolver *inference.GatewayResolver, endpointLimits map[inference.InferenceClient]*endpointLimit, method config.RouteKeyMethod, tenantID string) map[string]*pipeline.EndpointAIMD {
 	models := make(map[string]*pipeline.EndpointAIMD)
 	for _, modelID := range modelMap.SafeToModel {
-		client := resolver.ClientFor(modelID)
+		key := routeKey(method, tenantID, modelID)
+		client := resolver.ClientFor(key)
 		if client == nil {
 			continue
 		}
@@ -226,7 +233,7 @@ func buildAIMDModels(modelMap *modelMapFile, resolver *inference.GatewayResolver
 		if ep == nil {
 			continue
 		}
-		models[modelID] = &pipeline.EndpointAIMD{
+		models[key] = &pipeline.EndpointAIMD{
 			Sem:   ep.sem,
 			AIMD:  ep.aimd,
 			Label: ep.label,

--- a/internal/processor/worker/execute_pipeline_test.go
+++ b/internal/processor/worker/execute_pipeline_test.go
@@ -1,0 +1,122 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/semaphore"
+	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
+)
+
+func TestBuildAIMDModels(t *testing.T) {
+	// Tenant-scoped gateway config, as produced when route_key_method is
+	// "tenant": only "<tenantID>/<modelID>" entries exist in the resolver.
+	scopedResolver, err := inference.NewPerModelResolver(
+		map[string]inference.GatewayClientConfig{
+			"tenant-a/m1": {URL: "http://fake-a:8000"},
+			"tenant-b/m1": {URL: "http://fake-b:8000"},
+		},
+		testLogger(t),
+	)
+	if err != nil {
+		t.Fatalf("NewPerModelResolver: %v", err)
+	}
+	defer func() { _ = scopedResolver.Close() }()
+
+	bareResolver, err := inference.NewPerModelResolver(
+		map[string]inference.GatewayClientConfig{
+			"m1": {URL: "http://fake:8000"},
+		},
+		testLogger(t),
+	)
+	if err != nil {
+		t.Fatalf("NewPerModelResolver: %v", err)
+	}
+	defer func() { _ = bareResolver.Close() }()
+
+	limitsFor := func(t *testing.T, resolver *inference.GatewayResolver) map[inference.InferenceClient]*endpointLimit {
+		t.Helper()
+		limits := make(map[inference.InferenceClient]*endpointLimit)
+		for _, client := range resolver.Clients() {
+			sem, err := semaphore.NewAdaptive(2, nil)
+			if err != nil {
+				t.Fatalf("endpoint semaphore: %v", err)
+			}
+			limits[client] = &endpointLimit{sem: sem, label: resolver.ClientLabel(client)}
+		}
+		return limits
+	}
+
+	modelMap := &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 1}
+
+	tests := []struct {
+		name      string
+		resolver  *inference.GatewayResolver
+		method    config.RouteKeyMethod
+		tenantID  string
+		wantKeys  []string
+		wantEmpty bool
+	}{
+		{
+			name:     "tenant method registers the scoped key so dispatch finds the endpoint",
+			resolver: scopedResolver,
+			method:   config.RouteKeyMethodTenant,
+			tenantID: "tenant-a",
+			wantKeys: []string{"tenant-a/m1"},
+		},
+		{
+			name:      "bare method against scoped config registers nothing (guards the reported regression)",
+			resolver:  scopedResolver,
+			method:    config.RouteKeyMethodBare,
+			tenantID:  "tenant-a",
+			wantEmpty: true,
+		},
+		{
+			name:     "bare method against bare config keeps the default behavior",
+			resolver: bareResolver,
+			method:   config.RouteKeyMethodBare,
+			tenantID: "tenant-a",
+			wantKeys: []string{"m1"},
+		},
+		{
+			name:     "tenant method ignores endpoints of other tenants",
+			resolver: scopedResolver,
+			method:   config.RouteKeyMethodTenant,
+			tenantID: "tenant-b",
+			wantKeys: []string{"tenant-b/m1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			models := buildAIMDModels(modelMap, tt.resolver, limitsFor(t, tt.resolver), tt.method, tt.tenantID)
+			if tt.wantEmpty {
+				if len(models) != 0 {
+					t.Fatalf("buildAIMDModels() = %v keys, want empty", mapKeys(models))
+				}
+				return
+			}
+			if len(models) != len(tt.wantKeys) {
+				t.Fatalf("buildAIMDModels() = %v keys, want %v", mapKeys(models), tt.wantKeys)
+			}
+			for _, key := range tt.wantKeys {
+				ep := models[key]
+				if ep == nil {
+					t.Fatalf("buildAIMDModels() missing key %q (per-endpoint limiting would be silently disabled)", key)
+				}
+				if ep.Sem == nil {
+					t.Fatalf("buildAIMDModels()[%q].Sem is nil", key)
+				}
+			}
+		})
+	}
+}
+
+func mapKeys(m map[string]*pipeline.EndpointAIMD) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/processor/worker/preprocessor.go
+++ b/internal/processor/worker/preprocessor.go
@@ -178,9 +178,9 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 
 		if isPerModelGateway {
 			// Look up the gateway by the route key (tenant-scoped when
-			// route_key_by_tenant is enabled). The raw model ID stays in the
+			// route_key_method is "tenant"). The raw model ID stays in the
 			// error message and plan grouping below.
-			lookupID := routeKey(p.cfg.RouteKeyByTenant, jobInfo.TenantID, requestMeta.ModelID)
+			lookupID := routeKey(p.cfg.RouteKeyMethod, jobInfo.TenantID, requestMeta.ModelID)
 			registered, checked := registeredModels[lookupID]
 			if !checked {
 				registered = p.inference.ClientFor(lookupID) != nil
@@ -206,7 +206,9 @@ func (p *Processor) preProcessJob(ctx context.Context, jobInfo *batch_types.JobI
 					return fmt.Errorf("failed to write model_not_found error: %w", writeErr)
 				}
 				rejectedCount++
-				metrics.RecordRequestError(requestMeta.ModelID)
+				// Error metric rides the route key so labels stay consistent
+				// with the dispatch path, whose items carry the scoped ID.
+				metrics.RecordRequestError(lookupID)
 				logger.V(logging.DEBUG).Info("Rejected request for unregistered model",
 					"customId", requestMeta.CustomID, "model", requestMeta.ModelID)
 				offset += int64(len(line))

--- a/internal/processor/worker/route_key.go
+++ b/internal/processor/worker/route_key.go
@@ -1,13 +1,17 @@
 package worker
 
+import (
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+)
+
 // routeKey returns the model_gateways lookup key for a request model. When
-// byTenant is enabled and tenantID is non-empty, gateway entries are scoped
-// per tenant as "<tenantID>/<modelID>", letting identically-named models of
-// different tenants route to their own backends (e.g. per-InferSet gateways
-// sharing one batch-apiserver). Otherwise the bare model ID is used,
+// the route key method is "tenant" and tenantID is non-empty, gateway entries
+// are scoped per tenant as "<tenantID>/<modelID>", letting identically-named
+// models of different tenants route to their own backends (e.g. per-InferSet
+// gateways sharing one batch-apiserver). Otherwise the bare model ID is used,
 // preserving the default behavior.
-func routeKey(byTenant bool, tenantID, modelID string) string {
-	if !byTenant || tenantID == "" {
+func routeKey(method config.RouteKeyMethod, tenantID, modelID string) string {
+	if method != config.RouteKeyMethodTenant || tenantID == "" {
 		return modelID
 	}
 	return tenantID + "/" + modelID

--- a/internal/processor/worker/route_key.go
+++ b/internal/processor/worker/route_key.go
@@ -11,8 +11,8 @@ import (
 // gateways sharing one batch-apiserver). Otherwise the bare model ID is used,
 // preserving the default behavior.
 func routeKey(method config.RouteKeyMethod, tenantID, modelID string) string {
-	if method != config.RouteKeyMethodTenant || tenantID == "" {
-		return modelID
+	if method == config.RouteKeyMethodTenant && tenantID != "" {
+		return tenantID + "/" + modelID
 	}
-	return tenantID + "/" + modelID
+	return modelID
 }

--- a/internal/processor/worker/route_key_test.go
+++ b/internal/processor/worker/route_key_test.go
@@ -1,42 +1,53 @@
 package worker
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
+)
 
 func TestRouteKey(t *testing.T) {
 	tests := []struct {
 		name     string
-		byTenant bool
+		method   config.RouteKeyMethod
 		tenantID string
 		modelID  string
 		want     string
 	}{
 		{
-			name:     "disabled keeps bare model ID",
-			byTenant: false,
+			name:     "default method keeps bare model ID",
+			method:   config.RouteKeyMethodBare,
 			tenantID: "m-20260720103021-nvfbq",
 			modelID:  "test-model-v1",
 			want:     "test-model-v1",
 		},
 		{
-			name:     "enabled with empty tenant keeps bare model ID",
-			byTenant: true,
+			name:     "tenant method with empty tenant keeps bare model ID",
+			method:   config.RouteKeyMethodTenant,
 			tenantID: "",
 			modelID:  "test-model-v1",
 			want:     "test-model-v1",
 		},
 		{
-			name:     "enabled scopes the lookup key by tenant",
-			byTenant: true,
+			name:     "tenant method scopes the lookup key by tenant",
+			method:   config.RouteKeyMethodTenant,
 			tenantID: "m-20260720103021-nvfbq",
 			modelID:  "test-model-v1",
 			want:     "m-20260720103021-nvfbq/test-model-v1",
+		},
+		{
+			name:     "unknown method keeps bare model ID",
+			method:   config.RouteKeyMethod("geography"),
+			tenantID: "m-20260720103021-nvfbq",
+			modelID:  "test-model-v1",
+			want:     "test-model-v1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := routeKey(tt.byTenant, tt.tenantID, tt.modelID); got != tt.want {
-				t.Fatalf("routeKey(%v, %q, %q) = %q, want %q", tt.byTenant, tt.tenantID, tt.modelID, got, tt.want)
+			if got := routeKey(tt.method, tt.tenantID, tt.modelID); got != tt.want {
+				t.Fatalf("routeKey(%q, %q, %q) = %q, want %q", tt.method, tt.tenantID, tt.modelID, got, tt.want)
 			}
 		})
 	}

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -108,11 +108,11 @@ func (s *PlanFileSource) readEntry(entry planEntry, modelID string) (*pipeline.R
 		}, nil
 	}
 
-	// When route_key_by_tenant is enabled, scope the gateway lookup key by
+	// When route_key_method is "tenant", scope the gateway lookup key by
 	// tenant so identically-named models of different tenants route to their
 	// own backends (model_gateways entries keyed "<tenantID>/<modelID>").
 	// The request body itself is forwarded verbatim to the inference backend.
-	lookupID := routeKey(s.cfg.RouteKeyByTenant, s.tenantID, modelID)
+	lookupID := routeKey(s.cfg.RouteKeyMethod, s.tenantID, modelID)
 
 	headers := maps.Clone(s.passThroughHeaders)
 	headers = s.mergeHeaders(headers, lookupID)

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -383,7 +383,7 @@ func TestPlanFileSource_Produce_TenantScopedLookup(t *testing.T) {
 	defer func() { _ = resolver.Close() }()
 
 	cfg := config.NewConfig()
-	cfg.RouteKeyByTenant = true
+	cfg.RouteKeyMethod = config.RouteKeyMethodTenant
 	cfg.ModelGateways = map[string]config.ModelGatewayConfig{
 		"inferset-a/m1": {
 			URL:                "http://gw-a:8000",
@@ -425,7 +425,7 @@ func TestPlanFileSource_Produce_TenantScopedLookup(t *testing.T) {
 		t.Errorf("objective header = %q, want %q", items[0].Headers[inferenceObjectiveHeader], "inferset-a-batch")
 	}
 
-	// With the default config (route_key_by_tenant off), the same tenant must
+	// With the default config (route_key_method empty), the same tenant must
 	// not affect the lookup key — guards the backward-compatible behavior.
 	cfgOff := config.NewConfig()
 	inputFile2, err := os.Open(inputPath)
@@ -444,11 +444,11 @@ func TestPlanFileSource_Produce_TenantScopedLookup(t *testing.T) {
 	})
 	outOff := make(chan pipeline.RequestItem, 10)
 	if err := sourceOff.Produce(context.Background(), outOff); err != nil {
-		t.Fatalf("Produce (route_key_by_tenant off) error: %v", err)
+		t.Fatalf("Produce (route_key_method empty) error: %v", err)
 	}
 	for item := range outOff {
 		if item.ModelID != "m1" {
-			t.Errorf("route_key_by_tenant off: ModelID = %q, want bare %q", item.ModelID, "m1")
+			t.Errorf("route_key_method empty: ModelID = %q, want bare %q", item.ModelID, "m1")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #641

Follow-ups to the #630 review by @yizhaodev (comments on the merged PR):

1. **Fix silently disabled AIMD under tenant-scoped routing.** `buildAIMDModels` resolved clients and keyed its per-endpoint map by the bare model ID, while dispatch items carry the route key (`<tenantID>/<modelID>`) as their ModelID. With `route_key_method: tenant` the resolver lookup missed every scoped entry, the endpoint map was built empty, and `acquireSlot` silently fell back to global-semaphore-only gating — per-endpoint concurrency limits and AIMD adaptive backoff never engaged. Resolver lookup, map keys and the dispatcher lookup now all derive from `routeKey()`.

2. **`route_key_by_tenant` → `route_key_method` enum.** As suggested in review, this leaves room for future scope methods (e.g. `geography`). Empty (default) keeps bare-model lookups; `tenant` scopes as `<tenantID>/<modelID>`. The boolean merged in #630 has not shipped in any release, so this is a clean rename before it becomes public API.

3. **Metric label alignment.** The preprocessing model-not-found error metric now uses the route key, matching the dispatch path labels.

Plan preprocessing (grouping / prefix-cache sorting) is intentionally unchanged: jobs are single-tenant units, so bare and scoped keys partition identically within a job.

## Test plan

- New `TestBuildAIMDModels` covers the regression: scoped entries register under `<tenantID>/<modelID>`, cross-tenant isolation holds, bare method + bare config keeps default behavior, and the previously-broken combination (bare keys against scoped config) is asserted to register nothing.
- `TestRouteKey` enum behavior incl. unknown methods; `TestValidate_RouteKeyMethod` rejects unknown values.
- Chart tests cover `route_key_method` rendering; `helm lint` + 100 chart unit tests pass locally.
- `go test ./internal/processor/... ./pkg/clients/...` green; `go vet` clean.
