### PR TITLE
feat(gc): initialize OTel tracer and trace orphan triage

### DIFF
--- a/cmd/batch-gc/main.go
+++ b/cmd/batch-gc/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/clientset"
 	ucom "github.com/llm-d/llm-d-batch-gateway/internal/util/com"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/interrupt"
+	uotel "github.com/llm-d/llm-d-batch-gateway/internal/util/otel"
 )
 
 func main() {
@@ -70,6 +71,18 @@ func run() error {
 
 	logger.Info("Starting batch garbage collector", "dryRun", cfg.DryRun, "interval", cfg.Collector.Interval)
 
+	shutdownTracer, err := uotel.InitTracer(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := shutdownTracer(shutdownCtx); err != nil {
+			logger.Error(err, "Failed to shutdown tracer")
+		}
+	}()
+
 	if err := gcmetrics.InitMetrics(); err != nil {
 		return fmt.Errorf("failed to initialize metrics: %w", err)
 	}
@@ -78,6 +91,8 @@ func run() error {
 	defer cancel()
 
 	cfg.DBClientCfg.RedisCfg.ServiceName = "batch-gc"
+	cfg.DBClientCfg.RedisCfg.EnableTracing = cfg.OTelCfg.RedisTracing
+	cfg.DBClientCfg.PostgreSQLCfg.EnableTracing = cfg.OTelCfg.PostgresqlTracing
 
 	clientOpts := []clientset.Option{
 		clientset.WithDB(cfg.DBClientCfg),

--- a/internal/gc/config/config.go
+++ b/internal/gc/config/config.go
@@ -70,6 +70,9 @@ type Config struct {
 
 	// FileClientCfg holds the file storage backend configuration.
 	FileClientCfg sharedcfg.FileClientConfig `yaml:"file_client"`
+
+	// OTelCfg holds OpenTelemetry-related settings.
+	OTelCfg sharedcfg.OTelConfig `yaml:"otel"`
 }
 
 // Load reads and validates a Config from the given YAML file path.

--- a/internal/gc/reconciler/reconciler.go
+++ b/internal/gc/reconciler/reconciler.go
@@ -27,11 +27,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
 
 	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/batch_utils"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
 	batch_types "github.com/llm-d/llm-d-batch-gateway/internal/shared/types"
+	uotel "github.com/llm-d/llm-d-batch-gateway/internal/util/otel"
 )
 
 const pageSize = 100
@@ -219,7 +221,11 @@ func (r *Reconciler) fetchNonTerminalJobs(ctx context.Context) ([]*db.BatchItem,
 // triageOrphan determines the correct recovery action for an orphaned job
 // based on its current status and SLO.
 func (r *Reconciler) triageOrphan(ctx context.Context, job *db.BatchItem, result *Result) {
-	logger := logr.FromContextOrDiscard(ctx).WithValues("jobId", job.ID)
+	ctx = logr.NewContext(ctx, logr.FromContextOrDiscard(ctx).WithValues("jobId", job.ID))
+	ctx, span := uotel.StartSpan(ctx, "reconciler.triage")
+	defer span.End()
+	span.SetAttributes(attribute.String(uotel.AttrBatchID, job.ID))
+	logger := logr.FromContextOrDiscard(ctx)
 
 	var statusInfo openai.BatchStatusInfo
 	if err := json.Unmarshal(job.Status, &statusInfo); err != nil {
@@ -227,6 +233,7 @@ func (r *Reconciler) triageOrphan(ctx context.Context, job *db.BatchItem, result
 		result.Errors++
 		return
 	}
+	span.SetAttributes(attribute.String("batch.status", string(statusInfo.Status)))
 
 	sloExpired := isSLOExpired(job)
 


### PR DESCRIPTION
batch-gc is the only binary without tracing, so the reconciler's interventions (re-enqueues, CAS transitions on orphans) are invisible in traces even though they change batch state. This initializes the OTel tracer in main, wraps `triageOrphan` in a `reconciler.triage` span carrying the batch ID and status, and wires the existing `otel.redis_tracing` / `otel.postgresql_tracing` config flags through to the gc's store clients, matching the apiserver and processor.

No behavior change when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset (tracing stays disabled, same as the other binaries).
