### PR TITLE
fix(postgresql): retry ensureSchema on SQLSTATE 23505

### DIFF
--- a/internal/database/postgresql/db_core.go
+++ b/internal/database/postgresql/db_core.go
@@ -23,12 +23,15 @@ package postgresql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 )
@@ -454,8 +457,23 @@ func (c *pgCore) delete(ctx context.Context, ids []string) (deletedIDs []string,
 	return deletedIDs, nil
 }
 
+// ensureSchema applies the table DDL.
 func (c *pgCore) ensureSchema(ctx context.Context) error {
-	_, err := c.pool.Exec(ctx, c.desc.Schema())
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		if _, err = c.pool.Exec(ctx, c.desc.Schema()); err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "23505" {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+		}
+	}
 	return err
 }
 


### PR DESCRIPTION
Concurrent `CREATE TABLE IF NOT EXISTS` from multiple booting components can race inside Postgres and fail with spurious SQLSTATE 23505 unique violations on the `pg_type`/`pg_class` catalog indexes even though the `IF NOT EXISTS` guard holds. Seen as a real cold-boot crash when apiserver, processor, and gc start together against a fresh database. The loser now retries and finds the objects in place.

This treats the symptom at minimal size. The underlying shape — schema DDL running in every component — is #648; single-owner migrations make this retry unnecessary.
