### PR TITLE
feat: resume batches from Postgres result scratch after worker loss

### DIFF
--- a/internal/database/api/result_item.go
+++ b/internal/database/api/result_item.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+
+	"github.com/llm-d/llm-d-batch-gateway/internal/shared/store"
+)
+
+// ResultRow is one durably persisted request result: the output line a worker
+// wrote for a request, keyed by batch and custom_id so a replacement worker
+// can resume a batch without re-executing completed requests.
+type ResultRow struct {
+	BatchID  string
+	CustomID string
+	// IsError reports which local file the line belongs to (error.jsonl
+	// vs output.jsonl), mirroring the collector's routing.
+	IsError bool
+	// Line is the marshaled output line without a trailing newline.
+	Line []byte
+}
+
+// ResultDBClient persists per-request results as durable worker scratch space.
+type ResultDBClient interface {
+	store.BatchClientAdmin
+
+	// ResultStore inserts one row; a duplicate (batch_id, custom_id) is a no-op.
+	ResultStore(ctx context.Context, row *ResultRow) error
+	// ResultGetAll returns every persisted row for the batch.
+	ResultGetAll(ctx context.Context, batchID string) ([]*ResultRow, error)
+	// ResultDelete removes every persisted row for the batch.
+	ResultDelete(ctx context.Context, batchID string) error
+}

--- a/internal/database/postgresql/result_db.go
+++ b/internal/database/postgresql/result_db.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The llm-d Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgresql
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/llm-d/llm-d-batch-gateway/internal/database/api"
+)
+
+//go:embed result_schema.sql
+var resultSchemaSql string
+
+// Compile-time check: resultTableDescriptor implements TableDescriptor.
+var _ TableDescriptor = (*resultTableDescriptor)(nil)
+
+// resultTableDescriptor only supplies the schema; the client issues its own
+// SQL because the table is keyed by (batch_id, custom_id), not the common
+// id/tenant layout pgCore builds queries for.
+type resultTableDescriptor struct{}
+
+func (resultTableDescriptor) TableName() string      { return "batch_request_results" }
+func (resultTableDescriptor) Schema() string         { return resultSchemaSql }
+func (resultTableDescriptor) ExtraColumns() []string { return nil }
+
+// PostgresResultDBClient implements api.ResultDBClient using PostgreSQL.
+type PostgresResultDBClient struct {
+	core *pgCore
+}
+
+var _ api.ResultDBClient = (*PostgresResultDBClient)(nil)
+
+// NewPostgresResultDBClient creates a new PostgreSQL result database client.
+func NewPostgresResultDBClient(ctx context.Context, config *PostgreSQLConfig) (*PostgresResultDBClient, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	core, err := newPgCore(ctx, config, resultTableDescriptor{})
+	if err != nil {
+		return nil, err
+	}
+
+	logr.FromContextOrDiscard(ctx).Info("NewPostgresResultDBClient: client created successfully")
+	return &PostgresResultDBClient{core: core}, nil
+}
+
+func (c *PostgresResultDBClient) Close() error {
+	return c.core.close()
+}
+
+func (c *PostgresResultDBClient) ResultStore(ctx context.Context, row *api.ResultRow) error {
+	if row == nil {
+		return fmt.Errorf("row is nil")
+	}
+	_, err := c.core.pool.Exec(ctx,
+		`INSERT INTO batch_request_results (batch_id, custom_id, is_error, line)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (batch_id, custom_id) DO NOTHING`,
+		row.BatchID, row.CustomID, row.IsError, row.Line)
+	if err != nil {
+		return fmt.Errorf("store result row: %w", err)
+	}
+	return nil
+}
+
+func (c *PostgresResultDBClient) ResultGetAll(ctx context.Context, batchID string) ([]*api.ResultRow, error) {
+	rows, err := c.core.pool.Query(ctx,
+		`SELECT custom_id, is_error, line FROM batch_request_results WHERE batch_id = $1`, batchID)
+	if err != nil {
+		return nil, fmt.Errorf("get result rows: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*api.ResultRow
+	for rows.Next() {
+		r := &api.ResultRow{BatchID: batchID}
+		if err := rows.Scan(&r.CustomID, &r.IsError, &r.Line); err != nil {
+			return nil, fmt.Errorf("scan result row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate result rows: %w", err)
+	}
+	return out, nil
+}
+
+func (c *PostgresResultDBClient) ResultDelete(ctx context.Context, batchID string) error {
+	_, err := c.core.pool.Exec(ctx,
+		`DELETE FROM batch_request_results WHERE batch_id = $1`, batchID)
+	if err != nil {
+		return fmt.Errorf("delete result rows: %w", err)
+	}
+	return nil
+}

--- a/internal/database/postgresql/result_schema.sql
+++ b/internal/database/postgresql/result_schema.sql
@@ -1,0 +1,20 @@
+-- Copyright 2026 The llm-d Authors
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+-- http://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE IF NOT EXISTS batch_request_results (
+    batch_id  TEXT NOT NULL,
+    custom_id TEXT NOT NULL,
+    is_error  BOOLEAN NOT NULL,
+    line      JSONB NOT NULL,
+    PRIMARY KEY (batch_id, custom_id)
+);

--- a/internal/gc/reconciler/reconciler.go
+++ b/internal/gc/reconciler/reconciler.go
@@ -250,7 +250,14 @@ func (r *Reconciler) triageOrphan(ctx context.Context, job *db.BatchItem, result
 			ok = r.reEnqueueOrphan(ctx, job, result, logger)
 		}
 
-	case openai.BatchStatusInProgress, openai.BatchStatusFinalizing:
+	case openai.BatchStatusInProgress:
+		if sloExpired {
+			ok = r.transitionOrphan(ctx, job, &statusInfo, openai.BatchStatusExpired, result, logger)
+		} else {
+			ok = r.reEnqueueOrphan(ctx, job, result, logger)
+		}
+
+	case openai.BatchStatusFinalizing:
 		if sloExpired {
 			ok = r.transitionOrphan(ctx, job, &statusInfo, openai.BatchStatusExpired, result, logger)
 		} else {

--- a/internal/gc/reconciler/reconciler_test.go
+++ b/internal/gc/reconciler/reconciler_test.go
@@ -162,7 +162,7 @@ func TestTriageOrphan(t *testing.T) {
 		assertJobStatus(t, batchDB, "job-1", openai.BatchStatusExpired)
 	})
 
-	t.Run("in_progress with future SLO transitions to failed", func(t *testing.T) {
+	t.Run("in_progress with future SLO is re-enqueued", func(t *testing.T) {
 		batchDB := newMockBatchDB()
 		queue := mock.NewMockBatchPriorityQueueClient()
 		inflight := mock.NewMockInFlightClient()
@@ -174,10 +174,15 @@ func TestTriageOrphan(t *testing.T) {
 		r.run(ctx)
 
 		result := <-resultCh
-		if result.Failed != 1 {
-			t.Errorf("expected 1 failed, got %d", result.Failed)
+		if result.ReEnqueued != 1 {
+			t.Errorf("expected 1 re-enqueued, got %d", result.ReEnqueued)
 		}
-		assertJobStatus(t, batchDB, "job-1", openai.BatchStatusFailed)
+		assertJobStatus(t, batchDB, "job-1", openai.BatchStatusInProgress)
+
+		queuedIDs, _ := queue.PQGetIDs(ctx)
+		if !queuedIDs["job-1"] {
+			t.Error("expected job-1 to be in queue after re-enqueue")
+		}
 	})
 
 	t.Run("finalizing with expired SLO transitions to expired", func(t *testing.T) {
@@ -447,10 +452,15 @@ func TestTriageEdgeCases(t *testing.T) {
 		r.run(ctx)
 
 		result := <-resultCh
-		if result.Failed != 1 {
-			t.Errorf("expected 1 failed for stale in-flight job, got %d", result.Failed)
+		if result.ReEnqueued != 1 {
+			t.Errorf("expected 1 re-enqueued for stale in-flight job, got %d", result.ReEnqueued)
 		}
-		assertJobStatus(t, batchDB, "job-1", openai.BatchStatusFailed)
+		assertJobStatus(t, batchDB, "job-1", openai.BatchStatusInProgress)
+
+		queuedIDs, _ := queue.PQGetIDs(ctx)
+		if !queuedIDs["job-1"] {
+			t.Error("expected job-1 to be in queue after re-enqueue")
+		}
 	})
 }
 

--- a/internal/processor/pipeline/collector.go
+++ b/internal/processor/pipeline/collector.go
@@ -37,6 +37,7 @@ type ResultCollector struct {
 	tracker              *ProgressTracker
 	logger               logr.Logger
 	onPersistenceFailure func()
+	persist              func(customID string, isError bool, line []byte)
 }
 
 func NewResultCollector(outputFile, errorFile *os.File, pending *PendingRequests, tracker *ProgressTracker, logger logr.Logger) *ResultCollector {
@@ -99,14 +100,16 @@ func (c *ResultCollector) Receive(msg ResultItem) error {
 	if err != nil {
 		return fmt.Errorf("marshal output for %s: %w", msg.RequestID, err)
 	}
-	lineBytes = append(lineBytes, '\n')
 
 	w := c.output
 	if line.Error != nil {
 		w = c.errors
 	}
-	if _, err := w.Write(lineBytes); err != nil {
+	if _, err := w.Write(append(lineBytes, '\n')); err != nil {
 		return fmt.Errorf("write output for %s: %w", msg.RequestID, err)
+	}
+	if c.persist != nil {
+		c.persist(line.CustomID, line.Error != nil, lineBytes)
 	}
 
 	if line.isSuccess() {
@@ -126,6 +129,45 @@ func (c *ResultCollector) Receive(msg ResultItem) error {
 	}
 
 	return nil
+}
+
+// SetPersist installs a hook called with each marshaled line (no trailing
+// newline) after the local file write.
+func (c *ResultCollector) SetPersist(fn func(customID string, isError bool, line []byte)) {
+	c.persist = fn
+}
+
+// PersistedResult is one row recovered from durable scratch storage.
+type PersistedResult struct {
+	CustomID string
+	IsError  bool
+	Line     []byte
+}
+
+// Replay writes recovered rows to the local files and progress tracker before
+// execution starts, returning the custom_ids the source must skip.
+func (c *ResultCollector) Replay(rows []PersistedResult) (map[string]struct{}, error) {
+	skip := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		var line outputLine
+		if err := json.Unmarshal(row.Line, &line); err != nil {
+			return nil, fmt.Errorf("unmarshal persisted result %s: %w", row.CustomID, err)
+		}
+		w := c.output
+		if row.IsError {
+			w = c.errors
+		}
+		if _, err := w.Write(append(row.Line, '\n')); err != nil {
+			return nil, fmt.Errorf("replay result %s: %w", row.CustomID, err)
+		}
+		if line.isSuccess() {
+			c.tracker.RecordSuccess(ResultItem{CustomID: row.CustomID})
+		} else {
+			c.tracker.RecordFailure(fmt.Errorf("%s: replayed failure", row.CustomID))
+		}
+		skip[row.CustomID] = struct{}{}
+	}
+	return skip, nil
 }
 
 func recordTokenUsage(body map[string]any, model string, logger logr.Logger) {

--- a/internal/processor/pipeline/collector_test.go
+++ b/internal/processor/pipeline/collector_test.go
@@ -387,3 +387,130 @@ func TestProgressTracker_FlushOnCancel(t *testing.T) {
 			last.Completed, last.Failed)
 	}
 }
+
+func TestResultCollector_PersistHookReceivesEachLine(t *testing.T) {
+	outputFile := tempFile(t)
+	errorFile := tempFile(t)
+	pending := NewPendingRequests(0)
+	tracker := NewProgressTracker(2, nil, "test-job", 0, logr.Discard())
+	collector := NewResultCollector(outputFile, errorFile, pending, tracker, logr.Discard())
+
+	type persisted struct {
+		customID string
+		isError  bool
+		line     []byte
+	}
+	var got []persisted
+	collector.SetPersist(func(customID string, isError bool, line []byte) {
+		got = append(got, persisted{customID: customID, isError: isError, line: line})
+	})
+
+	results := []ResultItem{
+		{
+			RequestID: "req-1",
+			CustomID:  "c-1",
+			Response:  &batch_types.ResponseData{StatusCode: 200, RequestID: "req-1", Body: map[string]any{"ok": true}},
+		},
+		{
+			RequestID: "req-2",
+			CustomID:  "c-2",
+			Error:     &OutputError{Code: "SERVER_ERROR", Message: "connection refused"},
+		},
+	}
+	for _, r := range results {
+		pending.Store(RequestItem{RequestID: r.RequestID, CustomID: r.CustomID})
+	}
+	ch := make(chan ResultItem, len(results))
+	for _, r := range results {
+		ch <- r
+	}
+	close(ch)
+
+	if err := collector.Drain(context.Background(), ch); err != nil {
+		t.Fatalf("Drain error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("persist calls = %d, want 2", len(got))
+	}
+	if got[0].customID != "c-1" || got[0].isError {
+		t.Fatalf("persist[0] = %q isError=%v, want c-1 isError=false", got[0].customID, got[0].isError)
+	}
+	if got[1].customID != "c-2" || !got[1].isError {
+		t.Fatalf("persist[1] = %q isError=%v, want c-2 isError=true", got[1].customID, got[1].isError)
+	}
+	for _, p := range got {
+		if len(p.line) == 0 || p.line[len(p.line)-1] == '\n' {
+			t.Fatalf("persisted line for %s must be non-empty without trailing newline", p.customID)
+		}
+		var line outputLine
+		if err := json.Unmarshal(p.line, &line); err != nil {
+			t.Fatalf("persisted line for %s is not valid JSON: %v", p.customID, err)
+		}
+	}
+}
+
+func TestResultCollector_ReplayRestoresFilesAndProgress(t *testing.T) {
+	outputFile := tempFile(t)
+	errorFile := tempFile(t)
+	pending := NewPendingRequests(0)
+	tracker := NewProgressTracker(3, nil, "test-job", 0, logr.Discard())
+	collector := NewResultCollector(outputFile, errorFile, pending, tracker, logr.Discard())
+
+	successLine, _ := json.Marshal(&outputLine{
+		ID:       "req-1",
+		CustomID: "c-1",
+		Response: &batch_types.ResponseData{StatusCode: 200, RequestID: "req-1", Body: map[string]any{"ok": true}},
+	})
+	errLine, _ := json.Marshal(&outputLine{
+		ID:       "req-2",
+		CustomID: "c-2",
+		Error:    &OutputError{Code: "SERVER_ERROR", Message: "connection refused"},
+	})
+
+	skip, err := collector.Replay([]PersistedResult{
+		{CustomID: "c-1", IsError: false, Line: successLine},
+		{CustomID: "c-2", IsError: true, Line: errLine},
+	})
+	if err != nil {
+		t.Fatalf("Replay error: %v", err)
+	}
+	if len(skip) != 2 {
+		t.Fatalf("skip set size = %d, want 2", len(skip))
+	}
+	for _, id := range []string{"c-1", "c-2"} {
+		if _, ok := skip[id]; !ok {
+			t.Fatalf("skip set missing %s", id)
+		}
+	}
+
+	// Replayed lines only reach disk on flush, same as live results.
+	ch := make(chan ResultItem)
+	close(ch)
+	if err := collector.Drain(context.Background(), ch); err != nil {
+		t.Fatalf("Drain error: %v", err)
+	}
+
+	if lines := splitLines(readFile(t, outputFile)); len(lines) != 1 {
+		t.Fatalf("output lines = %d, want 1", len(lines))
+	}
+	if lines := splitLines(readFile(t, errorFile)); len(lines) != 1 {
+		t.Fatalf("error lines = %d, want 1", len(lines))
+	}
+
+	counts := tracker.Counts()
+	if counts.Completed != 1 || counts.Failed != 1 {
+		t.Fatalf("counts: completed=%d failed=%d, want completed=1 failed=1", counts.Completed, counts.Failed)
+	}
+}
+
+func TestResultCollector_ReplayRejectsCorruptLine(t *testing.T) {
+	outputFile := tempFile(t)
+	errorFile := tempFile(t)
+	tracker := NewProgressTracker(1, nil, "test-job", 0, logr.Discard())
+	collector := NewResultCollector(outputFile, errorFile, NewPendingRequests(0), tracker, logr.Discard())
+
+	if _, err := collector.Replay([]PersistedResult{{CustomID: "c-1", Line: []byte("{not json")}}); err == nil {
+		t.Fatal("expected error for corrupt persisted line")
+	}
+}

--- a/internal/processor/worker/execute_pipeline.go
+++ b/internal/processor/worker/execute_pipeline.go
@@ -10,10 +10,12 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/llm-d/llm-d-batch-gateway/pkg/clients/inference"
 
+	db "github.com/llm-d/llm-d-batch-gateway/internal/database/api"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/batchctx"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/config"
 	"github.com/llm-d/llm-d-batch-gateway/internal/processor/pipeline"
 	"github.com/llm-d/llm-d-batch-gateway/internal/shared/openai"
+	"github.com/llm-d/llm-d-batch-gateway/internal/util/failpoint"
 	"github.com/llm-d/llm-d-batch-gateway/internal/util/logging"
 )
 
@@ -61,18 +63,6 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	)
 	tracker.AddFailed(modelMap.RejectedCount)
 
-	source := NewPlanFileSource(PlanFileSourceConfig{
-		InputFile:          files.input,
-		PlansDir:           plansDir,
-		ModelMap:           modelMap,
-		Resolver:           p.inference,
-		Cfg:                p.cfg,
-		PassThroughHeaders: params.jobInfo.PassThroughHeaders,
-		SLODeadline:        sloDeadline,
-		TenantID:           params.jobInfo.TenantID,
-		Logger:             logger,
-	})
-
 	// The dispatcher forwards requests for processing.
 	pending := pipeline.NewPendingRequests(modelMap.LineCount)
 	dispatcher, err := p.buildRequestDispatcher(modelMap, pending, params.jobInfo.TenantID, logger)
@@ -89,6 +79,24 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 		logger,
 	)
 
+	skip, err := p.setupResultPersistence(ctx, params.jobInfo.JobID, resultCollector, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	source := NewPlanFileSource(PlanFileSourceConfig{
+		InputFile:          files.input,
+		PlansDir:           plansDir,
+		ModelMap:           modelMap,
+		Resolver:           p.inference,
+		Cfg:                p.cfg,
+		PassThroughHeaders: params.jobInfo.PassThroughHeaders,
+		SLODeadline:        sloDeadline,
+		TenantID:           params.jobInfo.TenantID,
+		Skip:               skip,
+		Logger:             logger,
+	})
+
 	// Orchestrates Job execution.
 	executor := pipeline.NewJobExecutor(pipeline.JobExecutorConfig{
 		Source:     source,
@@ -102,6 +110,48 @@ func (p *Processor) executeJobAsync(ctx context.Context, params *jobExecutionPar
 	counts, execErr := executor.Execute(ctx)
 
 	return counts, classifyOutcome(batchctx.Cause(ctx), counts, execErr)
+}
+
+// setupResultPersistence replays results persisted by a previous attempt into
+// the collector and installs the write-through hook for new results. Returns
+// the custom_ids the source must skip. No-op (nil skip set) when the backend
+// has no result store.
+func (p *Processor) setupResultPersistence(
+	ctx context.Context,
+	jobID string,
+	collector *pipeline.ResultCollector,
+	logger logr.Logger,
+) (map[string]struct{}, error) {
+	if p.resultDB == nil {
+		return nil, nil
+	}
+
+	rows, err := p.resultDB.ResultGetAll(ctx, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("load persisted results: %w", err)
+	}
+
+	var skip map[string]struct{}
+	if len(rows) > 0 {
+		persisted := make([]pipeline.PersistedResult, len(rows))
+		for i, r := range rows {
+			persisted[i] = pipeline.PersistedResult{CustomID: r.CustomID, IsError: r.IsError, Line: r.Line}
+		}
+		skip, err = collector.Replay(persisted)
+		if err != nil {
+			return nil, fmt.Errorf("replay persisted results: %w", err)
+		}
+		logger.V(logging.INFO).Info("Resumed from persisted results", "count", len(rows))
+	}
+
+	collector.SetPersist(func(customID string, isError bool, line []byte) {
+		failpoint.Inject("processor/before-result-persist")
+		row := &db.ResultRow{BatchID: jobID, CustomID: customID, IsError: isError, Line: line}
+		if err := p.resultDB.ResultStore(ctx, row); err != nil {
+			logger.Error(err, "Failed to persist result row", "customId", customID)
+		}
+	})
+	return skip, nil
 }
 
 // classifyOutcome maps the abort cause, request counts, and executor error to the

--- a/internal/processor/worker/finalizer.go
+++ b/internal/processor/worker/finalizer.go
@@ -174,6 +174,7 @@ func (p *Processor) finalizeJob(
 			return fmt.Errorf("cancelled status write failed: %w", errFinalizeFailedOver)
 		}
 		setRequestCountAttrs(ctx, requestCounts)
+		p.cleanupResultRows(ioCtx, dbJob.ID)
 		return batchctx.ErrCancelled
 	}
 
@@ -187,9 +188,22 @@ func (p *Processor) finalizeJob(
 	}
 
 	setRequestCountAttrs(ctx, requestCounts)
+	p.cleanupResultRows(ioCtx, dbJob.ID)
 
 	logger.V(logging.INFO).Info("Finalization completed", "outputFileID", outputFileID, "errorFileID", errorFileID)
 	return nil
+}
+
+// cleanupResultRows drops the batch's durable scratch rows once a terminal
+// status is written. Best-effort: leftover rows only cost storage until an
+// external sweep reclaims them.
+func (p *Processor) cleanupResultRows(ctx context.Context, batchID string) {
+	if p.resultDB == nil {
+		return
+	}
+	if err := p.resultDB.ResultDelete(ctx, batchID); err != nil {
+		logr.FromContextOrDiscard(ctx).Error(err, "Failed to delete result rows", "batchId", batchID)
+	}
 }
 
 // uploadOutputFile uploads the local output file to shared storage.

--- a/internal/processor/worker/source_planfile.go
+++ b/internal/processor/worker/source_planfile.go
@@ -30,6 +30,7 @@ type PlanFileSource struct {
 	passThroughHeaders map[string]string
 	sloDeadline        time.Time
 	tenantID           string
+	skip               map[string]struct{}
 	logger             logr.Logger
 }
 
@@ -44,7 +45,10 @@ type PlanFileSourceConfig struct {
 	PassThroughHeaders map[string]string
 	SLODeadline        time.Time
 	TenantID           string
-	Logger             logr.Logger
+	// Skip lists custom_ids whose results are already durably recorded;
+	// Produce drops their plan entries instead of dispatching them.
+	Skip   map[string]struct{}
+	Logger logr.Logger
 }
 
 func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
@@ -57,6 +61,7 @@ func NewPlanFileSource(cfg PlanFileSourceConfig) *PlanFileSource {
 		passThroughHeaders: cfg.PassThroughHeaders,
 		sloDeadline:        cfg.SLODeadline,
 		tenantID:           cfg.TenantID,
+		skip:               cfg.Skip,
 		logger:             cfg.Logger,
 	}
 }
@@ -79,6 +84,9 @@ func (s *PlanFileSource) Produce(_ context.Context, outgoingRequestCh chan<- pip
 			item, err := s.readEntry(entry, modelID)
 			if err != nil {
 				return err
+			}
+			if _, done := s.skip[item.CustomID]; done {
+				continue
 			}
 			outgoingRequestCh <- *item
 		}

--- a/internal/processor/worker/source_planfile_test.go
+++ b/internal/processor/worker/source_planfile_test.go
@@ -761,3 +761,69 @@ func TestPlanFileSource_Produce_CancellationProducesAllEntries(t *testing.T) {
 		}
 	}
 }
+
+func TestPlanFileSource_Produce_SkipsPersisted(t *testing.T) {
+	dir := t.TempDir()
+
+	requests := []batch_types.Request{
+		{CustomID: "c-1", Method: "POST", URL: "/v1/chat/completions", Body: map[string]any{"model": "m1", "prompt": "hello"}},
+		{CustomID: "c-2", Method: "POST", URL: "/v1/chat/completions", Body: map[string]any{"model": "m1", "prompt": "world"}},
+	}
+
+	inputPath := filepath.Join(dir, "input.jsonl")
+	var entries []planEntry
+	f, err := os.Create(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, req := range requests {
+		data, _ := json.Marshal(req)
+		data = append(data, '\n')
+		offset, _ := f.Seek(0, 1)
+		entries = append(entries, planEntry{Offset: offset, Length: uint32(len(data))})
+		if _, err := f.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+
+	plansDir := filepath.Join(dir, "plans")
+	writePlanFile(t, plansDir, "m1", entries)
+
+	inputFile, err := os.Open(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer inputFile.Close()
+
+	client := &mockInferenceClient{}
+	resolver := inference.NewSingleClientResolver(client)
+	defer func() { _ = resolver.Close() }()
+
+	source := NewPlanFileSource(PlanFileSourceConfig{
+		InputFile: inputFile,
+		PlansDir:  plansDir,
+		ModelMap:  &modelMapFile{SafeToModel: map[string]string{"m1": "m1"}, LineCount: 2},
+		Resolver:  resolver,
+		Cfg:       config.NewConfig(),
+		Skip:      map[string]struct{}{"c-1": {}},
+		Logger:    logr.Discard(),
+	})
+
+	out := make(chan pipeline.RequestItem, 10)
+	if err := source.Produce(context.Background(), out); err != nil {
+		t.Fatalf("Produce error: %v", err)
+	}
+
+	var items []pipeline.RequestItem
+	for item := range out {
+		items = append(items, item)
+	}
+
+	if len(items) != 1 {
+		t.Fatalf("produced %d items, want 1 (c-1 skipped)", len(items))
+	}
+	if items[0].CustomID != "c-2" {
+		t.Errorf("item CustomID = %q, want %q", items[0].CustomID, "c-2")
+	}
+}

--- a/internal/processor/worker/worker.go
+++ b/internal/processor/worker/worker.go
@@ -72,6 +72,7 @@ type Processor struct {
 	updater *StatusUpdater
 
 	batchDB        db.BatchDBClient                // job status lookups (heartbeat DB check)
+	resultDB       db.ResultDBClient               // durable per-request scratch; nil = disabled
 	event          db.BatchEventChannelClient      // cancel-event subscription
 	inflight       db.InFlightClient               // in-flight job tracking for orphan recovery
 	inference      *inference.GatewayResolver      // model → gateway routing (sync)
@@ -100,6 +101,7 @@ func NewProcessor(
 		poller:         poller,
 		updater:        updater,
 		batchDB:        clients.BatchDB,
+		resultDB:       clients.ResultDB,
 		event:          clients.Event,
 		inflight:       clients.InFlight,
 		inference:      clients.Inference,

--- a/internal/util/clientset/clientset.go
+++ b/internal/util/clientset/clientset.go
@@ -45,6 +45,7 @@ type Clientset struct {
 	File           fsapi.BatchFilesClient
 	BatchDB        dbapi.BatchDBClient
 	FileDB         dbapi.FileDBClient
+	ResultDB       dbapi.ResultDBClient // durable per-request scratch; nil when the backend does not support it
 	Queue          dbapi.BatchPriorityQueueClient
 	Event          dbapi.BatchEventChannelClient
 	Status         dbapi.BatchStatusClient
@@ -118,29 +119,34 @@ func NewRedisDBClients(ctx context.Context, cfg *uredis.RedisClientConfig) (dbap
 	return batchDB, fileDB, nil
 }
 
-// NewPostgreSQLDBClients creates PostgreSQL-backed batch and file database clients.
-// It reads the URL from the mounted secrets when not set in the config.
-func NewPostgreSQLDBClients(ctx context.Context, cfg *postgresql.PostgreSQLConfig) (dbapi.BatchDBClient, dbapi.FileDBClient, error) {
+// NewPostgreSQLDBClients creates PostgreSQL-backed batch, file, and result
+// database clients. It reads the URL from the mounted secrets when not set in
+// the config.
+func NewPostgreSQLDBClients(ctx context.Context, cfg *postgresql.PostgreSQLConfig) (dbapi.BatchDBClient, dbapi.FileDBClient, dbapi.ResultDBClient, error) {
 	if cfg == nil {
-		return nil, nil, fmt.Errorf("postgresql config cannot be nil")
+		return nil, nil, nil, fmt.Errorf("postgresql config cannot be nil")
 	}
 	if cfg.Url == "" {
 		postgreSQLURL, err := ucom.ReadSecretFile(ucom.SecretKeyPostgreSQLURL)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		cfg.Url = postgreSQLURL
 	}
 	batchDB, err := postgresql.NewPostgresBatchDBClient(ctx, cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create postgresql batch-db client: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create postgresql batch-db client: %w", err)
 	}
 	fileDB, err := postgresql.NewPostgresFileDBClient(ctx, cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create postgresql file-db client: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create postgresql file-db client: %w", err)
+	}
+	resultDB, err := postgresql.NewPostgresResultDBClient(ctx, cfg)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create postgresql result-db client: %w", err)
 	}
 	logr.FromContextOrDiscard(ctx).Info("PostgreSQL-based database client created")
-	return batchDB, fileDB, nil
+	return batchDB, fileDB, resultDB, nil
 }
 
 // Option configures which clients NewClientset creates.
@@ -263,12 +269,13 @@ func NewClientset(ctx context.Context, component ucom.Component, opts ...Option)
 			cs.BatchDB = batchDB
 			cs.FileDB = fileDB
 		case sharedcfg.DBTypePostgreSQL:
-			batchDB, fileDB, err := NewPostgreSQLDBClients(ctx, &cfg.dbCfg.PostgreSQLCfg)
+			batchDB, fileDB, resultDB, err := NewPostgreSQLDBClients(ctx, &cfg.dbCfg.PostgreSQLCfg)
 			if err != nil {
 				return nil, err
 			}
 			cs.BatchDB = batchDB
 			cs.FileDB = fileDB
+			cs.ResultDB = resultDB
 		default:
 			return nil, fmt.Errorf("unsupported database.type: %s (supported values: redis, valkey, postgresql)", cfg.dbCfg.Type)
 		}

--- a/test/simulation/client.go
+++ b/test/simulation/client.go
@@ -164,6 +164,22 @@ func (c *apiClient) cancelBatch(id string) (openai.Batch, error) {
 	return decodeInto[openai.Batch](resp)
 }
 
+func (c *apiClient) fileContent(id string) (string, error) {
+	resp, err := c.do(http.MethodGet, "/v1/files/"+id+"/content", "", nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, data)
+	}
+	return string(data), nil
+}
+
 func (c *apiClient) listFiles() ([]openai.FileObject, error) {
 	resp, err := c.do(http.MethodGet, "/v1/files", "", nil)
 	if err != nil {

--- a/test/simulation/harness.go
+++ b/test/simulation/harness.go
@@ -140,8 +140,19 @@ func simModel() string {
 // emits random token ids, so without ignore_eos a sampled EOS ends
 // generation after a few tokens and requests finish near-instantly.
 func inputJSONL(n, maxTokens int) string {
+	tokens := make([]int, n)
+	for i := range tokens {
+		tokens[i] = maxTokens
+	}
+	return inputJSONLTokens(tokens)
+}
+
+// inputJSONLTokens builds a batch input with one request per entry, each
+// generating exactly that many tokens, for scenarios that need mixed
+// durations in one batch.
+func inputJSONLTokens(tokens []int) string {
 	var b strings.Builder
-	for i := range n {
+	for i, maxTokens := range tokens {
 		fmt.Fprintf(&b,
 			`{"custom_id":"sim-%d","method":"POST","url":"/v1/chat/completions","body":{"model":"%s","max_tokens":%d,"min_tokens":%d,"ignore_eos":true,"messages":[{"role":"user","content":"simulation request %d"}]}}`+"\n",
 			i, simModel(), maxTokens, maxTokens, i)

--- a/test/simulation/ratchet.yaml
+++ b/test/simulation/ratchet.yaml
@@ -12,7 +12,8 @@ scenarios:
   F1c_create_compensation_partition: broken
   F4b_duplicate_execution: broken
   F3_terminal_overwrite: broken
-  F4a_worker_crash_strands_job: broken
+  F4a_worker_crash_strands_job: fixed
+  F4c_worker_crash_resume: fixed
   F2a_cancel_reverted: broken
   F2b_cancel_event_lost: broken
   F5_orphaned_blob: broken

--- a/test/simulation/scenarios_async_test.go
+++ b/test/simulation/scenarios_async_test.go
@@ -33,10 +33,14 @@ import (
 // the shared Redis result queue destructively. Kill the processor after
 // submission: the pending map dies with it, the replacement starts fresh
 // broadcasters with no subscribers, and when the results arrive they are
-// popped and discarded. The reconciler terminalizes the orphan as failed.
+// popped and discarded. With the reconciler re-enqueueing in_progress
+// orphans, the destruction manifests as duplicate spend: the discarded run
+// is re-executed in full, so the engine serves every request twice. Without
+// re-enqueue it manifested as a failed batch with no output.
 //
 // Violated invariant (work conservation): inference that was paid for and
-// whose results were durably produced must not be silently destroyed.
+// whose results were durably produced must not be silently destroyed —
+// neither dropped outright nor re-bought via full re-execution.
 func TestA1AsyncResultDestruction(t *testing.T) {
 	const scenario = "A1_async_result_destruction"
 	const lines = 4
@@ -97,9 +101,11 @@ func TestA1AsyncResultDestruction(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	cancelObs()
 
-	destroyed := final.Status == openai.BatchStatusFailed &&
+	strandedResults := final.Status == openai.BatchStatusFailed &&
 		final.OutputFileID == nil && final.ErrorFileID == nil &&
 		served >= lines && remaining == 0
+	duplicatedSpend := served > lines && remaining == 0
+	destroyed := strandedResults || duplicatedSpend
 	detail := fmt.Sprintf("observed sequence %v, final %s, engine served %d/%d, results left unconsumed %d, %s",
 		tl.statuses(), final.Status, served, lines, remaining, bridge)
 	judge(t, scenario, destroyed, detail)

--- a/test/simulation/scenarios_test.go
+++ b/test/simulation/scenarios_test.go
@@ -20,6 +20,7 @@ package simulation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -196,6 +197,83 @@ func TestF4aWorkerCrashStrandsJob(t *testing.T) {
 	detail := fmt.Sprintf("observed sequence %v, final %s, output_file=%v error_file=%v",
 		tl.statuses(), final.Status, final.OutputFileID != nil, final.ErrorFileID != nil)
 	judge(t, scenario, stranded, detail)
+}
+
+// TestF4cWorkerCrashResume guards the fix for F4a: per-request results are
+// written through to Postgres as they complete, the reconciler re-enqueues a
+// non-expired in_progress orphan instead of failing it, and the replacement
+// worker replays the persisted rows and executes only the remainder.
+//
+// Guarded invariant (work conservation, single delivery): after worker loss
+// the batch completes with every custom_id delivered exactly once.
+func TestF4cWorkerCrashResume(t *testing.T) {
+	const scenario = "F4c_worker_crash_resume"
+	h := newHarness(t, nil)
+	client := newAPIClient()
+
+	// Two ~1s requests complete and persist before the kill lands; two ~9s
+	// requests are still in flight and must be re-executed by the resume.
+	fileID, err := client.uploadFile("f4c.jsonl", inputJSONLTokens([]int{30, 30, 300, 300}))
+	if err != nil {
+		t.Fatalf("upload input file: %v", err)
+	}
+	batch, err := client.createBatch(fileID, "24h")
+	if err != nil {
+		t.Fatalf("create batch: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tl := observe(ctx, client, batch.ID, h.rec)
+
+	if _, ok := waitForStatus(client, batch.ID, 60*time.Second, openai.BatchStatusInProgress); !ok {
+		t.Fatal("batch never reached in_progress")
+	}
+	time.Sleep(3500 * time.Millisecond)
+	h.kill("processor")
+	h.restart("processor")
+
+	final, terminal := waitForStatus(client, batch.ID, 2*time.Minute,
+		openai.BatchStatusFailed, openai.BatchStatusCompleted, openai.BatchStatusExpired)
+	if !terminal {
+		t.Fatalf("batch never terminalized after worker loss; last status %s", final.Status)
+	}
+	time.Sleep(1 * time.Second)
+	cancel()
+
+	violated := final.Status != openai.BatchStatusCompleted || final.OutputFileID == nil
+	delivered := map[string]int{}
+	if !violated {
+		content, err := client.fileContent(*final.OutputFileID)
+		if err != nil {
+			t.Fatalf("fetch output file: %v", err)
+		}
+		for _, raw := range strings.Split(strings.TrimSpace(content), "\n") {
+			var line struct {
+				CustomID string `json:"custom_id"`
+			}
+			if err := json.Unmarshal([]byte(raw), &line); err != nil {
+				t.Fatalf("parse output line %q: %v", raw, err)
+			}
+			delivered[line.CustomID]++
+		}
+		for i := range 4 {
+			if delivered[fmt.Sprintf("sim-%d", i)] != 1 {
+				violated = true
+			}
+		}
+		if len(delivered) != 4 {
+			violated = true
+		}
+	}
+
+	detail := fmt.Sprintf("observed sequence %v, final %s, delivered %v",
+		tl.statuses(), final.Status, delivered)
+	if served, ok := h.b.inferenceRequests(); ok {
+		h.rec.event("witness", map[string]any{"served": served})
+		detail += fmt.Sprintf(", engine served %d", served)
+	}
+	judge(t, scenario, violated, detail)
 }
 
 // TestF2aCancelReverted reproduces finding F2a: cancelling a queued batch is


### PR DESCRIPTION
Example fix for F4a driven by the consistency ratchet in #654. Worker scratch state moves to Postgres: each request's output line is written through to a batch_request_results table keyed by (batch_id, custom_id) as it completes, the reconciler re-enqueues non-expired in_progress orphans instead of failing them, and the replacement worker replays persisted rows and executes only the remainder. Rows are deleted after the terminal status write; a processor/before-result-persist failpoint covers the response-to-commit window.

Ratchet results: F4a flips broken -> fixed (worker loss now ends completed, not stranded). New scenario F4c kills the worker with 2 of 4 results persisted and requires exactly-once delivery; the engine serves 6 requests, not 8, proving the resume skips persisted work. A1 still reproduces, its symptom morphing from destroyed work to duplicate spend, and the judge now pins that. All other scenarios reproduce unchanged.

Known gaps, deliberate for a prototype: rows orphaned by non-finalize terminalization have no sweep yet, redis backends run with persistence disabled (full re-run on resume), and F4b's double-dispatch remains.